### PR TITLE
refactor: replace row_offset with ConstraintDomain

### DIFF
--- a/ir/src/boundary_stmts.rs
+++ b/ir/src/boundary_stmts.rs
@@ -3,7 +3,7 @@ use crate::{BoundaryConstraintsMap, TraceSegment};
 use super::{BTreeMap, Expression, IdentifierType, SemanticError, SymbolTable};
 use parser::ast::{self, BoundaryStmt};
 
-// BOUNDARY CONSTRAINTS
+// BOUNDARY STATEMENTS
 // ================================================================================================
 
 /// A struct containing all of the boundary constraints to be applied at each of the 2 allowed

--- a/ir/src/integrity_stmts/constraint.rs
+++ b/ir/src/integrity_stmts/constraint.rs
@@ -1,0 +1,77 @@
+use super::NodeIndex;
+
+/// A [ConstraintRoot] represents the entry node of a subgraph representing an integrity constraint
+/// within the [AlgebraicGraph]. It also contains the row offset for the constraint which is the
+/// maximum of all row offsets accessed by the constraint. For example, if a constraint only
+/// accesses the trace in the current row then the row offset will be 0, but if it accesses the
+/// trace in both the current and the next rows then the row offset will be 1.
+#[derive(Debug, Clone)]
+pub struct ConstraintRoot {
+    index: NodeIndex,
+    domain: ConstraintDomain,
+}
+
+impl ConstraintRoot {
+    /// Creates a new [ConstraintRoot] with the specified entry index and row offset.
+    pub fn new(index: NodeIndex, domain: ConstraintDomain) -> Self {
+        Self { index, domain }
+    }
+
+    /// Returns the index of the entry node of the subgraph representing the constraint.
+    pub fn node_index(&self) -> &NodeIndex {
+        &self.index
+    }
+
+    /// Returns the [ConstraintDomain] for this constraint, which specifies the rows against which
+    /// the constraint should be applied.
+    pub fn domain(&self) -> ConstraintDomain {
+        self.domain
+    }
+}
+
+/// The domain to which the constraint is applied, which is either the first or last row (for
+/// boundary constraints), every row (for validity constraints), or every frame (for transition
+/// constraints). When the constraint is applied to a frame the inner value specifies the size of
+/// the frame. For example, for a transition constraint that is applied against the current and next
+/// rows, the frame size will be 2.
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+pub enum ConstraintDomain {
+    FirstRow,          // for boundary constraints against the first row
+    LastRow,           // for boundary constraints against the last row
+    EveryRow,          // for validity constraints
+    EveryFrame(usize), // for transition constraints
+}
+
+impl ConstraintDomain {
+    /// Combines the two [ConstraintDomain]s into a single [ConstraintDomain] that represents the
+    /// maximum constraint domain. For example, if one domain is [ConstraintDomain::EveryFrame(2)]
+    /// and the other is [ConstraintDomain::EveryFrame(3)] then the result will be
+    /// [ConstraintDomain::EveryFrame(3)].
+    pub fn merge(&self, other: &ConstraintDomain) -> ConstraintDomain {
+        if self == other {
+            return *other;
+        }
+
+        match (self, other) {
+            (ConstraintDomain::EveryFrame(a), ConstraintDomain::EveryFrame(b)) => {
+                ConstraintDomain::EveryFrame(*a.max(b))
+            }
+            (ConstraintDomain::EveryFrame(a), _) => ConstraintDomain::EveryFrame(*a),
+            (_, ConstraintDomain::EveryFrame(b)) => ConstraintDomain::EveryFrame(*b),
+            // for any other pair of constraints which are not equal, the result of combining the
+            // domains is to apply the constraint at every row.
+            _ => ConstraintDomain::EveryRow,
+        }
+    }
+}
+
+impl From<usize> for ConstraintDomain {
+    /// Creates a [ConstraintDomain] from the specified row offset.
+    fn from(row_offset: usize) -> Self {
+        if row_offset == 0 {
+            ConstraintDomain::EveryRow
+        } else {
+            ConstraintDomain::EveryFrame(row_offset + 1)
+        }
+    }
+}

--- a/ir/src/symbol_table.rs
+++ b/ir/src/symbol_table.rs
@@ -8,10 +8,10 @@ use std::fmt::Display;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(super) enum IdentifierType {
-    /// an identifier for a constant, containing it's type and value
+    /// an identifier for a constant, containing its type and value
     Constant(ConstantType),
     /// an identifier for a trace column, containing trace column information with its trace
-    /// segment, it's size and it's offset.
+    /// segment, its size and its offset.
     TraceColumns(TraceColumns),
     /// an identifier for a public input, containing the size of the public input array
     PublicInput(usize),

--- a/parser/src/ast/boundary_constraints.rs
+++ b/parser/src/ast/boundary_constraints.rs
@@ -1,7 +1,7 @@
 use super::{Expression, NamedTraceAccess, Variable};
 use std::fmt::Display;
 
-// BOUNDARY CONSTRAINTS
+// BOUNDARY STATEMENTS
 // ================================================================================================
 
 #[derive(Debug, Eq, PartialEq)]

--- a/parser/src/ast/integrity_constraints.rs
+++ b/parser/src/ast/integrity_constraints.rs
@@ -1,6 +1,6 @@
 use super::{Expression, Variable};
 
-// INTEGRITY CONSTRAINTS
+// INTEGRITY STATEMENTS
 // ================================================================================================
 
 #[derive(Debug, Eq, PartialEq)]

--- a/parser/src/lexer/tests/boundary_constraints.rs
+++ b/parser/src/lexer/tests/boundary_constraints.rs
@@ -1,6 +1,6 @@
 use super::{expect_valid_tokenization, Token};
 
-// BOUNDARY CONSTRAINTS VALID TOKENIZATION
+// BOUNDARY STATEMENTS VALID TOKENIZATION
 // ================================================================================================
 
 #[test]

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -118,7 +118,7 @@ PeriodicColumn: PeriodicColumn = {
         PeriodicColumn::new(name, values),
 }
 
-// BOUNDARY CONSTRAINTS
+// BOUNDARY STATEMENTS
 // ================================================================================================
 
 BoundaryConstraints: Vec<BoundaryStmt> = {

--- a/parser/src/parser/tests/boundary_constraints.rs
+++ b/parser/src/parser/tests/boundary_constraints.rs
@@ -7,7 +7,7 @@ use crate::{
     error::{Error, ParseError},
 };
 
-// BOUNDARY CONSTRAINTS
+// BOUNDARY STATEMENTS
 // ================================================================================================
 
 #[test]

--- a/parser/src/parser/tests/integrity_constraints.rs
+++ b/parser/src/parser/tests/integrity_constraints.rs
@@ -7,7 +7,7 @@ use crate::{
     error::{Error, ParseError},
 };
 
-// INTEGRITY CONSTRAINTS
+// INTEGRITY STATEMENTS
 // ================================================================================================
 
 #[test]


### PR DESCRIPTION
This PR adds the `ConstraintDomain` struct and replaces `row_offset` with this struct as the first step for #106. A couple of other minor related refactor changes are included as well:

- moving some types into the graph or `integrity_stmts` module and making them private, since they're not needed elsewhere
- reordering `ExprDetails` to put `NodeIndex` first, since the other pieces of information are about where the constraint is applied, whereas this represents the actual constraint (its root), so it felt like a more appropriate ordering.