### PR TITLE
Allow expressions as exponents in exp expressions

### DIFF
--- a/air-script-core/src/expression.rs
+++ b/air-script-core/src/expression.rs
@@ -20,5 +20,5 @@ pub enum Expression {
     Add(Box<Expression>, Box<Expression>),
     Sub(Box<Expression>, Box<Expression>),
     Mul(Box<Expression>, Box<Expression>),
-    Exp(Box<Expression>, u64),
+    Exp(Box<Expression>, Box<Expression>),
 }

--- a/codegen/winterfell/src/air/boundary_constraints.rs
+++ b/codegen/winterfell/src/air/boundary_constraints.rs
@@ -167,7 +167,11 @@ impl Codegen for Expression {
                 )
             }
             Self::Exp(lhs, rhs) => {
-                format!("({}).exp({})", lhs.to_string(ir, is_aux_constraint), rhs)
+                if let Self::Const(rhs) = **rhs {
+                    format!("({}).exp({})", lhs.to_string(ir, is_aux_constraint), rhs)
+                } else {
+                    todo!()
+                }
             }
             _ => panic!("boundary constraint expressions cannot reference the trace"),
         }

--- a/ir/src/integrity_stmts/graph.rs
+++ b/ir/src/integrity_stmts/graph.rs
@@ -171,7 +171,12 @@ impl AlgebraicGraph {
                 let (lhs, trace_segment, domain) =
                     self.insert_expr(symbol_table, *lhs, variable_roots)?;
                 // add exponent subexpression.
-                let node_index = self.insert_op(Operation::Exp(lhs, rhs as usize));
+                let node_index = if let Expression::Const(rhs) = *rhs {
+                    self.insert_op(Operation::Exp(lhs, rhs as usize))
+                } else {
+                    todo!()
+                };
+
                 Ok((node_index, trace_segment, domain))
             }
         }
@@ -480,6 +485,7 @@ pub enum Operation {
     Mul(NodeIndex, NodeIndex),
     /// Exponentiation operation applied to the node with the specified index, using the provided
     /// value as the power.
+    /// TODO: Support non const exponents.
     Exp(NodeIndex, usize),
 }
 

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -173,14 +173,19 @@ BoundaryExpr: Expression = {
 }
 
 BoundaryFactor: Expression = {
-    <lexpr: BoundaryFactor> "*" <rexpr: BoundaryAtom> =>
+    <lexpr: BoundaryFactor> "*" <rexpr: BoundaryExponent> =>
         Expression::Mul(Box::new(lexpr), Box::new(rexpr)),
+    BoundaryExponent
+}
+
+BoundaryExponent: Expression = {
+    <lexpr: BoundaryExponent> "^" <rexpr: BoundaryAtom> =>
+        Expression::Exp(Box::new(lexpr), Box::new(rexpr)),
     BoundaryAtom
 }
 
 BoundaryAtom: Expression = {
     "(" <BoundaryExpr> ")",
-    <lexpr: BoundaryAtom> "^" <num: Num_u64> => Expression::Exp(Box::new(lexpr), num),
     "$rand" <idx: Index> => Expression::Rand(idx),
     <n: Num_u64> => Expression::Const(n),
     <ident: Identifier> => Expression::Elem(ident),
@@ -238,14 +243,19 @@ IntegrityExpr: Expression = {
 }
 
 IntegrityFactor: Expression = {
-    <lexpr: IntegrityFactor> "*" <rexpr: IntegrityAtom> =>
+    <lexpr: IntegrityFactor> "*" <rexpr: IntegrityExponent> =>
         Expression::Mul(Box::new(lexpr), Box::new(rexpr)),
+    IntegrityExponent
+}
+
+IntegrityExponent: Expression = {
+    <lexpr: IntegrityExponent> "^" <rexpr: IntegrityAtom> =>
+        Expression::Exp(Box::new(lexpr), Box::new(rexpr)),
     IntegrityAtom
 }
 
 IntegrityAtom: Expression = {
     "(" <IntegrityExpr> ")",
-    <lexpr: IntegrityAtom> "^" <num: Num_u64> => Expression::Exp(Box::new(lexpr), num),
     "$rand" <idx: Index> => Expression::Rand(idx),
     <col_access: IndexedTraceAccess> => Expression::IndexedTraceAccess(col_access),
     <n: Num_u64> => Expression::Const(n),

--- a/parser/src/parser/tests/boundary_constraints.rs
+++ b/parser/src/parser/tests/boundary_constraints.rs
@@ -162,7 +162,7 @@ fn boundary_constraint_with_variables() {
     let expected = Source(vec![SourceSection::BoundaryConstraints(vec![
         Variable(Variable::new(
             Identifier("a".to_string()),
-            VariableType::Scalar(Exp(Box::new(Const(2)), 2)),
+            VariableType::Scalar(Exp(Box::new(Const(2)), Box::new(Const(2)))),
         )),
         Variable(Variable::new(
             Identifier("b".to_string()),
@@ -182,7 +182,10 @@ fn boundary_constraint_with_variables() {
                         Box::new(Elem(Identifier("a".to_string()))),
                         Box::new(Const(1)),
                     ),
-                    Exp(Box::new(Elem(Identifier("a".to_string()))), 2),
+                    Exp(
+                        Box::new(Elem(Identifier("a".to_string()))),
+                        Box::new(Const(2)),
+                    ),
                 ],
                 vec![
                     VectorAccess(VectorAccess::new(Identifier("b".to_string()), 0)),

--- a/parser/src/parser/tests/integrity_constraints.rs
+++ b/parser/src/parser/tests/integrity_constraints.rs
@@ -147,7 +147,7 @@ fn integrity_constraint_with_variables() {
     let expected = Source(vec![SourceSection::IntegrityConstraints(vec![
         Variable(Variable::new(
             Identifier("a".to_string()),
-            VariableType::Scalar(Exp(Box::new(Const(2)), 2)),
+            VariableType::Scalar(Exp(Box::new(Const(2)), Box::new(Const(2)))),
         )),
         Variable(Variable::new(
             Identifier("b".to_string()),
@@ -167,7 +167,10 @@ fn integrity_constraint_with_variables() {
                         Box::new(Elem(Identifier("a".to_string()))),
                         Box::new(Const(1)),
                     ),
-                    Exp(Box::new(Elem(Identifier("a".to_string()))), 2),
+                    Exp(
+                        Box::new(Elem(Identifier("a".to_string()))),
+                        Box::new(Const(2)),
+                    ),
                 ],
                 vec![
                     VectorAccess(VectorAccess::new(Identifier("b".to_string()), 0)),


### PR DESCRIPTION
This PR adds support for expressions as exponents for `Exp` expressions at the parser level but doesn't yet handle them at the IR and codegen level. This is required to write some constraints more concisely.