### PR TITLE
Update keywords in Cargo.toml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # AirScript
 
+<a href="https://github.com/0xPolygonMiden/air-script/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+<img src="https://github.com/0xPolygonMiden/air-script/workflows/CI/badge.svg?branch=main">
+<a href="https://crates.io/crates/air-script"><img src="https://img.shields.io/crates/v/air-script"></a>
+
 A domain-specific language for expressing AIR constraints for STARKs, especially for STARK-based virtual machines like [Miden VM](https://github.com/maticnetwork/miden/).
 
 An in-depth description of AirScript is available in the full AirScript [documentation](https://0xpolygonmiden.github.io/air-script/).

--- a/air-script/Cargo.toml
+++ b/air-script/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/0xPolygonMiden/air-script"
 documnetation = "https://0xpolygonmiden.github.io/air-script/"
 categories = ["compilers", "cryptography"]
-keywords = ["air", "stark", "zero knowledge", "zkp"]
+keywords = ["air", "stark", "zero-knowledge", "zkp"]
 edition = "2021"
 rust-version = "1.65"
 

--- a/codegen/winterfell/Cargo.toml
+++ b/codegen/winterfell/Cargo.toml
@@ -7,7 +7,7 @@ readme="README.md"
 license = "MIT"
 repository = "https://github.com/0xPolygonMiden/air-script"
 categories = ["compilers", "cryptography"]
-keywords = ["air", "stark", "winterfell", "zero knowledge", "zkp"]
+keywords = ["air", "stark", "winterfell", "zero-knowledge", "zkp"]
 edition = "2021"
 rust-version = "1.65"
 

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -7,7 +7,7 @@ readme="README.md"
 license = "MIT"
 repository = "https://github.com/0xPolygonMiden/air-script"
 categories = ["compilers", "cryptography"]
-keywords = ["air", "stark", "zero knowledge", "zkp"]
+keywords = ["air", "stark", "zero-knowledge", "zkp"]
 edition = "2021"
 rust-version = "1.65"
 

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -7,7 +7,7 @@ readme="README.md"
 license = "MIT"
 repository = "https://github.com/0xPolygonMiden/air-script"
 categories = ["compilers", "cryptography", "parser-implementations"]
-keywords = ["air", "stark", "zero knowledge", "zkp"]
+keywords = ["air", "stark", "zero-knowledge", "zkp"]
 edition = "2021"
 rust-version = "1.65"
 [build-dependencies]


### PR DESCRIPTION
Seems like we can't have spaces in keywords. So, updating `zero knowledge` to `zero-knowledge`.

Also, added badges to the main README file.