### PR TITLE
Update Cargo.toml files for v0.1 release

### DIFF
--- a/air-script/Cargo.toml
+++ b/air-script/Cargo.toml
@@ -1,19 +1,28 @@
 [package]
 name = "air-script"
 version = "0.1.0"
+description="AirScript language compiler"
+authors = ["miden contributors"]
+readme="README.md"
+license = "MIT"
+repository = "https://github.com/0xPolygonMiden/air-script"
+documnetation = "https://0xpolygonmiden.github.io/air-script/"
+categories = ["compilers", "cryptography"]
+keywords = ["air", "stark", "zero knowledge", "zkp"]
 edition = "2021"
+rust-version = "1.65"
 
 [[bin]]
 name = "airc"
 path = "src/main.rs"
 
 [dependencies]
-parser = { package = "air-parser", path = "../parser", version = "0.1.0" }
-ir = { package = "air-ir", path = "../ir", version = "0.1.0" }
 codegen-winter = { package = "air-codegen-winter", path = "../codegen/winterfell", version = "0.1.0" }
-structopt = "0.3.26"
 env_logger = "0.9"
+ir = { package = "air-ir", path = "../ir", version = "0.1.0" }
 log = { version = "0.4", default-features = false }
+parser = { package = "air-parser", path = "../parser", version = "0.1.0" }
+structopt = "0.3.26"
 
 [dev-dependencies]
 expect-test = "1.4.0"

--- a/codegen/winterfell/Cargo.toml
+++ b/codegen/winterfell/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
 name = "air-codegen-winter"
 version = "0.1.0"
+description="Winterfell code generator for the AirScript language"
+authors = ["miden contributors"]
+readme="README.md"
+license = "MIT"
+repository = "https://github.com/0xPolygonMiden/air-script"
+categories = ["compilers", "cryptography"]
+keywords = ["air", "stark", "winterfell", "zero knowledge", "zkp"]
 edition = "2021"
+rust-version = "1.65"
 
 [dependencies]
 codegen = "0.2.0"

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
 name = "air-ir"
 version = "0.1.0"
+description="Intermediate representation for the AirScript language"
+authors = ["miden contributors"]
+readme="README.md"
+license = "MIT"
+repository = "https://github.com/0xPolygonMiden/air-script"
+categories = ["compilers", "cryptography"]
+keywords = ["air", "stark", "zero knowledge", "zkp"]
 edition = "2021"
+rust-version = "1.65"
 
 [dependencies]
 parser = { package = "air-parser", path = "../parser", version = "0.1.0" }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,12 +1,19 @@
 [package]
 name = "air-parser"
 version = "0.1.0"
+description="Parser for the AirScript language"
+authors = ["miden contributors"]
+readme="README.md"
+license = "MIT"
+repository = "https://github.com/0xPolygonMiden/air-script"
+categories = ["compilers", "cryptography", "parser-implementations"]
+keywords = ["air", "stark", "zero knowledge", "zkp"]
 edition = "2021"
-
+rust-version = "1.65"
 [build-dependencies]
 lalrpop = "0.19.7"
 
 [dependencies]
 lalrpop-util = { version = "0.19.7" }
-regex = "1"
 logos = "0.12.0"
+regex = "1"


### PR DESCRIPTION
This PR adds a bunch of fields to Cargo.toml files which are needed to have for publishing to crates.io. It also alphabetizes all dependencies.