### PR TITLE
Minor docs fix

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -4,3 +4,6 @@ language = "en"
 multilingual = false
 src = "src"
 title = "Polygon Miden's Air DSL"
+
+[output.linkcheck]
+warning-policy = "ignore"

--- a/docs/src/description/declarations.md
+++ b/docs/src/description/declarations.md
@@ -6,7 +6,7 @@ A `trace_columns` section contains declarations for `main` trace columns or `aux
 
 The `main` and `aux` declarations define the shape of the main and auxiliary execution traces respectively and declare identifiers which can be used to refer to each of the columns in that trace.
 
-**A `trace_columns` section with a `main` declaration is required for an Air DSL to be valid.** The `aux` declaration is optional.
+**A `trace_columns` section with a `main` declaration is required for an Air DSL to be valid.** The `aux` declaration is optional. Also, the `main` trace columns should be declared before `aux` trace columns.
 
 The following is a valid `trace_columns` block:
 

--- a/docs/src/description/syntax.md
+++ b/docs/src/description/syntax.md
@@ -21,7 +21,7 @@ Air DSL defines the following keywords:
 
 ## Delimiters and special characters
 
-- `:` is used as a delimiter when declaring [source sections](./primitives.md) and [types](./declarations.md)
+- `:` is used as a delimiter when declaring [source sections](./structure.md#source-sections) and [types](./declarations.md)
 - `.` is used to access a boundary on a trace column, e.g. `a.first` or `a.last`
 - `[` and `]` are used for defining arrays in [type declarations](./declarations.md) and for indexing in [constraint descriptions](./constraints.md)
 - `,` is used as a delimiter for defining arrays in [type declarations](./declarations.md)


### PR DESCRIPTION
This PR makes 3 minor changes to the docs.
- Fixes a link
- Adds mdbook-linkcheck
- Adds clarification regarding declaring main trace columns before aux trace columns