### PR TITLE
Add repo link to mdbook

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -7,6 +7,7 @@ title = "AirScript by Polygon Miden"
 
 [output.katex]
 [output.html]
+git-repository-url = "https://github.com/0xPolygonMiden/air-script/"
 
 [output.linkcheck]
 warning-policy = "ignore"

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Polygon Miden's AirScript is designed to make it simple to describe AIR constraints and generate efficient and accurate code in the required target language.
+Polygon Miden's AirScript is designed to make it simple to describe AIR constraints and generate efficient and accurate code in the required target language. The code for AirScript can be found [here](https://github.com/0xPolygonMiden/air-script/).
 
 ## Current Version
 


### PR DESCRIPTION
Question: Should the contributing guidelines be added to mdbook as well if the docs could be a possible entry point for people or maybe just added to the mdbook and removed from repo readme?