### PR TITLE
Add additional checks for random values

### DIFF
--- a/ir/src/constraints/graph.rs
+++ b/ir/src/constraints/graph.rs
@@ -10,7 +10,7 @@ use super::{
 /// The offset of the "current" row during constraint evaluation.
 const CURRENT_ROW: usize = 0;
 /// The default segment against which a constraint is applied is the main trace segment.
-const DEFAULT_SEGMENT: TraceSegment = 0;
+pub const DEFAULT_SEGMENT: TraceSegment = 0;
 /// The auxiliary trace segment.
 const AUX_SEGMENT: TraceSegment = 1;
 

--- a/ir/src/helpers.rs
+++ b/ir/src/helpers.rs
@@ -2,29 +2,35 @@ use crate::error::SemanticError;
 
 /// Struct to help with validation of AIR source.
 pub(super) struct SourceValidator {
-    trace_columns_exists: bool,
+    main_trace_columns_exists: bool,
+    aux_trace_columns_exists: bool,
     public_inputs_exists: bool,
     boundary_constraints_exists: bool,
     integrity_constraints_exists: bool,
+    random_values_exists: bool,
 }
 
 impl SourceValidator {
     pub fn new() -> Self {
         SourceValidator {
-            trace_columns_exists: false,
+            main_trace_columns_exists: false,
+            aux_trace_columns_exists: false,
             public_inputs_exists: false,
             boundary_constraints_exists: false,
             integrity_constraints_exists: false,
+            random_values_exists: false,
         }
     }
 
     /// If the declaration exists, sets corresponding boolean flag to true.
     pub fn exists(&mut self, section: &str) {
         match section {
-            "trace_columns" => self.trace_columns_exists = true,
+            "main_trace_columns" => self.main_trace_columns_exists = true,
+            "aux_trace_columns" => self.aux_trace_columns_exists = true,
             "public_inputs" => self.public_inputs_exists = true,
             "boundary_constraints" => self.boundary_constraints_exists = true,
             "integrity_constraints" => self.integrity_constraints_exists = true,
+            "random_values" => self.random_values_exists = true,
             _ => unreachable!(),
         }
     }
@@ -32,7 +38,7 @@ impl SourceValidator {
     /// Returns a SemanticError if any of the required declarations are missing.
     pub fn check(&self) -> Result<(), SemanticError> {
         // make sure trace_columns are declared.
-        if !self.trace_columns_exists {
+        if !self.main_trace_columns_exists {
             return Err(SemanticError::MissingDeclaration(
                 "trace_columns section is missing".to_string(),
             ));
@@ -53,6 +59,13 @@ impl SourceValidator {
         if !self.integrity_constraints_exists {
             return Err(SemanticError::MissingDeclaration(
                 "integrity_constraints section is missing".to_string(),
+            ));
+        }
+        // make sure random_values are declared only if aux trace columns are declared
+        if !self.aux_trace_columns_exists && self.random_values_exists {
+            return Err(SemanticError::MissingDeclaration(
+                "random_values section requires aux_trace_columns section, which is missing"
+                    .to_string(),
             ));
         }
 

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -74,11 +74,12 @@ impl AirIR {
                 ast::SourceSection::Trace(columns) => {
                     // process & validate the main trace columns
                     symbol_table.insert_trace_columns(0, &columns.main_cols)?;
+                    validator.exists("main_trace_columns");
                     if !columns.aux_cols.is_empty() {
                         // process & validate the auxiliary trace columns
                         symbol_table.insert_trace_columns(1, &columns.aux_cols)?;
+                        validator.exists("aux_trace_columns");
                     }
-                    validator.exists("trace_columns");
                 }
                 ast::SourceSection::PublicInputs(inputs) => {
                     // process & validate the public inputs
@@ -91,6 +92,7 @@ impl AirIR {
                 }
                 ast::SourceSection::RandomValues(values) => {
                     symbol_table.insert_random_values(values)?;
+                    validator.exists("random_values");
                 }
                 _ => {}
             }

--- a/ir/src/tests/mod.rs
+++ b/ir/src/tests/mod.rs
@@ -500,6 +500,47 @@ fn error_random_values_out_of_bounds() {
 }
 
 #[test]
+fn err_random_values_without_aux_cols() {
+    let source = "
+    trace_columns:
+        main: [a, b[12]]
+    public_inputs:
+        stack_inputs: [16]
+    random_values:
+        rand: [16]
+    boundary_constraints:
+        enf a.first = 2
+        enf a.last = 1
+    integrity_constraints:
+        enf a' = a + 1";
+
+    let parsed = parse(source).expect("Parsing failed");
+    let result = AirIR::from_source(&parsed);
+    assert!(result.is_err());
+}
+
+#[test]
+fn err_random_values_in_bc_against_main_cols() {
+    let source = "
+    trace_columns:
+        main: [a, b[12]]
+        aux: [c, d]
+    public_inputs:
+        stack_inputs: [16]
+    random_values:
+        rand: [16]
+    boundary_constraints:
+        enf a.first = $rand[10] * 2
+        enf b[2].last = 1
+    integrity_constraints:
+        enf c' = $rand[3] + 1";
+
+    let parsed = parse(source).expect("Parsing failed");
+    let result = AirIR::from_source(&parsed);
+    assert!(result.is_err());
+}
+
+#[test]
 fn err_bc_invalid_vector_access() {
     let source = "
     const A = 123


### PR DESCRIPTION
Addressing #46.
Added checks: 
- For having random values without auxiliary columns
- For using random values against main columns in boundary constraints 