### PR TITLE
Remove struct wrapper around boundary constraints and transition constraints

### DIFF
--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -72,12 +72,12 @@ impl AirIR {
         for section in source {
             match section {
                 ast::SourceSection::BoundaryConstraints(constraints) => {
-                    for constraint in constraints.boundary_constraints.iter() {
+                    for constraint in constraints.iter() {
                         boundary_constraints.insert(&symbol_table, constraint)?;
                     }
                 }
                 ast::SourceSection::TransitionConstraints(constraints) => {
-                    for constraint in constraints.transition_constraints.iter() {
+                    for constraint in constraints.iter() {
                         transition_constraints.insert(&symbol_table, constraint)?;
                     }
                 }

--- a/parser/src/ast/boundary_constraints.rs
+++ b/parser/src/ast/boundary_constraints.rs
@@ -4,12 +4,6 @@ use std::fmt::Display;
 // BOUNDARY CONSTRAINTS
 // ================================================================================================
 
-/// Stores the boundary constraints to be enforced on the trace column values.
-#[derive(Debug, PartialEq)]
-pub struct BoundaryConstraints {
-    pub boundary_constraints: Vec<BoundaryConstraint>,
-}
-
 /// Stores the expression corresponding to the boundary constraint.
 #[derive(Debug, PartialEq)]
 pub struct BoundaryConstraint {

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -39,8 +39,8 @@ pub enum SourceSection {
     TraceCols(TraceCols),
     PublicInputs(Vec<PublicInput>),
     PeriodicColumns(Vec<PeriodicColumn>),
-    BoundaryConstraints(BoundaryConstraints),
-    TransitionConstraints(TransitionConstraints),
+    BoundaryConstraints(Vec<BoundaryConstraint>),
+    TransitionConstraints(Vec<TransitionConstraint>),
 }
 
 // TRACE

--- a/parser/src/ast/transition_constraints.rs
+++ b/parser/src/ast/transition_constraints.rs
@@ -3,12 +3,6 @@ use super::Identifier;
 // TRANSITION CONSTRAINTS
 // ================================================================================================
 
-/// Stores the transition constraints to be enforced on the trace column values.
-#[derive(Debug, PartialEq)]
-pub struct TransitionConstraints {
-    pub transition_constraints: Vec<TransitionConstraint>,
-}
-
 /// Stores the expression corresponding to the transition constraint.
 #[derive(Debug, PartialEq, Clone)]
 pub struct TransitionConstraint {

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -1,8 +1,8 @@
 use crate::{
     ast::{
-        boundary_constraints::{Boundary, BoundaryConstraints, BoundaryConstraint, BoundaryExpr}, 
-        transition_constraints::{TransitionConstraint, TransitionConstraints, TransitionExpr},
-        Identifier, Source, SourceSection, TraceCols, PublicInput, PeriodicColumn
+        boundary_constraints::{Boundary, BoundaryConstraint, BoundaryExpr}, 
+        transition_constraints::{TransitionConstraint, TransitionExpr}, Identifier, Source,
+        SourceSection, TraceCols, PublicInput, PeriodicColumn
     }, error::{Error, ParseError::{InvalidInt, InvalidTraceCols}}, lexer::Token
 };
 use std::str::FromStr;
@@ -84,9 +84,8 @@ PeriodicColumn: PeriodicColumn = {
 // BOUNDARY CONSTRAINTS
 // ================================================================================================
 
-BoundaryConstraints: BoundaryConstraints = {
-    "boundary_constraints" ":" <boundary_constraints: BoundaryConstraint+> =>
-        BoundaryConstraints { boundary_constraints }
+BoundaryConstraints: Vec<BoundaryConstraint> = {
+    "boundary_constraints" ":" <boundary_constraints: BoundaryConstraint+> => boundary_constraints
 }
 
 BoundaryConstraint: BoundaryConstraint = {
@@ -123,9 +122,9 @@ BoundaryAtom: BoundaryExpr = {
 // TRANSITION CONSTRAINTS
 // ================================================================================================
 
-TransitionConstraints: TransitionConstraints = {
-    "transition_constraints" ":" <transition_constraints: TransitionConstraint+> =>
-        TransitionConstraints { transition_constraints }
+TransitionConstraints: Vec<TransitionConstraint> = {
+    "transition_constraints" ":" <transition_constraints: TransitionConstraint+> => 
+        transition_constraints
 }
 
 TransitionConstraint: TransitionConstraint = {

--- a/parser/src/parser/tests/boundary_constraints.rs
+++ b/parser/src/parser/tests/boundary_constraints.rs
@@ -1,6 +1,5 @@
 use super::{
-    build_parse_test, Boundary, BoundaryConstraint, BoundaryConstraints, BoundaryExpr, Identifier,
-    Source, SourceSection,
+    build_parse_test, Boundary, BoundaryConstraint, BoundaryExpr, Identifier, Source, SourceSection,
 };
 
 // BOUNDARY CONSTRAINTS
@@ -11,15 +10,13 @@ fn boundary_constraint_at_first() {
     let source = "
     boundary_constraints:
         enf clk.first = 0";
-    let expected = Source(vec![SourceSection::BoundaryConstraints(
-        BoundaryConstraints {
-            boundary_constraints: vec![BoundaryConstraint::new(
-                Identifier("clk".to_string()),
-                Boundary::First,
-                BoundaryExpr::Const(0),
-            )],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::BoundaryConstraints(vec![
+        BoundaryConstraint::new(
+            Identifier("clk".to_string()),
+            Boundary::First,
+            BoundaryExpr::Const(0),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -28,15 +25,13 @@ fn boundary_constraint_at_last() {
     let source = "
     boundary_constraints:
         enf clk.last = 15";
-    let expected = Source(vec![SourceSection::BoundaryConstraints(
-        BoundaryConstraints {
-            boundary_constraints: vec![BoundaryConstraint::new(
-                Identifier("clk".to_string()),
-                Boundary::Last,
-                BoundaryExpr::Const(15),
-            )],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::BoundaryConstraints(vec![
+        BoundaryConstraint::new(
+            Identifier("clk".to_string()),
+            Boundary::Last,
+            BoundaryExpr::Const(15),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -54,22 +49,18 @@ fn multiple_boundary_constraints() {
     boundary_constraints:
         enf clk.first = 0
         enf clk.last = 1";
-    let expected = Source(vec![SourceSection::BoundaryConstraints(
-        BoundaryConstraints {
-            boundary_constraints: vec![
-                BoundaryConstraint::new(
-                    Identifier("clk".to_string()),
-                    Boundary::First,
-                    BoundaryExpr::Const(0),
-                ),
-                BoundaryConstraint::new(
-                    Identifier("clk".to_string()),
-                    Boundary::Last,
-                    BoundaryExpr::Const(1),
-                ),
-            ],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::BoundaryConstraints(vec![
+        BoundaryConstraint::new(
+            Identifier("clk".to_string()),
+            Boundary::First,
+            BoundaryExpr::Const(0),
+        ),
+        BoundaryConstraint::new(
+            Identifier("clk".to_string()),
+            Boundary::Last,
+            BoundaryExpr::Const(1),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -78,15 +69,13 @@ fn boundary_constraint_with_pub_input() {
     let source = "
     boundary_constraints:
         enf clk.first = a[0]";
-    let expected = Source(vec![SourceSection::BoundaryConstraints(
-        BoundaryConstraints {
-            boundary_constraints: vec![BoundaryConstraint::new(
-                Identifier("clk".to_string()),
-                Boundary::First,
-                BoundaryExpr::PubInput(Identifier("a".to_string()), 0),
-            )],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::BoundaryConstraints(vec![
+        BoundaryConstraint::new(
+            Identifier("clk".to_string()),
+            Boundary::First,
+            BoundaryExpr::PubInput(Identifier("a".to_string()), 0),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -95,21 +84,19 @@ fn boundary_constraint_with_expr() {
     let source = "
     boundary_constraints:
         enf clk.first = 5 + a[3] + 6";
-    let expected = Source(vec![SourceSection::BoundaryConstraints(
-        BoundaryConstraints {
-            boundary_constraints: vec![BoundaryConstraint::new(
-                Identifier("clk".to_string()),
-                Boundary::First,
-                BoundaryExpr::Add(
-                    Box::new(BoundaryExpr::Add(
-                        Box::new(BoundaryExpr::Const(5)),
-                        Box::new(BoundaryExpr::PubInput(Identifier("a".to_string()), 3)),
-                    )),
-                    Box::new(BoundaryExpr::Const(6)),
-                ),
-            )],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::BoundaryConstraints(vec![
+        BoundaryConstraint::new(
+            Identifier("clk".to_string()),
+            Boundary::First,
+            BoundaryExpr::Add(
+                Box::new(BoundaryExpr::Add(
+                    Box::new(BoundaryExpr::Const(5)),
+                    Box::new(BoundaryExpr::PubInput(Identifier("a".to_string()), 3)),
+                )),
+                Box::new(BoundaryExpr::Const(6)),
+            ),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 

--- a/parser/src/parser/tests/expressions.rs
+++ b/parser/src/parser/tests/expressions.rs
@@ -1,6 +1,5 @@
 use super::{
-    build_parse_test, Identifier, Source, SourceSection, TransitionConstraint,
-    TransitionConstraints, TransitionExpr,
+    build_parse_test, Identifier, Source, SourceSection, TransitionConstraint, TransitionExpr,
 };
 
 // EXPRESSIONS
@@ -12,17 +11,15 @@ fn single_addition() {
     let source = "
     transition_constraints:
         enf clk' + clk = 0";
-    let expected = Source(vec![SourceSection::TransitionConstraints(
-        TransitionConstraints {
-            transition_constraints: vec![TransitionConstraint::new(
-                TransitionExpr::Add(
-                    Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
-                    Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
-                ),
-                TransitionExpr::Const(0),
-            )],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::TransitionConstraints(vec![
+        TransitionConstraint::new(
+            TransitionExpr::Add(
+                Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
+            ),
+            TransitionExpr::Const(0),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -32,20 +29,18 @@ fn multi_addition() {
     let source = "
     transition_constraints:
         enf clk' + clk + 2 = 0";
-    let expected = Source(vec![SourceSection::TransitionConstraints(
-        TransitionConstraints {
-            transition_constraints: vec![TransitionConstraint::new(
-                TransitionExpr::Add(
-                    Box::new(TransitionExpr::Add(
-                        Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
-                        Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
-                    )),
-                    Box::new(TransitionExpr::Const(2)),
-                ),
-                TransitionExpr::Const(0),
-            )],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::TransitionConstraints(vec![
+        TransitionConstraint::new(
+            TransitionExpr::Add(
+                Box::new(TransitionExpr::Add(
+                    Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                    Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
+                )),
+                Box::new(TransitionExpr::Const(2)),
+            ),
+            TransitionExpr::Const(0),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -55,17 +50,15 @@ fn single_subtraction() {
     let source = "
     transition_constraints:
         enf clk' - clk = 0";
-    let expected = Source(vec![SourceSection::TransitionConstraints(
-        TransitionConstraints {
-            transition_constraints: vec![TransitionConstraint::new(
-                TransitionExpr::Sub(
-                    Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
-                    Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
-                ),
-                TransitionExpr::Const(0),
-            )],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::TransitionConstraints(vec![
+        TransitionConstraint::new(
+            TransitionExpr::Sub(
+                Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
+            ),
+            TransitionExpr::Const(0),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -75,20 +68,18 @@ fn multi_subtraction() {
     let source = "
     transition_constraints:
         enf clk' - clk - 1 = 0";
-    let expected = Source(vec![SourceSection::TransitionConstraints(
-        TransitionConstraints {
-            transition_constraints: vec![TransitionConstraint::new(
-                TransitionExpr::Sub(
-                    Box::new(TransitionExpr::Sub(
-                        Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
-                        Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
-                    )),
-                    Box::new(TransitionExpr::Const(1)),
-                ),
-                TransitionExpr::Const(0),
-            )],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::TransitionConstraints(vec![
+        TransitionConstraint::new(
+            TransitionExpr::Sub(
+                Box::new(TransitionExpr::Sub(
+                    Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                    Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
+                )),
+                Box::new(TransitionExpr::Const(1)),
+            ),
+            TransitionExpr::Const(0),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -98,17 +89,15 @@ fn single_multiplication() {
     let source = "
     transition_constraints:
         enf clk' * clk = 0";
-    let expected = Source(vec![SourceSection::TransitionConstraints(
-        TransitionConstraints {
-            transition_constraints: vec![TransitionConstraint::new(
-                TransitionExpr::Mul(
-                    Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
-                    Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
-                ),
-                TransitionExpr::Const(0),
-            )],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::TransitionConstraints(vec![
+        TransitionConstraint::new(
+            TransitionExpr::Mul(
+                Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
+            ),
+            TransitionExpr::Const(0),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -118,20 +107,18 @@ fn multi_multiplication() {
     let source = "
     transition_constraints:
         enf clk' * clk * 2 = 0";
-    let expected = Source(vec![SourceSection::TransitionConstraints(
-        TransitionConstraints {
-            transition_constraints: vec![TransitionConstraint::new(
-                TransitionExpr::Mul(
-                    Box::new(TransitionExpr::Mul(
-                        Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
-                        Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
-                    )),
-                    Box::new(TransitionExpr::Const(2)),
-                ),
-                TransitionExpr::Const(0),
-            )],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::TransitionConstraints(vec![
+        TransitionConstraint::new(
+            TransitionExpr::Mul(
+                Box::new(TransitionExpr::Mul(
+                    Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                    Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
+                )),
+                Box::new(TransitionExpr::Const(2)),
+            ),
+            TransitionExpr::Const(0),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -141,17 +128,15 @@ fn unit_with_parens() {
     let source = "
     transition_constraints:
         enf (2) + 1 = 3";
-    let expected = Source(vec![SourceSection::TransitionConstraints(
-        TransitionConstraints {
-            transition_constraints: vec![TransitionConstraint::new(
-                TransitionExpr::Add(
-                    Box::new(TransitionExpr::Const(2)),
-                    Box::new(TransitionExpr::Const(1)),
-                ),
-                TransitionExpr::Const(3),
-            )],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::TransitionConstraints(vec![
+        TransitionConstraint::new(
+            TransitionExpr::Add(
+                Box::new(TransitionExpr::Const(2)),
+                Box::new(TransitionExpr::Const(1)),
+            ),
+            TransitionExpr::Const(3),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -161,20 +146,18 @@ fn ops_with_parens() {
     let source = "
     transition_constraints:
         enf (clk' + clk) * 2 = 4";
-    let expected = Source(vec![SourceSection::TransitionConstraints(
-        TransitionConstraints {
-            transition_constraints: vec![TransitionConstraint::new(
-                TransitionExpr::Mul(
-                    Box::new(TransitionExpr::Add(
-                        Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
-                        Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
-                    )),
-                    Box::new(TransitionExpr::Const(2)),
-                ),
-                TransitionExpr::Const(4),
-            )],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::TransitionConstraints(vec![
+        TransitionConstraint::new(
+            TransitionExpr::Mul(
+                Box::new(TransitionExpr::Add(
+                    Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                    Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
+                )),
+                Box::new(TransitionExpr::Const(2)),
+            ),
+            TransitionExpr::Const(4),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -184,17 +167,15 @@ fn single_exponentiation() {
     let source = "
     transition_constraints:
         enf clk'^2 = 1";
-    let expected = Source(vec![SourceSection::TransitionConstraints(
-        TransitionConstraints {
-            transition_constraints: vec![TransitionConstraint::new(
-                TransitionExpr::Exp(
-                    Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
-                    2,
-                ),
-                TransitionExpr::Const(1),
-            )],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::TransitionConstraints(vec![
+        TransitionConstraint::new(
+            TransitionExpr::Exp(
+                Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                2,
+            ),
+            TransitionExpr::Const(1),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -231,23 +212,21 @@ fn multi_arithmetic_ops_same_precedence() {
     let source = "
     transition_constraints:
         enf clk' - clk - 2 + 1 = 0";
-    let expected = Source(vec![SourceSection::TransitionConstraints(
-        TransitionConstraints {
-            transition_constraints: vec![TransitionConstraint::new(
-                TransitionExpr::Add(
+    let expected = Source(vec![SourceSection::TransitionConstraints(vec![
+        TransitionConstraint::new(
+            TransitionExpr::Add(
+                Box::new(TransitionExpr::Sub(
                     Box::new(TransitionExpr::Sub(
-                        Box::new(TransitionExpr::Sub(
-                            Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
-                            Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
-                        )),
-                        Box::new(TransitionExpr::Const(2)),
+                        Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                        Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
                     )),
-                    Box::new(TransitionExpr::Const(1)),
-                ),
-                TransitionExpr::Const(0),
-            )],
-        },
-    )]);
+                    Box::new(TransitionExpr::Const(2)),
+                )),
+                Box::new(TransitionExpr::Const(1)),
+            ),
+            TransitionExpr::Const(0),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -262,26 +241,24 @@ fn multi_arithmetic_ops_different_precedence() {
     // 2. Multiplication
     // 3. Addition/Subtraction
     // These operations are evaluated in the order of decreasing precedence.
-    let expected = Source(vec![SourceSection::TransitionConstraints(
-        TransitionConstraints {
-            transition_constraints: vec![TransitionConstraint::new(
-                TransitionExpr::Sub(
-                    Box::new(TransitionExpr::Sub(
-                        Box::new(TransitionExpr::Exp(
-                            Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
-                            2,
-                        )),
-                        Box::new(TransitionExpr::Mul(
-                            Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
-                            Box::new(TransitionExpr::Const(2)),
-                        )),
+    let expected = Source(vec![SourceSection::TransitionConstraints(vec![
+        TransitionConstraint::new(
+            TransitionExpr::Sub(
+                Box::new(TransitionExpr::Sub(
+                    Box::new(TransitionExpr::Exp(
+                        Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                        2,
                     )),
-                    Box::new(TransitionExpr::Const(1)),
-                ),
-                TransitionExpr::Const(0),
-            )],
-        },
-    )]);
+                    Box::new(TransitionExpr::Mul(
+                        Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
+                        Box::new(TransitionExpr::Const(2)),
+                    )),
+                )),
+                Box::new(TransitionExpr::Const(1)),
+            ),
+            TransitionExpr::Const(0),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -297,25 +274,23 @@ fn multi_arithmetic_ops_different_precedence_w_parens() {
     // 3. Multiplication
     // 4. Addition/Subtraction
     // These operations are evaluated in the order of decreasing precedence.
-    let expected = Source(vec![SourceSection::TransitionConstraints(
-        TransitionConstraints {
-            transition_constraints: vec![TransitionConstraint::new(
-                TransitionExpr::Sub(
-                    Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
-                    Box::new(TransitionExpr::Mul(
-                        Box::new(TransitionExpr::Exp(
-                            Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
-                            2,
-                        )),
-                        Box::new(TransitionExpr::Sub(
-                            Box::new(TransitionExpr::Const(2)),
-                            Box::new(TransitionExpr::Const(1)),
-                        )),
+    let expected = Source(vec![SourceSection::TransitionConstraints(vec![
+        TransitionConstraint::new(
+            TransitionExpr::Sub(
+                Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                Box::new(TransitionExpr::Mul(
+                    Box::new(TransitionExpr::Exp(
+                        Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
+                        2,
                     )),
-                ),
-                TransitionExpr::Const(0),
-            )],
-        },
-    )]);
+                    Box::new(TransitionExpr::Sub(
+                        Box::new(TransitionExpr::Const(2)),
+                        Box::new(TransitionExpr::Const(1)),
+                    )),
+                )),
+            ),
+            TransitionExpr::Const(0),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }

--- a/parser/src/parser/tests/mod.rs
+++ b/parser/src/parser/tests/mod.rs
@@ -41,25 +41,21 @@ fn full_air_file() {
         }),
         // transition_constraints:
         //     enf clk' = clk + 1
-        SourceSection::TransitionConstraints(TransitionConstraints {
-            transition_constraints: vec![TransitionConstraint::new(
-                // clk' = clk + 1
-                TransitionExpr::Next(Identifier("clk".to_string())),
-                TransitionExpr::Add(
-                    Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
-                    Box::new(TransitionExpr::Const(1)),
-                ),
-            )],
-        }),
+        SourceSection::TransitionConstraints(vec![TransitionConstraint::new(
+            // clk' = clk + 1
+            TransitionExpr::Next(Identifier("clk".to_string())),
+            TransitionExpr::Add(
+                Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
+                Box::new(TransitionExpr::Const(1)),
+            ),
+        )]),
         // boundary_constraints:
         //     enf clk.first = 0
-        SourceSection::BoundaryConstraints(BoundaryConstraints {
-            boundary_constraints: vec![BoundaryConstraint::new(
-                Identifier("clk".to_string()),
-                Boundary::First,
-                BoundaryExpr::Const(0),
-            )],
-        }),
+        SourceSection::BoundaryConstraints(vec![BoundaryConstraint::new(
+            Identifier("clk".to_string()),
+            Boundary::First,
+            BoundaryExpr::Const(0),
+        )]),
     ]);
     build_parse_test!(source.as_str()).expect_ast(expected);
 }

--- a/parser/src/parser/tests/transition_constraints.rs
+++ b/parser/src/parser/tests/transition_constraints.rs
@@ -1,6 +1,5 @@
 use super::{
-    build_parse_test, Identifier, Source, SourceSection, TransitionConstraint,
-    TransitionConstraints, TransitionExpr,
+    build_parse_test, Identifier, Source, SourceSection, TransitionConstraint, TransitionExpr,
 };
 
 // TRANSITION CONSTRAINTS
@@ -11,17 +10,15 @@ fn transition_constraints() {
     let source = "
     transition_constraints:
         enf clk' = clk + 1";
-    let expected = Source(vec![SourceSection::TransitionConstraints(
-        TransitionConstraints {
-            transition_constraints: vec![TransitionConstraint::new(
-                TransitionExpr::Next(Identifier("clk".to_string())),
-                TransitionExpr::Add(
-                    Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
-                    Box::new(TransitionExpr::Const(1)),
-                ),
-            )],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::TransitionConstraints(vec![
+        TransitionConstraint::new(
+            TransitionExpr::Next(Identifier("clk".to_string())),
+            TransitionExpr::Add(
+                Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
+                Box::new(TransitionExpr::Const(1)),
+            ),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -38,26 +35,22 @@ fn multiple_transition_constraints() {
     transition_constraints:
         enf clk' = clk + 1
         enf clk' - clk = 1";
-    let expected = Source(vec![SourceSection::TransitionConstraints(
-        TransitionConstraints {
-            transition_constraints: vec![
-                TransitionConstraint::new(
-                    TransitionExpr::Next(Identifier("clk".to_string())),
-                    TransitionExpr::Add(
-                        Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
-                        Box::new(TransitionExpr::Const(1)),
-                    ),
-                ),
-                TransitionConstraint::new(
-                    TransitionExpr::Sub(
-                        Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
-                        Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
-                    ),
-                    TransitionExpr::Const(1),
-                ),
-            ],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::TransitionConstraints(vec![
+        TransitionConstraint::new(
+            TransitionExpr::Next(Identifier("clk".to_string())),
+            TransitionExpr::Add(
+                Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
+                Box::new(TransitionExpr::Const(1)),
+            ),
+        ),
+        TransitionConstraint::new(
+            TransitionExpr::Sub(
+                Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
+            ),
+            TransitionExpr::Const(1),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -66,17 +59,15 @@ fn transition_constraint_with_periodic_col() {
     let source = "
     transition_constraints:
         enf k0 + b = 0";
-    let expected = Source(vec![SourceSection::TransitionConstraints(
-        TransitionConstraints {
-            transition_constraints: vec![TransitionConstraint::new(
-                TransitionExpr::Add(
-                    Box::new(TransitionExpr::Var(Identifier("k0".to_string()))),
-                    Box::new(TransitionExpr::Var(Identifier("b".to_string()))),
-                ),
-                TransitionExpr::Const(0),
-            )],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::TransitionConstraints(vec![
+        TransitionConstraint::new(
+            TransitionExpr::Add(
+                Box::new(TransitionExpr::Var(Identifier("k0".to_string()))),
+                Box::new(TransitionExpr::Var(Identifier("b".to_string()))),
+            ),
+            TransitionExpr::Const(0),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 
@@ -85,17 +76,15 @@ fn transition_constraint_with_random_value() {
     let source = "
     transition_constraints:
         enf a + $rand[1] = 0";
-    let expected = Source(vec![SourceSection::TransitionConstraints(
-        TransitionConstraints {
-            transition_constraints: vec![TransitionConstraint::new(
-                TransitionExpr::Add(
-                    Box::new(TransitionExpr::Var(Identifier("a".to_string()))),
-                    Box::new(TransitionExpr::Rand(1)),
-                ),
-                TransitionExpr::Const(0),
-            )],
-        },
-    )]);
+    let expected = Source(vec![SourceSection::TransitionConstraints(vec![
+        TransitionConstraint::new(
+            TransitionExpr::Add(
+                Box::new(TransitionExpr::Var(Identifier("a".to_string()))),
+                Box::new(TransitionExpr::Rand(1)),
+            ),
+            TransitionExpr::Const(0),
+        ),
+    ])]);
     build_parse_test!(source).expect_ast(expected);
 }
 


### PR DESCRIPTION
This PR removes struct wrapper around BoundaryConstraints and TranstionConstraints sections as they are probably redundant and can be removed.