### PR TITLE
Throw error when sections are empty or omitted

### DIFF
--- a/air-script/tests/aux_trace/aux_trace.air
+++ b/air-script/tests/aux_trace/aux_trace.air
@@ -3,7 +3,10 @@ def AuxiliaryAir
 trace_columns:
     main: [a, b, c]
     aux: [p0, p1]
-  
+
+public_inputs:
+    stack_inputs: [16]
+
 boundary_constraints:
     enf a.first = 1
     enf b.first = 1

--- a/air-script/tests/aux_trace/aux_trace.rs
+++ b/air-script/tests/aux_trace/aux_trace.rs
@@ -2,21 +2,25 @@ use winter_air::{Air, AirContext, Assertion, AuxTraceRandElements, EvaluationFra
 use winter_math::{fields, ExtensionOf, FieldElement};
 use winter_utils::{collections, ByteWriter, Serializable};
 
-pub struct PublicInputs;
+pub struct PublicInputs {
+    stack_inputs: [Felt; 16],
+}
 
 impl PublicInputs {
-    pub fn new() -> Self {
-        Self {  }
+    pub fn new(stack_inputs: [Felt; 16]) -> Self {
+        Self { stack_inputs }
     }
 }
 
 impl Serializable for PublicInputs {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write(self.stack_inputs.as_slice());
     }
 }
 
 pub struct AuxiliaryAir {
     context: AirContext<Felt>,
+    stack_inputs: [Felt; 16],
 }
 
 impl AuxiliaryAir {
@@ -48,7 +52,7 @@ impl Air for AuxiliaryAir {
             options,
         )
         .set_num_transition_exemptions(2);
-        Self { context,  }
+        Self { context, stack_inputs: public_inputs.stack_inputs }
     }
 
     fn get_periodic_column_values(&self) -> Vec<Vec<Felt>> {

--- a/air-script/tests/binary/binary.air
+++ b/air-script/tests/binary/binary.air
@@ -3,6 +3,12 @@ def BinaryAir
 trace_columns:
     main: [a, b]
 
+public_inputs:
+    stack_inputs: [16]
+
+boundary_constraints:
+    enf a.first = 0
+
 transition_constraints:
     enf a^2 - a = 0
     enf b^2 - b = 0

--- a/air-script/tests/binary/binary.rs
+++ b/air-script/tests/binary/binary.rs
@@ -2,21 +2,25 @@ use winter_air::{Air, AirContext, Assertion, AuxTraceRandElements, EvaluationFra
 use winter_math::{fields, ExtensionOf, FieldElement};
 use winter_utils::{collections, ByteWriter, Serializable};
 
-pub struct PublicInputs;
+pub struct PublicInputs {
+    stack_inputs: [Felt; 16],
+}
 
 impl PublicInputs {
-    pub fn new() -> Self {
-        Self {  }
+    pub fn new(stack_inputs: [Felt; 16]) -> Self {
+        Self { stack_inputs }
     }
 }
 
 impl Serializable for PublicInputs {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write(self.stack_inputs.as_slice());
     }
 }
 
 pub struct BinaryAir {
     context: AirContext<Felt>,
+    stack_inputs: [Felt; 16],
 }
 
 impl BinaryAir {
@@ -36,7 +40,7 @@ impl Air for BinaryAir {
     fn new(trace_info: TraceInfo, public_inputs: PublicInputs, options: WinterProofOptions) -> Self {
         let main_degrees = vec![TransitionConstraintDegree::new(2), TransitionConstraintDegree::new(2)];
         let aux_degrees = Vec::new();
-        let num_main_assertions = 0;
+        let num_main_assertions = 1;
         let num_aux_assertions = 0;
 
         let context = AirContext::new_multi_segment(
@@ -48,7 +52,7 @@ impl Air for BinaryAir {
             options,
         )
         .set_num_transition_exemptions(2);
-        Self { context,  }
+        Self { context, stack_inputs: public_inputs.stack_inputs }
     }
 
     fn get_periodic_column_values(&self) -> Vec<Vec<Felt>> {
@@ -57,6 +61,7 @@ impl Air for BinaryAir {
 
     fn get_assertions(&self) -> Vec<Assertion<Felt>> {
         let mut result = Vec::new();
+        result.push(Assertion::single(0, 0, Felt::new(0)));
         result
     }
 

--- a/air-script/tests/periodic_columns/periodic_columns.air
+++ b/air-script/tests/periodic_columns/periodic_columns.air
@@ -3,9 +3,15 @@ def PeriodicColumnsAir
 trace_columns:
     main: [a, b, c]
 
+public_inputs:
+    stack_inputs: [16]
+
 periodic_columns:
     k0: [1, 0, 0, 0]
     k1: [1, 1, 1, 1, 1, 1, 1, 0]
+
+boundary_constraints:
+    enf a.first = 0
 
 transition_constraints:
     enf k0 * (b + c) = 0

--- a/air-script/tests/periodic_columns/periodic_columns.rs
+++ b/air-script/tests/periodic_columns/periodic_columns.rs
@@ -2,21 +2,25 @@ use winter_air::{Air, AirContext, Assertion, AuxTraceRandElements, EvaluationFra
 use winter_math::{fields, ExtensionOf, FieldElement};
 use winter_utils::{collections, ByteWriter, Serializable};
 
-pub struct PublicInputs;
+pub struct PublicInputs {
+    stack_inputs: [Felt; 16],
+}
 
 impl PublicInputs {
-    pub fn new() -> Self {
-        Self {  }
+    pub fn new(stack_inputs: [Felt; 16]) -> Self {
+        Self { stack_inputs }
     }
 }
 
 impl Serializable for PublicInputs {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write(self.stack_inputs.as_slice());
     }
 }
 
 pub struct PeriodicColumnsAir {
     context: AirContext<Felt>,
+    stack_inputs: [Felt; 16],
 }
 
 impl PeriodicColumnsAir {
@@ -36,7 +40,7 @@ impl Air for PeriodicColumnsAir {
     fn new(trace_info: TraceInfo, public_inputs: PublicInputs, options: WinterProofOptions) -> Self {
         let main_degrees = vec![TransitionConstraintDegree::with_cycles(1, vec![4]), TransitionConstraintDegree::with_cycles(1, vec![8])];
         let aux_degrees = Vec::new();
-        let num_main_assertions = 0;
+        let num_main_assertions = 1;
         let num_aux_assertions = 0;
 
         let context = AirContext::new_multi_segment(
@@ -48,7 +52,7 @@ impl Air for PeriodicColumnsAir {
             options,
         )
         .set_num_transition_exemptions(2);
-        Self { context,  }
+        Self { context, stack_inputs: public_inputs.stack_inputs }
     }
 
     fn get_periodic_column_values(&self) -> Vec<Vec<Felt>> {
@@ -57,6 +61,7 @@ impl Air for PeriodicColumnsAir {
 
     fn get_assertions(&self) -> Vec<Assertion<Felt>> {
         let mut result = Vec::new();
+        result.push(Assertion::single(0, 0, Felt::new(0)));
         result
     }
 

--- a/air-script/tests/pub_inputs/pub_inputs.air
+++ b/air-script/tests/pub_inputs/pub_inputs.air
@@ -19,3 +19,6 @@ boundary_constraints:
     enf b.last = stack_outputs[1]
     enf c.last = stack_outputs[2]
     enf d.last = stack_outputs[3]
+
+transition_constraints:
+    enf a' = b + c

--- a/air-script/tests/pub_inputs/pub_inputs.rs
+++ b/air-script/tests/pub_inputs/pub_inputs.rs
@@ -47,7 +47,7 @@ impl Air for PubInputsAir {
     }
 
     fn new(trace_info: TraceInfo, public_inputs: PublicInputs, options: WinterProofOptions) -> Self {
-        let main_degrees = vec![];
+        let main_degrees = vec![TransitionConstraintDegree::new(1)];
         let aux_degrees = Vec::new();
         let num_main_assertions = 8;
         let num_aux_assertions = 0;
@@ -90,6 +90,7 @@ impl Air for PubInputsAir {
     fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
         let current = frame.current();
         let next = frame.next();
+        result[0] = next[0] - (current[1] + current[2]);
     }
 
     fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])

--- a/air-script/tests/system/system.air
+++ b/air-script/tests/system/system.air
@@ -2,7 +2,10 @@ def SystemAir
 
 trace_columns:
     main: [clk, fmp, ctx]
-  
+
+public_inputs:
+    stack_inputs: [16]
+
 transition_constraints:
     enf clk' = clk + 1
   

--- a/air-script/tests/system/system.rs
+++ b/air-script/tests/system/system.rs
@@ -2,21 +2,25 @@ use winter_air::{Air, AirContext, Assertion, AuxTraceRandElements, EvaluationFra
 use winter_math::{fields, ExtensionOf, FieldElement};
 use winter_utils::{collections, ByteWriter, Serializable};
 
-pub struct PublicInputs;
+pub struct PublicInputs {
+    stack_inputs: [Felt; 16],
+}
 
 impl PublicInputs {
-    pub fn new() -> Self {
-        Self {  }
+    pub fn new(stack_inputs: [Felt; 16]) -> Self {
+        Self { stack_inputs }
     }
 }
 
 impl Serializable for PublicInputs {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write(self.stack_inputs.as_slice());
     }
 }
 
 pub struct SystemAir {
     context: AirContext<Felt>,
+    stack_inputs: [Felt; 16],
 }
 
 impl SystemAir {
@@ -48,7 +52,7 @@ impl Air for SystemAir {
             options,
         )
         .set_num_transition_exemptions(2);
-        Self { context,  }
+        Self { context, stack_inputs: public_inputs.stack_inputs }
     }
 
     fn get_periodic_column_values(&self) -> Vec<Vec<Felt>> {

--- a/examples/aux_trace.air
+++ b/examples/aux_trace.air
@@ -3,7 +3,10 @@ def AuxiliaryAir
 trace_columns:
     main: [a, b, c]
     aux: [p0, p1]
-  
+
+public_inputs:
+    stack_inputs: [16]
+
 boundary_constraints:
     enf a.first = 1
     enf b.first = 1

--- a/examples/binary.air
+++ b/examples/binary.air
@@ -3,6 +3,12 @@ def BinaryAir
 trace_columns:
     main: [a, b]
 
+public_inputs:
+    stack_inputs: [16]
+
+boundary_constraints:
+    enf a.first = 0
+
 transition_constraints:
     enf a^2 - a = 0
     enf b^2 - b = 0

--- a/examples/periodic_columns.air
+++ b/examples/periodic_columns.air
@@ -3,9 +3,15 @@ def PeriodicColumnsAir
 trace_columns:
     main: [a, b, c]
 
+public_inputs:
+    stack_inputs: [16]
+
 periodic_columns:
     k0: [1, 0, 0, 0]
     k1: [1, 1, 1, 1, 1, 1, 1, 0]
+
+boundary_constraints:
+    enf a.first = 0
 
 transition_constraints:
     enf k0 * (b + c) = 0

--- a/examples/pub_inputs.air
+++ b/examples/pub_inputs.air
@@ -19,3 +19,6 @@ boundary_constraints:
     enf b.last = stack_outputs[1]
     enf c.last = stack_outputs[2]
     enf d.last = stack_outputs[3]
+
+transition_constraints:
+    enf a' = b + c

--- a/examples/system.air
+++ b/examples/system.air
@@ -2,7 +2,10 @@ def SystemAir
 
 trace_columns:
     main: [clk, fmp, ctx]
-  
+
+public_inputs:
+    stack_inputs: [16]
+
 transition_constraints:
     enf clk' = clk + 1
   

--- a/ir/src/error.rs
+++ b/ir/src/error.rs
@@ -6,5 +6,5 @@ pub enum SemanticError {
     IndexOutOfRange(String),
     TooManyConstraints(String),
     InvalidPeriodicColumn(String),
-    MissingSourceSection(String),
+    MissingDeclaration(String),
 }

--- a/ir/src/error.rs
+++ b/ir/src/error.rs
@@ -6,4 +6,5 @@ pub enum SemanticError {
     IndexOutOfRange(String),
     TooManyConstraints(String),
     InvalidPeriodicColumn(String),
+    MissingSourceSection(String),
 }

--- a/ir/src/helpers.rs
+++ b/ir/src/helpers.rs
@@ -1,0 +1,67 @@
+use crate::error::SemanticError;
+
+/// Struct to store existence of sections in the AIR source code
+pub(super) struct SourceValidator {
+    trace_columns_exists: bool,
+    public_inputs_exists: bool,
+    boundary_constraints_exists: bool,
+    transition_constraints_exists: bool,
+}
+
+impl SourceValidator {
+    pub fn new() -> Self {
+        SourceValidator {
+            trace_columns_exists: false,
+            public_inputs_exists: false,
+            boundary_constraints_exists: false,
+            transition_constraints_exists: false,
+        }
+    }
+
+    /// If the section exists, sets the provided section boolean to true.
+    pub fn exists(&mut self, section: &str) {
+        match section {
+            "trace_columns" => self.trace_columns_exists = true,
+            "public_inputs" => self.public_inputs_exists = true,
+            "boundary_constraints" => self.boundary_constraints_exists = true,
+            "transition_constraints" => self.transition_constraints_exists = true,
+            _ => unreachable!(),
+        }
+    }
+
+    /// Returns a MissingSourceSection error if the provided section is missing.
+    pub fn check(&self, section: &str) -> Result<(), SemanticError> {
+        match section {
+            "trace_columns" => {
+                if !self.trace_columns_exists {
+                    return Err(SemanticError::MissingSourceSection(
+                        "trace_columns section is missing".to_string(),
+                    ));
+                }
+            }
+            "public_inputs" => {
+                if !self.public_inputs_exists {
+                    return Err(SemanticError::MissingSourceSection(
+                        "public_inputs section is missing".to_string(),
+                    ));
+                }
+            }
+            "boundary_constraints" => {
+                if !self.boundary_constraints_exists {
+                    return Err(SemanticError::MissingSourceSection(
+                        "boundary_constraints section is missing".to_string(),
+                    ));
+                }
+            }
+            "transition_constraints" => {
+                if !self.transition_constraints_exists {
+                    return Err(SemanticError::MissingSourceSection(
+                        "transition_constraints section is missing".to_string(),
+                    ));
+                }
+            }
+            _ => unreachable!(),
+        }
+        Ok(())
+    }
+}

--- a/ir/src/helpers.rs
+++ b/ir/src/helpers.rs
@@ -1,6 +1,6 @@
 use crate::error::SemanticError;
 
-/// Struct to store existence of sections in the AIR source code
+/// Struct to help with validation of AIR source.
 pub(super) struct SourceValidator {
     trace_columns_exists: bool,
     public_inputs_exists: bool,
@@ -18,7 +18,7 @@ impl SourceValidator {
         }
     }
 
-    /// If the section exists, sets the provided section boolean to true.
+    /// If the declaration exists, sets corresponding boolean flag to true.
     pub fn exists(&mut self, section: &str) {
         match section {
             "trace_columns" => self.trace_columns_exists = true,
@@ -29,39 +29,33 @@ impl SourceValidator {
         }
     }
 
-    /// Returns a MissingSourceSection error if the provided section is missing.
-    pub fn check(&self, section: &str) -> Result<(), SemanticError> {
-        match section {
-            "trace_columns" => {
-                if !self.trace_columns_exists {
-                    return Err(SemanticError::MissingSourceSection(
-                        "trace_columns section is missing".to_string(),
-                    ));
-                }
-            }
-            "public_inputs" => {
-                if !self.public_inputs_exists {
-                    return Err(SemanticError::MissingSourceSection(
-                        "public_inputs section is missing".to_string(),
-                    ));
-                }
-            }
-            "boundary_constraints" => {
-                if !self.boundary_constraints_exists {
-                    return Err(SemanticError::MissingSourceSection(
-                        "boundary_constraints section is missing".to_string(),
-                    ));
-                }
-            }
-            "transition_constraints" => {
-                if !self.transition_constraints_exists {
-                    return Err(SemanticError::MissingSourceSection(
-                        "transition_constraints section is missing".to_string(),
-                    ));
-                }
-            }
-            _ => unreachable!(),
+    /// Returns a SemanticError if any of the required declarations are missing.
+    pub fn check(&self) -> Result<(), SemanticError> {
+        // make sure trace_columns are declared.
+        if !self.trace_columns_exists {
+            return Err(SemanticError::MissingDeclaration(
+                "trace_columns section is missing".to_string(),
+            ));
         }
+        // make sure public_inputs are declared.
+        if !self.public_inputs_exists {
+            return Err(SemanticError::MissingDeclaration(
+                "public_inputs section is missing".to_string(),
+            ));
+        }
+        // make sure boundary_constraints are declared.
+        if !self.boundary_constraints_exists {
+            return Err(SemanticError::MissingDeclaration(
+                "boundary_constraints section is missing".to_string(),
+            ));
+        }
+        // make sure transition_constraints are declared.
+        if !self.transition_constraints_exists {
+            return Err(SemanticError::MissingDeclaration(
+                "transition_constraints section is missing".to_string(),
+            ));
+        }
+
         Ok(())
     }
 }

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -10,4 +10,5 @@ pub enum Error {
 pub enum ParseError {
     InvalidInt(String),
     InvalidTraceCols(String),
+    MissingMainTraceCols(String),
 }

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -42,7 +42,7 @@ TraceCols: TraceCols = {
         (Some(main_cols), Some(aux_cols)) => Ok(TraceCols { main_cols, aux_cols }),
         (Some(main_cols), None) => Ok(TraceCols { main_cols, aux_cols: vec![] }),
         (None, Some(_aux_cols)) => Err(ParseError::User {
-            error: Error::ParseError(MissingMainTraceCols("Main Trace Columns definition is required".to_string()))
+            error: Error::ParseError(MissingMainTraceCols("Declaration of main trace columns is required".to_string()))
         }),
         (None, None) => Err(ParseError::User {
             error: Error::ParseError(InvalidTraceCols("Trace Columns cannot be empty".to_string()))

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -3,7 +3,7 @@ use crate::{
         boundary_constraints::{Boundary, BoundaryConstraints, BoundaryConstraint, BoundaryExpr}, 
         transition_constraints::{TransitionConstraint, TransitionConstraints, TransitionExpr},
         Identifier, Source, SourceSection, TraceCols, PublicInput, PeriodicColumn
-    }, error::{Error, ParseError::{InvalidInt, InvalidTraceCols}}, lexer::Token
+    }, error::{Error, ParseError::{InvalidInt, InvalidTraceCols, MissingMainTraceCols}}, lexer::Token
 };
 use std::str::FromStr;
 use lalrpop_util::ParseError;
@@ -41,7 +41,9 @@ TraceCols: TraceCols = {
     {
         (Some(main_cols), Some(aux_cols)) => Ok(TraceCols { main_cols, aux_cols }),
         (Some(main_cols), None) => Ok(TraceCols { main_cols, aux_cols: vec![] }),
-        (None, Some(aux_cols)) => Ok(TraceCols { main_cols: vec![], aux_cols }),
+        (None, Some(_aux_cols)) => Err(ParseError::User {
+            error: Error::ParseError(MissingMainTraceCols("Main Trace Columns definition is required".to_string()))
+        }),
         (None, None) => Err(ParseError::User {
             error: Error::ParseError(InvalidTraceCols("Trace Columns cannot be empty".to_string()))
         })

--- a/parser/src/parser/tests/boundary_constraints.rs
+++ b/parser/src/parser/tests/boundary_constraints.rs
@@ -122,3 +122,12 @@ fn err_boundary_constraint_with_identifier() {
         enf clk.first = a + 5";
     build_parse_test!(source).expect_unrecognized_token();
 }
+
+#[test]
+fn err_empty_boundary_constraints() {
+    let source = "
+    boundary_constraints:
+    transition_constraints:
+        enf clk' = clk + 1";
+    build_parse_test!(source).expect_unrecognized_token();
+}

--- a/parser/src/parser/tests/trace_columns.rs
+++ b/parser/src/parser/tests/trace_columns.rs
@@ -49,3 +49,22 @@ fn empty_trace_columns_error() {
     ));
     build_parse_test!(source).expect_error(error);
 }
+
+#[test]
+fn main_trace_cols_missing_error() {
+    // returns an error if main trace columns are not defined
+    let source = "
+    trace_columns:
+        aux: [clk]
+    public_inputs:
+        stack_inputs: [16]
+    transition_constraints:
+        enf clk' = clk + 1
+    boundary_constraints:
+        enf clk.first = 0";
+
+    let error = Error::ParseError(ParseError::MissingMainTraceCols(
+        "Main Trace Columns definition is required".to_string(),
+    ));
+    build_parse_test!(source).expect_error(error);
+}

--- a/parser/src/parser/tests/trace_columns.rs
+++ b/parser/src/parser/tests/trace_columns.rs
@@ -64,7 +64,7 @@ fn main_trace_cols_missing_error() {
         enf clk.first = 0";
 
     let error = Error::ParseError(ParseError::MissingMainTraceCols(
-        "Main Trace Columns definition is required".to_string(),
+        "Declaration of main trace columns is required".to_string(),
     ));
     build_parse_test!(source).expect_error(error);
 }

--- a/parser/src/parser/tests/transition_constraints.rs
+++ b/parser/src/parser/tests/transition_constraints.rs
@@ -109,3 +109,13 @@ fn error_invalid_next_usage() {
         enf clk'' = clk + 1";
     build_parse_test!(source).expect_unrecognized_token();
 }
+
+#[test]
+fn err_empty_transition_constraints() {
+    let source = "
+    transition_constraints:
+        
+    boundary_constraints:
+        enf clk.first = 1";
+    build_parse_test!(source).expect_unrecognized_token();
+}


### PR DESCRIPTION
Addressing #45, #44 and #30 and #29.
- Regarding throwing error when boundary_constraints or transition_constraints are empty, that case was already handled but I have included tests in parser for the same.
- Changes to the docs for transition constraints and boundary constraints are missing in this PR as they should be done after #36 is merged.