### PR TITLE
Make the trace reference more general in the IR

### DIFF
--- a/codegen/winterfell/src/air/mod.rs
+++ b/codegen/winterfell/src/air/mod.rs
@@ -99,7 +99,7 @@ fn add_fn_new(impl_ref: &mut Impl, ir: &AirIR) {
 
     // define the transition constraint degrees of the main trace `main_degrees`.
     let main_degrees = ir
-        .main_degrees()
+        .constraint_degrees(0)
         .iter()
         .map(|degree| degree.to_string(false))
         .collect::<Vec<_>>();
@@ -110,7 +110,7 @@ fn add_fn_new(impl_ref: &mut Impl, ir: &AirIR) {
 
     // define the transition constraint degrees of the aux trace `aux_degrees`.
     let aux_degrees = ir
-        .aux_degrees()
+        .constraint_degrees(1)
         .iter()
         .map(|degree| degree.to_string(true))
         .collect::<Vec<_>>();

--- a/codegen/winterfell/src/air/transition_constraints.rs
+++ b/codegen/winterfell/src/air/transition_constraints.rs
@@ -25,7 +25,7 @@ pub(super) fn add_fn_evaluate_transition(impl_ref: &mut Impl, ir: &AirIR) {
 
     // output the constraints.
     let graph = ir.transition_graph();
-    for (idx, constraint) in ir.main_transition_constraints().iter().enumerate() {
+    for (idx, constraint) in ir.transition_constraints(0).iter().enumerate() {
         evaluate_transition.line(format!(
             "result[{}] = {};",
             idx,
@@ -56,7 +56,7 @@ pub(super) fn add_fn_evaluate_aux_transition(impl_ref: &mut Impl, ir: &AirIR) {
 
     // output the constraints.
     let graph = ir.transition_graph();
-    for (idx, constraint) in ir.aux_transition_constraints().iter().enumerate() {
+    for (idx, constraint) in ir.transition_constraints(1).iter().enumerate() {
         evaluate_aux_transition.line(format!(
             "result[{}] = {};",
             idx,
@@ -85,12 +85,15 @@ impl Codegen for Operation {
     fn to_string(&self, graph: &AlgebraicGraph) -> String {
         match self {
             Operation::Const(value) => format!("E::from({}_u64)", value),
-            Operation::MainTraceCurrentRow(col_idx) | Operation::AuxTraceCurrentRow(col_idx) => {
-                format!("current[{}]", col_idx)
-            }
-            Operation::MainTraceNextRow(col_idx) | Operation::AuxTraceNextRow(col_idx) => {
-                format!("next[{}]", col_idx)
-            }
+            Operation::TraceElement(trace_access) => match trace_access.row_offset() {
+                0 => {
+                    format!("current[{}]", trace_access.col_idx())
+                }
+                1 => {
+                    format!("next[{}]", trace_access.col_idx())
+                }
+                _ => panic!("Winterfell doesn't support row offsets greater than 1."),
+            },
             Operation::PeriodicColumn(col_idx, _) => {
                 format!("periodic_values[{}]", col_idx)
             }

--- a/ir/src/error.rs
+++ b/ir/src/error.rs
@@ -1,11 +1,11 @@
 #[derive(Debug)]
 pub enum SemanticError {
+    DuplicateIdentifier(String),
+    IndexOutOfRange(String),
     InvalidConstraint(String),
     InvalidIdentifier(String),
-    DuplicateIdentifier(String),
-    InvalidUsage(String),
-    IndexOutOfRange(String),
-    TooManyConstraints(String),
     InvalidPeriodicColumn(String),
+    InvalidUsage(String),
     MissingDeclaration(String),
+    TooManyConstraints(String),
 }

--- a/ir/src/error.rs
+++ b/ir/src/error.rs
@@ -1,5 +1,6 @@
 #[derive(Debug)]
 pub enum SemanticError {
+    InvalidConstraint(String),
     InvalidIdentifier(String),
     DuplicateIdentifier(String),
     InvalidUsage(String),

--- a/ir/src/symbol_table.rs
+++ b/ir/src/symbol_table.rs
@@ -154,6 +154,8 @@ impl SymbolTable {
         Ok(())
     }
 
+    /// Consumes this symbol table and returns the information required for declaring public inputs
+    /// and periodic columns for the AIR.
     pub(super) fn into_declarations(self) -> (PublicInputs, PeriodicColumns) {
         (self.public_inputs, self.periodic_columns)
     }

--- a/ir/src/transition_constraints/graph.rs
+++ b/ir/src/transition_constraints/graph.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::BTreeMap, degree::TransitionConstraintDegree, ConstraintType, SemanticError, SymbolTable,
+    super::BTreeMap, degree::TransitionConstraintDegree, SemanticError, SymbolTable, TraceSegment,
 };
 use crate::symbol_table::IdentifierType;
 use parser::ast::{Identifier, TransitionExpr};
@@ -50,10 +50,7 @@ impl AlgebraicGraph {
         // recursively walk the subgraph and compute the degree from the operation and child nodes
         match self.node(index).op() {
             Operation::Const(_) | Operation::RandomValue(_) => 0,
-            Operation::MainTraceCurrentRow(_)
-            | Operation::MainTraceNextRow(_)
-            | Operation::AuxTraceCurrentRow(_)
-            | Operation::AuxTraceNextRow(_) => 1,
+            Operation::TraceElement(_) => 1,
             Operation::PeriodicColumn(index, cycle_len) => {
                 cycles.insert(*index, *cycle_len);
                 0
@@ -90,54 +87,58 @@ impl AlgebraicGraph {
         &mut self,
         symbol_table: &SymbolTable,
         expr: TransitionExpr,
-    ) -> Result<(ConstraintType, NodeIndex), SemanticError> {
+    ) -> Result<(TraceSegment, NodeIndex), SemanticError> {
         match expr {
             TransitionExpr::Const(value) => {
                 // constraint target defaults to Main trace.
-                let constraint_type = ConstraintType::Main;
+                let trace_segment = 0;
                 let node_index = self.insert_op(Operation::Const(value));
-                Ok((constraint_type, node_index))
+                Ok((trace_segment, node_index))
             }
             TransitionExpr::Var(Identifier(ident)) => self.insert_variable(symbol_table, &ident),
             TransitionExpr::Next(Identifier(ident)) => self.insert_next(symbol_table, &ident),
             TransitionExpr::Rand(index) => {
-                let constraint_type = ConstraintType::Auxiliary;
+                // constraint target for random values defaults to the second trace segment.
+                // TODO: make this more general, so random values from further trace segments can be
+                // used. This requires having a way to describe different sets of randomness in
+                // the AirScript syntax.
+                let trace_segment = 1;
                 let node_index = self.insert_op(Operation::RandomValue(index));
-                Ok((constraint_type, node_index))
+                Ok((trace_segment, node_index))
             }
             TransitionExpr::Add(lhs, rhs) => {
                 // add both subexpressions.
-                let (lhs_type, lhs) = self.insert_expr(symbol_table, *lhs)?;
-                let (rhs_type, rhs) = self.insert_expr(symbol_table, *rhs)?;
+                let (lhs_segment, lhs) = self.insert_expr(symbol_table, *lhs)?;
+                let (rhs_segment, rhs) = self.insert_expr(symbol_table, *rhs)?;
                 // add the expression.
-                let constraint_type = get_binop_constraint_type(lhs_type, rhs_type);
+                let trace_segment = lhs_segment.max(rhs_segment);
                 let node_index = self.insert_op(Operation::Add(lhs, rhs));
-                Ok((constraint_type, node_index))
+                Ok((trace_segment, node_index))
             }
             TransitionExpr::Sub(lhs, rhs) => {
                 // add both subexpressions.
-                let (lhs_type, lhs) = self.insert_expr(symbol_table, *lhs)?;
-                let (rhs_type, rhs) = self.insert_expr(symbol_table, *rhs)?;
+                let (lhs_segment, lhs) = self.insert_expr(symbol_table, *lhs)?;
+                let (rhs_segment, rhs) = self.insert_expr(symbol_table, *rhs)?;
                 // add the expression.
-                let constraint_type = get_binop_constraint_type(lhs_type, rhs_type);
+                let trace_segment = lhs_segment.max(rhs_segment);
                 let node_index = self.insert_op(Operation::Sub(lhs, rhs));
-                Ok((constraint_type, node_index))
+                Ok((trace_segment, node_index))
             }
             TransitionExpr::Mul(lhs, rhs) => {
                 // add both subexpressions.
-                let (lhs_type, lhs) = self.insert_expr(symbol_table, *lhs)?;
-                let (rhs_type, rhs) = self.insert_expr(symbol_table, *rhs)?;
+                let (lhs_segment, lhs) = self.insert_expr(symbol_table, *lhs)?;
+                let (rhs_segment, rhs) = self.insert_expr(symbol_table, *rhs)?;
                 // add the expression.
-                let constraint_type = get_binop_constraint_type(lhs_type, rhs_type);
+                let trace_segment = lhs_segment.max(rhs_segment);
                 let node_index = self.insert_op(Operation::Mul(lhs, rhs));
-                Ok((constraint_type, node_index))
+                Ok((trace_segment, node_index))
             }
             TransitionExpr::Exp(lhs, rhs) => {
                 // add base subexpression.
-                let (constraint_type, lhs) = self.insert_expr(symbol_table, *lhs)?;
+                let (trace_segment, lhs) = self.insert_expr(symbol_table, *lhs)?;
                 // add exponent subexpression.
                 let node_index = self.insert_op(Operation::Exp(lhs, rhs as usize));
-                Ok((constraint_type, node_index))
+                Ok((trace_segment, node_index))
             }
         }
     }
@@ -146,20 +147,15 @@ impl AlgebraicGraph {
         &mut self,
         symbol_table: &SymbolTable,
         ident: &str,
-    ) -> Result<(ConstraintType, NodeIndex), SemanticError> {
+    ) -> Result<(TraceSegment, NodeIndex), SemanticError> {
         let col_type = symbol_table.get_type(ident)?;
 
-        // a "next" variable expression always references an execution trace columns
         match col_type {
-            IdentifierType::MainTraceColumn(index) => {
-                let constraint_type = ConstraintType::Main;
-                let node_index = self.insert_op(Operation::MainTraceNextRow(index));
-                Ok((constraint_type, node_index))
-            }
-            IdentifierType::AuxTraceColumn(index) => {
-                let constraint_type = ConstraintType::Auxiliary;
-                let node_index = self.insert_op(Operation::AuxTraceNextRow(index));
-                Ok((constraint_type, node_index))
+            IdentifierType::TraceColumn(column) => {
+                let trace_segment = column.trace_segment();
+                let trace_access = TraceAccess::new(trace_segment, column.col_idx(), 1);
+                let node_index = self.insert_op(Operation::TraceElement(trace_access));
+                Ok((trace_segment, node_index))
             }
             _ => Err(SemanticError::InvalidUsage(format!(
                 "Identifier {} was declared as a {} not as a trace column",
@@ -172,27 +168,23 @@ impl AlgebraicGraph {
         &mut self,
         symbol_table: &SymbolTable,
         ident: &str,
-    ) -> Result<(ConstraintType, NodeIndex), SemanticError> {
+    ) -> Result<(TraceSegment, NodeIndex), SemanticError> {
         let col_type = symbol_table.get_type(ident)?;
 
         // since variable definitions are not possible yet, the identifier must match one of
         // the declared trace columns or one of the declared periodic columns.
         match col_type {
-            IdentifierType::MainTraceColumn(index) => {
-                let constraint_type = ConstraintType::Main;
-                let node_index = self.insert_op(Operation::MainTraceCurrentRow(index));
-                Ok((constraint_type, node_index))
-            }
-            IdentifierType::AuxTraceColumn(index) => {
-                let constraint_type = ConstraintType::Auxiliary;
-                let node_index = self.insert_op(Operation::AuxTraceCurrentRow(index));
-                Ok((constraint_type, node_index))
+            IdentifierType::TraceColumn(column) => {
+                let trace_segment = column.trace_segment();
+                let trace_access = TraceAccess::new(trace_segment, column.col_idx(), 0);
+                let node_index = self.insert_op(Operation::TraceElement(trace_access));
+                Ok((trace_segment, node_index))
             }
             IdentifierType::PeriodicColumn(index, cycle_len) => {
                 // constraint target defaults to Main trace.
-                let constraint_type = ConstraintType::Main;
+                let trace_segment = 0;
                 let node_index = self.insert_op(Operation::PeriodicColumn(index, cycle_len));
-                Ok((constraint_type, node_index))
+                Ok((trace_segment, node_index))
             }
             _ => Err(SemanticError::InvalidUsage(format!(
                 "Identifier {} was declared as a {} not as a trace column",
@@ -219,16 +211,8 @@ impl AlgebraicGraph {
     }
 }
 
-fn get_binop_constraint_type(lhs_type: ConstraintType, rhs_type: ConstraintType) -> ConstraintType {
-    if lhs_type == ConstraintType::Auxiliary || rhs_type == ConstraintType::Auxiliary {
-        ConstraintType::Auxiliary
-    } else {
-        ConstraintType::Main
-    }
-}
-
 /// Reference to a node in a graph by its index in the nodes vector of the graph struct.
-#[derive(Debug, Eq, PartialEq, Default)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub struct NodeIndex(usize);
 
 #[derive(Debug)]
@@ -247,18 +231,9 @@ impl Node {
 #[derive(Debug, Eq, PartialEq)]
 pub enum Operation {
     Const(u64),
-    /// An identifier for a for a cell in the specified column in the current row in the main trace.
-    /// The inner value is the index of the column within the trace.
-    MainTraceCurrentRow(usize),
-    /// An identifier for a cell in the specified column in the next row in the main trace. The
-    /// inner value is the index of the column within the trace.
-    MainTraceNextRow(usize),
-    /// An identifier for a cell in the specified column in the current row in the auxiliary trace.
-    /// The inner value is the index of the column within the trace.
-    AuxTraceCurrentRow(usize),
-    /// An identifier for a cell in the specified column in the next row in the auxiliary trace. The
-    /// inner value is the index of the column within the trace.
-    AuxTraceNextRow(usize),
+    /// An identifier for an element in the trace segment, column, and row offset specified by the
+    /// [TraceAccess]
+    TraceElement(TraceAccess),
     /// An identifier for a periodic value from a specified periodic column. The first inner value
     /// is the index of the periodic column within the declared periodic columns. The second inner
     /// value is the length of the column's periodic cycle. The periodic value made available from
@@ -278,4 +253,36 @@ pub enum Operation {
     /// Exponentiation operation applied to the node with the specified index, using the provided
     /// value as the power.
     Exp(NodeIndex, usize),
+}
+
+/// Access information for getting an element in the execution trace. The trace_segment specifies
+/// how many trace commitments have preceded the specified segment. `col_idx` specifies the index
+/// of the column within that trace segment, and `row_offset` specifies the offset from the current
+/// row. For example, an element in the "next" row of the "main" trace would be specified by
+/// a trace_segment of 0 and a row_offset of 1.
+#[derive(Debug, Eq, PartialEq)]
+pub struct TraceAccess {
+    trace_segment: TraceSegment,
+    col_idx: usize,
+    row_offset: usize,
+}
+
+impl TraceAccess {
+    fn new(trace_segment: TraceSegment, col_idx: usize, row_offset: usize) -> Self {
+        Self {
+            trace_segment,
+            col_idx,
+            row_offset,
+        }
+    }
+
+    /// Gets the column index of this [TraceAccess].
+    pub fn col_idx(&self) -> usize {
+        self.col_idx
+    }
+
+    /// Gets the row offset of this [TraceAccess].
+    pub fn row_offset(&self) -> usize {
+        self.row_offset
+    }
 }

--- a/ir/src/transition_constraints/mod.rs
+++ b/ir/src/transition_constraints/mod.rs
@@ -1,4 +1,4 @@
-use super::{SemanticError, SymbolTable};
+use super::{SemanticError, SymbolTable, TraceSegment};
 use parser::ast;
 
 mod degree;
@@ -15,57 +15,56 @@ pub const MIN_CYCLE_LENGTH: usize = 2;
 // TRANSITION CONSTRAINTS
 // ================================================================================================
 
-#[derive(PartialEq)]
-enum ConstraintType {
-    Main,
-    Auxiliary,
-}
-
 #[derive(Default, Debug)]
 pub(super) struct TransitionConstraints {
-    /// The indices of the entry nodes for each of the transition constraints against the main trace
-    /// in the graph.
-    main_constraints: Vec<NodeIndex>,
-
-    /// The indices of the entry nodes for each of the transition constraints against the auxiliary
-    /// trace in the graph.
-    aux_constraints: Vec<NodeIndex>,
+    /// Transition constraints against the execution trace, where each index contains a vector of
+    /// the constraint roots for all constraints against that segment of the trace. For example,
+    /// constraints against the main execution trace, which is trace segment 0, will be specified by
+    /// a vector in constraint_roots[0] containing a [NodeIndex] in the graph for each constraint
+    /// against the main trace.
+    constraint_roots: Vec<Vec<NodeIndex>>,
 
     /// A directed acyclic graph which represents all of the transition constraints.
     graph: AlgebraicGraph,
 }
 
 impl TransitionConstraints {
+    // --- CONSTRUCTOR ----------------------------------------------------------------------------
+
+    pub fn new(num_trace_segments: usize) -> Self {
+        Self {
+            constraint_roots: vec![Vec::new(); num_trace_segments],
+            graph: AlgebraicGraph::default(),
+        }
+    }
+
     // --- PUBLIC ACCESSORS -----------------------------------------------------------------------
 
-    /// Returns a vector of the degrees of the transition constraints.
-    pub fn main_degrees(&self) -> Vec<TransitionConstraintDegree> {
-        self.main_constraints
+    /// Returns a vector of the degrees of the transition constraints for the specified trace
+    /// segment.
+    pub fn constraint_degrees(
+        &self,
+        trace_segment: TraceSegment,
+    ) -> Vec<TransitionConstraintDegree> {
+        if self.constraint_roots.len() <= trace_segment.into() {
+            return Vec::new();
+        }
+
+        self.constraint_roots[trace_segment as usize]
             .iter()
             .map(|entry_index| self.graph.degree(entry_index))
             .collect()
     }
 
-    /// Returns all transition constraints against the main execution trace as a vector of
+    /// Returns all transition constraints against the specified trace segment as a vector of
     /// [NodeIndex] where each index is the tip of the subgraph representing the constraint within
     /// the [AlgebraicGraph].
-    pub fn main_constraints(&self) -> &[NodeIndex] {
-        &self.main_constraints
-    }
+    pub fn constraints(&self, trace_segment: TraceSegment) -> &[NodeIndex] {
+        if self.constraint_roots.len() <= trace_segment.into() {
+            return &[];
+        }
 
-    /// Returns a vector of the degrees of the transition constraints.
-    pub fn aux_degrees(&self) -> Vec<TransitionConstraintDegree> {
-        self.aux_constraints
-            .iter()
-            .map(|entry_index| self.graph.degree(entry_index))
-            .collect()
-    }
-
-    /// Returns all transition constraints against the auxiliary execution trace as a vector of
-    /// [NodeIndex] where each index is the tip of the subgraph representing the constraint within
-    /// the [AlgebraicGraph].
-    pub fn aux_constraints(&self) -> &[NodeIndex] {
-        &self.aux_constraints
+        &self.constraint_roots[trace_segment as usize]
     }
 
     /// Returns the [AlgebraicGraph] representing all transition constraints.
@@ -87,13 +86,17 @@ impl TransitionConstraints {
         let expr = constraint.expr();
 
         // add it to the transition constraints graph and get its entry index.
-        let (constraint_type, entry_index) = self.graph.insert_expr(symbol_table, expr)?;
+        let (trace_segment, root_index) = self.graph.insert_expr(symbol_table, expr)?;
+
+        // the constraint should not be against an undeclared trace segment.
+        if symbol_table.num_trace_segments() <= trace_segment.into() {
+            return Err(SemanticError::InvalidConstraint(
+                "Constraint against undeclared trace segment".to_string(),
+            ));
+        }
 
         // add the transition constraint to the appropriate set of constraints.
-        match constraint_type {
-            ConstraintType::Main => self.main_constraints.push(entry_index),
-            ConstraintType::Auxiliary => self.aux_constraints.push(entry_index),
-        }
+        self.constraint_roots[trace_segment as usize].push(root_index);
 
         Ok(())
     }


### PR DESCRIPTION
This PR makes the trace reference more general in the IR, addressing issue #54. This PR depends on the fix in #91 and should not be merged first.

The IR has been generalized everywhere except:
- the insertion of random values into the graph. This can't change until we have a way to describe different sets of randomness in the AirScript syntax.
- the way we store boundary constraints. This needs more thinking and probably deserves its own issue