### PR TITLE
fix: restore public input support

### DIFF
--- a/air-script/tests/main.rs
+++ b/air-script/tests/main.rs
@@ -36,10 +36,7 @@ fn periodic_columns() {
     expected.assert_eq(&generated_air);
 }
 
-/// TODO: restore this test after public inputs are re-implemented for boundary constraints in the
-/// graph
 #[test]
-#[ignore]
 fn pub_inputs() {
     let generated_air = Test::new("tests/pub_inputs/pub_inputs.air".to_string())
         .transpile()

--- a/codegen/winterfell/src/air/graph.rs
+++ b/codegen/winterfell/src/air/graph.rs
@@ -80,6 +80,9 @@ impl Codegen for Operation {
             Operation::PeriodicColumn(col_idx, _) => {
                 format!("periodic_values[{col_idx}]")
             }
+            Operation::PublicInput(ident, idx) => {
+                format!("self.{ident}[{idx}]")
+            }
             Operation::RandomValue(idx) => {
                 format!("aux_rand_elements.get_segment_elements(0)[{idx}]")
             }

--- a/ir/src/tests/mod.rs
+++ b/ir/src/tests/mod.rs
@@ -40,20 +40,17 @@ fn boundary_constraints_with_constants() {
     assert!(result.is_ok());
 }
 
-/// This test is ignored because it is not yet supported.
-/// TODO: add public inputs to the constraint graph.
 #[test]
-#[ignore]
 fn boundary_constraints_with_public_inputs() {
     let source = "
     trace_columns:
         main: [clk]
     public_inputs:
         stack_inputs: [16]
-    integrity_constraints:
-        enf clk' = clk - 1
     boundary_constraints:
-        enf a.first = stack_inputs[0]^3";
+        enf clk.first = stack_inputs[0]^3
+    integrity_constraints:
+        enf clk' = clk - 1";
 
     let parsed = parse(source).expect("Parsing failed");
     let result = AirIR::from_source(&parsed);


### PR DESCRIPTION
This PR restores simple public input support for fixed-size arrays, which was removed when boundary constraints were migrated into the constraint graph in #126.