### PR TITLE
Allow access to vector in matrix variable

### DIFF
--- a/docs/src/description/variables.md
+++ b/docs/src/description/variables.md
@@ -44,8 +44,10 @@ Currently, it is not possible to:
     ```
     ...
     boundary_constraints:
-        let a = [1, 2]
-        let b = [a, [3, 4]]  <-- `b` consists of array `[3, 4]` and reference to array `a`
+        let a = [[1,2], [3,4]]  # <-- this is allowed
+        let b = [1, 2]
+        let c = [a[1], b]  # <-- this is allowed
+        let d = [b, [3, 4]]  # <-- this is not allowed, because `d` consists of array `[3, 4]` and reference to array `b`
         enf ...
     ...
     ```
@@ -59,9 +61,9 @@ Currently, it is not possible to:
         let a = [[1, 2], [3, 4]]
         let b = [5, 6]
         let c = 7
-        let d = [e for e in [8, c, b[0], a[0][1]]]  <-- source array is a plain array
-        let f = [g for g in a[1]]  <-- source is a matirx row
-        let h = [i for i in a[0][0..2]]  <-- source is a range in matrix row
+        let d = [e for e in [8, 9, 10]]  # <-- source array is an inlined vector
+        let f = [g for g in a[1]]  # <-- source is a matrix row
+        let h = [i for i in a[0][0..2]]  # <-- source is a range in matrix row
         enf ...
     ...
     ```

--- a/docs/src/description/variables.md
+++ b/docs/src/description/variables.md
@@ -45,11 +45,11 @@ Currently, it is not possible to:
     ...
     boundary_constraints:
         let a = [1, 2]
-        let b = [a, [3, 4]]  <-- b consists of array `[3, 4]` and reference to array `a`
+        let b = [a, [3, 4]]  <-- `b` consists of array `[3, 4]` and reference to array `a`
         enf ...
     ...
     ```
-2. Create variables with list comprehension for which the source array is a plain array, a matrix row, or a range in matrix row.
+2. Create variables with list comprehension for which the source array is a inlined vector, a matrix row, or a range in matrix row.
 
     Example: 
 

--- a/docs/src/description/variables.md
+++ b/docs/src/description/variables.md
@@ -34,6 +34,38 @@ integrity_constraints:
     enf a' = z[0][0] + z[0][1] + z[1][0] + z[1][1]
 ```
 
+### Syntax restriction for local variables
+Currently, it is not possible to:
+
+1. Create matrices containing both arrays and references to arrays.
+
+    Example:
+
+    ```
+    ...
+    boundary_constraints:
+        let a = [1, 2]
+        let b = [a, [3, 4]]  <-- b consists of array `[3, 4]` and reference to array `a`
+        enf ...
+    ...
+    ```
+2. Create variables with list comprehension for which the source array is a plain array, a matrix row, or a range in matrix row.
+
+    Example: 
+
+    ```
+    ...
+    integrity_constraints:
+        let a = [[1, 2], [3, 4]]
+        let b = [5, 6]
+        let c = 7
+        let d = [e for e in [8, c, b[0], a[0][1]]]  <-- source array is a plain array
+        let f = [g for g in a[1]]  <-- source is a matirx row
+        let h = [i for i in a[0][0..2]]  <-- source is a range in matrix row
+        enf ...
+    ...
+    ```
+
 ## Built-in variables
 
 Built-in variables are identified by the starting character `$`. There are two built-in variables:

--- a/ir/src/symbol_table.rs
+++ b/ir/src/symbol_table.rs
@@ -311,11 +311,11 @@ impl SymbolTable {
                 Ok(symbol_type)
             }
             IdentifierType::Variable(_, variable) => match variable.value() {
+                VariableType::Scalar(_) => Ok(symbol_type),
                 VariableType::Vector(vector) => {
                     validate_vector_access(vector_access, vector.len())?;
                     Ok(symbol_type)
                 }
-                VariableType::Scalar(_) => Ok(symbol_type),
                 _ => Err(SemanticError::invalid_vector_access(
                     vector_access,
                     symbol_type,
@@ -367,12 +367,12 @@ impl SymbolTable {
                 Ok(symbol_type)
             }
             IdentifierType::Variable(_, variable) => match variable.value() {
+                VariableType::Scalar(_) => Ok(symbol_type),
+                VariableType::Vector(_) => Ok(symbol_type),
                 VariableType::Matrix(matrix) => {
                     validate_matrix_access(matrix_access, matrix.len(), matrix[0].len())?;
                     Ok(symbol_type)
                 }
-                VariableType::Vector(_) => Ok(symbol_type),
-                VariableType::Scalar(_) => Ok(symbol_type),
                 _ => Err(SemanticError::invalid_matrix_access(
                     matrix_access,
                     symbol_type,

--- a/ir/src/symbol_table.rs
+++ b/ir/src/symbol_table.rs
@@ -310,17 +310,17 @@ impl SymbolTable {
                 validate_vector_access(vector_access, vector.len())?;
                 Ok(symbol_type)
             }
-            IdentifierType::Variable(_, variable) => {
-                if let VariableType::Vector(vector) = variable.value() {
+            IdentifierType::Variable(_, variable) => match variable.value() {
+                VariableType::Vector(vector) => {
                     validate_vector_access(vector_access, vector.len())?;
                     Ok(symbol_type)
-                } else {
-                    Err(SemanticError::invalid_vector_access(
-                        vector_access,
-                        symbol_type,
-                    ))
                 }
-            }
+                VariableType::Scalar(_) => Ok(symbol_type),
+                _ => Err(SemanticError::invalid_vector_access(
+                    vector_access,
+                    symbol_type,
+                )),
+            },
             IdentifierType::TraceColumns(trace_columns) => {
                 if vector_access.idx() < trace_columns.size() {
                     Ok(symbol_type)
@@ -366,17 +366,18 @@ impl SymbolTable {
                 validate_matrix_access(matrix_access, matrix.len(), matrix[0].len())?;
                 Ok(symbol_type)
             }
-            IdentifierType::Variable(_, variable) => {
-                if let VariableType::Matrix(matrix) = variable.value() {
+            IdentifierType::Variable(_, variable) => match variable.value() {
+                VariableType::Matrix(matrix) => {
                     validate_matrix_access(matrix_access, matrix.len(), matrix[0].len())?;
                     Ok(symbol_type)
-                } else {
-                    Err(SemanticError::invalid_matrix_access(
-                        matrix_access,
-                        symbol_type,
-                    ))
                 }
-            }
+                VariableType::Vector(_) => Ok(symbol_type),
+                VariableType::Scalar(_) => Ok(symbol_type),
+                _ => Err(SemanticError::invalid_matrix_access(
+                    matrix_access,
+                    symbol_type,
+                )),
+            },
             _ => Err(SemanticError::invalid_matrix_access(
                 matrix_access,
                 symbol_type,

--- a/ir/src/symbol_table.rs
+++ b/ir/src/symbol_table.rs
@@ -367,8 +367,7 @@ impl SymbolTable {
                 Ok(symbol_type)
             }
             IdentifierType::Variable(_, variable) => match variable.value() {
-                VariableType::Scalar(_) => Ok(symbol_type),
-                VariableType::Vector(_) => Ok(symbol_type),
+                VariableType::Scalar(_) | VariableType::Vector(_) => Ok(symbol_type),
                 VariableType::Matrix(matrix) => {
                     validate_matrix_access(matrix_access, matrix.len(), matrix[0].len())?;
                     Ok(symbol_type)

--- a/ir/src/tests/variables.rs
+++ b/ir/src/tests/variables.rs
@@ -122,6 +122,30 @@ fn ic_with_variables() {
 }
 
 #[test]
+fn ic_variables_access_vector_from_matrix() {
+    let source = "
+    trace_columns:
+        main: [clk]
+    public_inputs:
+        stack_inputs: [16]
+    integrity_constraints:
+        let a = [[1, 2], [3, 4]]
+        let b = a[1]
+        let c = b
+        let d = [a[0], a[1], b]
+        let e = d
+        enf clk' = c[0] + e[2][0] + e[0][1]
+    boundary_constraints:
+        enf clk.first = 7
+        enf clk.last = 8";
+
+    let parsed = parse(source).expect("Parsing failed");
+
+    let result = AirIR::new(&parsed);
+    assert!(result.is_ok());
+}
+
+#[test]
 fn err_bc_variable_access_before_declaration() {
     let source = "
     const A = [[2, 3], [1, 0]]

--- a/ir/src/tests/variables.rs
+++ b/ir/src/tests/variables.rs
@@ -146,8 +146,9 @@ fn ic_variables_access_vector_from_matrix() {
 }
 
 #[test]
-fn err_ic_variables_access_vector_from_matrix() {
-    // We can not parse matrix variable that consists of inlined vector and scalar elements
+fn err_ic_variables_vector_with_inlined_vector() {
+    // We can not parse matrix variable that consists of inlined vector and scalar elements.
+    // Variable `d` is parsed as a vector and can not contain inlined vectors.
     let source = "
     trace_columns:
         main: [clk]
@@ -157,12 +158,29 @@ fn err_ic_variables_access_vector_from_matrix() {
         enf clk.first = 7
         enf clk.last = 8
     integrity_constraints:
-        let a = [[1, 2, 3, 4], [5, 6, 7, 8]]
-        let b = [9, 10]
-        let c = 12
-        let c = [a[0], [11, c, b[1], a[1][0]]]
-        d = [[11, c, b[1], a[1][0]], a[0]]
-        enf clk' = c[0][0] + d[1][1]";
+        let a = [[1, 2], [3, 4]]
+        let d = [a[0], [3, 4]]
+        enf clk' = d[0][0]";
+
+    parse(source).expect_err("Parsing failed");
+}
+
+#[test]
+fn err_ic_variables_matrix_with_vector_reference() {
+    // We can not parse matrix variable that consists of inlined vector and scalar elements
+    // Variable `d` is parsed as a matrix and can not contain references to vectors.
+    let source = "
+    trace_columns:
+        main: [clk]
+    public_inputs:
+        stack_inputs: [16]
+    boundary_constraints:
+        enf clk.first = 7
+        enf clk.last = 8
+    integrity_constraints:
+        let a = [[1, 2], [3, 4]]
+        let d = [[3, 4], a[0]]
+        enf clk' = d[0][0]";
 
     parse(source).expect_err("Parsing failed");
 }

--- a/ir/src/tests/variables.rs
+++ b/ir/src/tests/variables.rs
@@ -145,9 +145,9 @@ fn ic_variables_access_vector_from_matrix() {
     assert!(result.is_ok());
 }
 
-// We can not parse matrix variable that consists of array and non-array elements
 #[test]
 fn err_ic_variables_access_vector_from_matrix() {
+    // We can not parse matrix variable that consists of inlined vector and scalar elements
     let source = "
     trace_columns:
         main: [clk]

--- a/ir/src/tests/variables.rs
+++ b/ir/src/tests/variables.rs
@@ -128,21 +128,43 @@ fn ic_variables_access_vector_from_matrix() {
         main: [clk]
     public_inputs:
         stack_inputs: [16]
+    boundary_constraints:
+        enf clk.first = 7
+        enf clk.last = 8
     integrity_constraints:
         let a = [[1, 2], [3, 4]]
         let b = a[1]
         let c = b
         let d = [a[0], a[1], b]
         let e = d
-        enf clk' = c[0] + e[2][0] + e[0][1]
-    boundary_constraints:
-        enf clk.first = 7
-        enf clk.last = 8";
+        enf clk' = c[0] + e[2][0] + e[0][1]";
 
     let parsed = parse(source).expect("Parsing failed");
 
     let result = AirIR::new(&parsed);
     assert!(result.is_ok());
+}
+
+// We can not parse matrix variable that consists of array and non-array elements
+#[test]
+fn err_ic_variables_access_vector_from_matrix() {
+    let source = "
+    trace_columns:
+        main: [clk]
+    public_inputs:
+        stack_inputs: [16]
+    boundary_constraints:
+        enf clk.first = 7
+        enf clk.last = 8
+    integrity_constraints:
+        let a = [[1, 2, 3, 4], [5, 6, 7, 8]]
+        let b = [9, 10]
+        let c = 12
+        let c = [a[0], [11, c, b[1], a[1][0]]]
+        d = [[11, c, b[1], a[1][0]], a[0]]
+        enf clk' = c[0][0] + d[1][1]";
+
+    parse(source).expect_err("Parsing failed");
 }
 
 #[test]

--- a/parser/src/parser/tests/variables.rs
+++ b/parser/src/parser/tests/variables.rs
@@ -40,3 +40,13 @@ fn err_invalid_matrix_element() {
     let a = [[1, 2], [3, [4, 5]]]";
     build_parse_test!(source).expect_unrecognized_token();
 }
+
+#[test]
+fn err_matrix_variable_from_vector_and_reference() {
+    let source = "integrity_constraints:
+    let a = [[1, 2], [3, 4]]
+    let b = [5, 6]
+    let c = [b, [7, 8]]
+    let d = [[7, 8], a[0]]";
+    build_parse_test!(source).expect_unrecognized_token();
+}


### PR DESCRIPTION
Addressing: #132 
This PR makes possible to:
- create vector variables as row of the matrix variable
- create matrix variables as vector of matrix rows and vector variables

This PR fixes all bugs which do not require parsing modification.

Cases that were fixed:
1. Creating vector variable as row of the matrix and copying this variable:
```
integrity_constraints:
    let a = [[1, 2], [3, 4]]
    let b = a[0] 
    let c = b
    enf clk' = b[1] + c[0]
```
2. Creating matrix variable as vector of matrix rows and vector variables, and copying this variable:
```
integrity_constraints:
    let a = [[1, 2], [3, 4]]
    let b = a[0] 
    let c = [a[1], b]
    let d = c
    enf clk' = d[0][0] + c[1][1]
```