### PR TITLE
fix: fix codegen for aux transition constraints that use main cols

### DIFF
--- a/air-script/tests/aux_trace/aux_trace.rs
+++ b/air-script/tests/aux_trace/aux_trace.rs
@@ -78,20 +78,22 @@ impl Air for AuxiliaryAir {
     }
 
     fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
-        let current = frame.current();
-        let next = frame.next();
-        result[0] = next[0] - (current[1] + current[2]);
-        result[1] = next[1] - (current[2] + next[0]);
-        result[2] = current[2] - (current[0] + current[1]);
+        let main_current = frame.current();
+        let main_next = frame.next();
+        result[0] = main_next[0] - (main_current[1] + main_current[2]);
+        result[1] = main_next[1] - (main_current[2] + main_next[0]);
+        result[2] = main_current[2] - (main_current[0] + main_current[1]);
     }
 
     fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])
     where F: FieldElement<BaseField = Felt>,
           E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
     {
-        let current = aux_frame.current();
-        let next = aux_frame.next();
-        result[0] = next[0] - ((current[0]) * (current[0] + aux_rand_elements.get_segment_elements(0)[0] + current[1] + aux_rand_elements.get_segment_elements(0)[1]));
-        result[1] = current[1] - ((next[1]) * (current[2] + aux_rand_elements.get_segment_elements(0)[0]));
+        let main_current = main_frame.current();
+        let main_next = main_frame.next();
+        let aux_current = aux_frame.current();
+        let aux_next = aux_frame.next();
+        result[0] = aux_next[0] - ((aux_current[0]) * (main_current[0] + aux_rand_elements.get_segment_elements(0)[0] + main_current[1] + aux_rand_elements.get_segment_elements(0)[1]));
+        result[1] = aux_current[1] - ((aux_next[1]) * (main_current[2] + aux_rand_elements.get_segment_elements(0)[0]));
     }
 }

--- a/air-script/tests/binary/binary.rs
+++ b/air-script/tests/binary/binary.rs
@@ -73,17 +73,19 @@ impl Air for BinaryAir {
     }
 
     fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
-        let current = frame.current();
-        let next = frame.next();
-        result[0] = (current[0]).exp(E::PositiveInteger::from(2_u64)) - (current[0]) - (E::from(0_u64));
-        result[1] = (current[1]).exp(E::PositiveInteger::from(2_u64)) - (current[1]) - (E::from(0_u64));
+        let main_current = frame.current();
+        let main_next = frame.next();
+        result[0] = (main_current[0]).exp(E::PositiveInteger::from(2_u64)) - (main_current[0]) - (E::from(0_u64));
+        result[1] = (main_current[1]).exp(E::PositiveInteger::from(2_u64)) - (main_current[1]) - (E::from(0_u64));
     }
 
     fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])
     where F: FieldElement<BaseField = Felt>,
           E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
     {
-        let current = aux_frame.current();
-        let next = aux_frame.next();
+        let main_current = main_frame.current();
+        let main_next = main_frame.next();
+        let aux_current = aux_frame.current();
+        let aux_next = aux_frame.next();
     }
 }

--- a/air-script/tests/bitwise/bitwise.rs
+++ b/air-script/tests/bitwise/bitwise.rs
@@ -73,32 +73,34 @@ impl Air for BitwiseAir {
     }
 
     fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
-        let current = frame.current();
-        let next = frame.next();
-        result[0] = (current[0]).exp(E::PositiveInteger::from(2_u64)) - (current[0]) - (E::from(0_u64));
-        result[1] = (periodic_values[1]) * (next[0] - (current[0])) - (E::from(0_u64));
-        result[2] = (current[3]).exp(E::PositiveInteger::from(2_u64)) - (current[3]) - (E::from(0_u64));
-        result[3] = (current[4]).exp(E::PositiveInteger::from(2_u64)) - (current[4]) - (E::from(0_u64));
-        result[4] = (current[5]).exp(E::PositiveInteger::from(2_u64)) - (current[5]) - (E::from(0_u64));
-        result[5] = (current[6]).exp(E::PositiveInteger::from(2_u64)) - (current[6]) - (E::from(0_u64));
-        result[6] = (current[7]).exp(E::PositiveInteger::from(2_u64)) - (current[7]) - (E::from(0_u64));
-        result[7] = (current[8]).exp(E::PositiveInteger::from(2_u64)) - (current[8]) - (E::from(0_u64));
-        result[8] = (current[9]).exp(E::PositiveInteger::from(2_u64)) - (current[9]) - (E::from(0_u64));
-        result[9] = (current[10]).exp(E::PositiveInteger::from(2_u64)) - (current[10]) - (E::from(0_u64));
-        result[10] = (periodic_values[0]) * (current[1] - (((E::from(2_u64)).exp(E::PositiveInteger::from(0_u64))) * (current[3]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(1_u64))) * (current[4]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(2_u64))) * (current[5]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(3_u64))) * (current[6]))) - (E::from(0_u64));
-        result[11] = (periodic_values[0]) * (current[2] - (((E::from(2_u64)).exp(E::PositiveInteger::from(0_u64))) * (current[7]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(1_u64))) * (current[8]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(2_u64))) * (current[9]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(3_u64))) * (current[10]))) - (E::from(0_u64));
-        result[12] = (periodic_values[1]) * (next[1] - ((current[1]) * (E::from(16_u64)) + ((E::from(2_u64)).exp(E::PositiveInteger::from(0_u64))) * (current[3]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(1_u64))) * (current[4]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(2_u64))) * (current[5]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(3_u64))) * (current[6]))) - (E::from(0_u64));
-        result[13] = (periodic_values[1]) * (next[2] - ((current[2]) * (E::from(16_u64)) + ((E::from(2_u64)).exp(E::PositiveInteger::from(0_u64))) * (current[7]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(1_u64))) * (current[8]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(2_u64))) * (current[9]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(3_u64))) * (current[10]))) - (E::from(0_u64));
-        result[14] = (periodic_values[0]) * (current[11]) - (E::from(0_u64));
-        result[15] = (periodic_values[1]) * (current[12] - (next[11])) - (E::from(0_u64));
-        result[16] = (E::from(1_u64) - (current[0])) * (current[12] - ((current[11]) * (E::from(16_u64)) + (((E::from(2_u64)).exp(E::PositiveInteger::from(0_u64))) * (current[3])) * (current[7]) + (((E::from(2_u64)).exp(E::PositiveInteger::from(1_u64))) * (current[4])) * (current[8]) + (((E::from(2_u64)).exp(E::PositiveInteger::from(2_u64))) * (current[5])) * (current[9]) + (((E::from(2_u64)).exp(E::PositiveInteger::from(3_u64))) * (current[6])) * (current[10]))) + (current[0]) * (current[12] - ((current[11]) * (E::from(16_u64)) + ((E::from(2_u64)).exp(E::PositiveInteger::from(0_u64))) * (current[3] + current[7] - (((E::from(2_u64)) * (current[3])) * (current[7]))) + ((E::from(2_u64)).exp(E::PositiveInteger::from(1_u64))) * (current[4] + current[8] - (((E::from(2_u64)) * (current[4])) * (current[8]))) + ((E::from(2_u64)).exp(E::PositiveInteger::from(2_u64))) * (current[5] + current[9] - (((E::from(2_u64)) * (current[5])) * (current[9]))) + ((E::from(2_u64)).exp(E::PositiveInteger::from(3_u64))) * (current[6] + current[10] - (((E::from(2_u64)) * (current[6])) * (current[10]))))) - (E::from(0_u64));
+        let main_current = frame.current();
+        let main_next = frame.next();
+        result[0] = (main_current[0]).exp(E::PositiveInteger::from(2_u64)) - (main_current[0]) - (E::from(0_u64));
+        result[1] = (periodic_values[1]) * (main_next[0] - (main_current[0])) - (E::from(0_u64));
+        result[2] = (main_current[3]).exp(E::PositiveInteger::from(2_u64)) - (main_current[3]) - (E::from(0_u64));
+        result[3] = (main_current[4]).exp(E::PositiveInteger::from(2_u64)) - (main_current[4]) - (E::from(0_u64));
+        result[4] = (main_current[5]).exp(E::PositiveInteger::from(2_u64)) - (main_current[5]) - (E::from(0_u64));
+        result[5] = (main_current[6]).exp(E::PositiveInteger::from(2_u64)) - (main_current[6]) - (E::from(0_u64));
+        result[6] = (main_current[7]).exp(E::PositiveInteger::from(2_u64)) - (main_current[7]) - (E::from(0_u64));
+        result[7] = (main_current[8]).exp(E::PositiveInteger::from(2_u64)) - (main_current[8]) - (E::from(0_u64));
+        result[8] = (main_current[9]).exp(E::PositiveInteger::from(2_u64)) - (main_current[9]) - (E::from(0_u64));
+        result[9] = (main_current[10]).exp(E::PositiveInteger::from(2_u64)) - (main_current[10]) - (E::from(0_u64));
+        result[10] = (periodic_values[0]) * (main_current[1] - (((E::from(2_u64)).exp(E::PositiveInteger::from(0_u64))) * (main_current[3]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(1_u64))) * (main_current[4]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(2_u64))) * (main_current[5]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(3_u64))) * (main_current[6]))) - (E::from(0_u64));
+        result[11] = (periodic_values[0]) * (main_current[2] - (((E::from(2_u64)).exp(E::PositiveInteger::from(0_u64))) * (main_current[7]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(1_u64))) * (main_current[8]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(2_u64))) * (main_current[9]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(3_u64))) * (main_current[10]))) - (E::from(0_u64));
+        result[12] = (periodic_values[1]) * (main_next[1] - ((main_current[1]) * (E::from(16_u64)) + ((E::from(2_u64)).exp(E::PositiveInteger::from(0_u64))) * (main_current[3]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(1_u64))) * (main_current[4]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(2_u64))) * (main_current[5]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(3_u64))) * (main_current[6]))) - (E::from(0_u64));
+        result[13] = (periodic_values[1]) * (main_next[2] - ((main_current[2]) * (E::from(16_u64)) + ((E::from(2_u64)).exp(E::PositiveInteger::from(0_u64))) * (main_current[7]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(1_u64))) * (main_current[8]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(2_u64))) * (main_current[9]) + ((E::from(2_u64)).exp(E::PositiveInteger::from(3_u64))) * (main_current[10]))) - (E::from(0_u64));
+        result[14] = (periodic_values[0]) * (main_current[11]) - (E::from(0_u64));
+        result[15] = (periodic_values[1]) * (main_current[12] - (main_next[11])) - (E::from(0_u64));
+        result[16] = (E::from(1_u64) - (main_current[0])) * (main_current[12] - ((main_current[11]) * (E::from(16_u64)) + (((E::from(2_u64)).exp(E::PositiveInteger::from(0_u64))) * (main_current[3])) * (main_current[7]) + (((E::from(2_u64)).exp(E::PositiveInteger::from(1_u64))) * (main_current[4])) * (main_current[8]) + (((E::from(2_u64)).exp(E::PositiveInteger::from(2_u64))) * (main_current[5])) * (main_current[9]) + (((E::from(2_u64)).exp(E::PositiveInteger::from(3_u64))) * (main_current[6])) * (main_current[10]))) + (main_current[0]) * (main_current[12] - ((main_current[11]) * (E::from(16_u64)) + ((E::from(2_u64)).exp(E::PositiveInteger::from(0_u64))) * (main_current[3] + main_current[7] - (((E::from(2_u64)) * (main_current[3])) * (main_current[7]))) + ((E::from(2_u64)).exp(E::PositiveInteger::from(1_u64))) * (main_current[4] + main_current[8] - (((E::from(2_u64)) * (main_current[4])) * (main_current[8]))) + ((E::from(2_u64)).exp(E::PositiveInteger::from(2_u64))) * (main_current[5] + main_current[9] - (((E::from(2_u64)) * (main_current[5])) * (main_current[9]))) + ((E::from(2_u64)).exp(E::PositiveInteger::from(3_u64))) * (main_current[6] + main_current[10] - (((E::from(2_u64)) * (main_current[6])) * (main_current[10]))))) - (E::from(0_u64));
     }
 
     fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])
     where F: FieldElement<BaseField = Felt>,
           E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
     {
-        let current = aux_frame.current();
-        let next = aux_frame.next();
+        let main_current = main_frame.current();
+        let main_next = main_frame.next();
+        let aux_current = aux_frame.current();
+        let aux_next = aux_frame.next();
     }
 }

--- a/air-script/tests/constants/constants.rs
+++ b/air-script/tests/constants/constants.rs
@@ -91,20 +91,22 @@ impl Air for ConstantsAir {
     }
 
     fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
-        let current = frame.current();
-        let next = frame.next();
-        result[0] = next[0] - (current[0] + E::from(A));
-        result[1] = next[1] - ((E::from(B[0])) * (current[1]));
-        result[2] = next[2] - ((E::from(C[0][0]) + E::from(B[0])) * (current[2]));
+        let main_current = frame.current();
+        let main_next = frame.next();
+        result[0] = main_next[0] - (main_current[0] + E::from(A));
+        result[1] = main_next[1] - ((E::from(B[0])) * (main_current[1]));
+        result[2] = main_next[2] - ((E::from(C[0][0]) + E::from(B[0])) * (main_current[2]));
     }
 
     fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])
     where F: FieldElement<BaseField = Felt>,
           E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
     {
-        let current = aux_frame.current();
-        let next = aux_frame.next();
-        result[0] = next[0] - (current[0] + E::from(A) + (E::from(B[0])) * (E::from(C[0][1])));
-        result[1] = current[0] - (E::from(A) + (E::from(B[1])) * (E::from(C[1][1])));
+        let main_current = main_frame.current();
+        let main_next = main_frame.next();
+        let aux_current = aux_frame.current();
+        let aux_next = aux_frame.next();
+        result[0] = aux_next[0] - (aux_current[0] + E::from(A) + (E::from(B[0])) * (E::from(C[0][1])));
+        result[1] = aux_current[0] - (E::from(A) + (E::from(B[1])) * (E::from(C[1][1])));
     }
 }

--- a/air-script/tests/indexed_trace_access/indexed_trace_access.rs
+++ b/air-script/tests/indexed_trace_access/indexed_trace_access.rs
@@ -73,17 +73,19 @@ impl Air for IndexedTraceAccessAir {
     }
 
     fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
-        let current = frame.current();
-        let next = frame.next();
-        result[0] = next[0] - (current[1] + E::from(1_u64));
+        let main_current = frame.current();
+        let main_next = frame.next();
+        result[0] = main_next[0] - (main_current[1] + E::from(1_u64));
     }
 
     fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])
     where F: FieldElement<BaseField = Felt>,
           E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
     {
-        let current = aux_frame.current();
-        let next = aux_frame.next();
-        result[0] = next[0] - (current[1] + E::from(1_u64));
+        let main_current = main_frame.current();
+        let main_next = main_frame.next();
+        let aux_current = aux_frame.current();
+        let aux_next = aux_frame.next();
+        result[0] = aux_next[0] - (aux_current[1] + E::from(1_u64));
     }
 }

--- a/air-script/tests/periodic_columns/periodic_columns.rs
+++ b/air-script/tests/periodic_columns/periodic_columns.rs
@@ -73,17 +73,19 @@ impl Air for PeriodicColumnsAir {
     }
 
     fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
-        let current = frame.current();
-        let next = frame.next();
-        result[0] = (periodic_values[0]) * (current[1] + current[2]) - (E::from(0_u64));
-        result[1] = (periodic_values[1]) * (next[0] - (current[0])) - (E::from(0_u64));
+        let main_current = frame.current();
+        let main_next = frame.next();
+        result[0] = (periodic_values[0]) * (main_current[1] + main_current[2]) - (E::from(0_u64));
+        result[1] = (periodic_values[1]) * (main_next[0] - (main_current[0])) - (E::from(0_u64));
     }
 
     fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])
     where F: FieldElement<BaseField = Felt>,
           E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
     {
-        let current = aux_frame.current();
-        let next = aux_frame.next();
+        let main_current = main_frame.current();
+        let main_next = main_frame.next();
+        let aux_current = aux_frame.current();
+        let aux_next = aux_frame.next();
     }
 }

--- a/air-script/tests/pub_inputs/pub_inputs.rs
+++ b/air-script/tests/pub_inputs/pub_inputs.rs
@@ -89,16 +89,18 @@ impl Air for PubInputsAir {
     }
 
     fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
-        let current = frame.current();
-        let next = frame.next();
-        result[0] = next[0] - (current[1] + current[2]);
+        let main_current = frame.current();
+        let main_next = frame.next();
+        result[0] = main_next[0] - (main_current[1] + main_current[2]);
     }
 
     fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])
     where F: FieldElement<BaseField = Felt>,
           E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
     {
-        let current = aux_frame.current();
-        let next = aux_frame.next();
+        let main_current = main_frame.current();
+        let main_next = main_frame.next();
+        let aux_current = aux_frame.current();
+        let aux_next = aux_frame.next();
     }
 }

--- a/air-script/tests/random_values/random_values.rs
+++ b/air-script/tests/random_values/random_values.rs
@@ -74,16 +74,18 @@ impl Air for RandomValuesAir {
     }
 
     fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
-        let current = frame.current();
-        let next = frame.next();
+        let main_current = frame.current();
+        let main_next = frame.next();
     }
 
     fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])
     where F: FieldElement<BaseField = Felt>,
           E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
     {
-        let current = aux_frame.current();
-        let next = aux_frame.next();
-        result[0] = next[0] - (aux_rand_elements.get_segment_elements(0)[15] - (aux_rand_elements.get_segment_elements(0)[0]) + aux_rand_elements.get_segment_elements(0)[3]);
+        let main_current = main_frame.current();
+        let main_next = main_frame.next();
+        let aux_current = aux_frame.current();
+        let aux_next = aux_frame.next();
+        result[0] = aux_next[0] - (aux_rand_elements.get_segment_elements(0)[15] - (aux_rand_elements.get_segment_elements(0)[0]) + aux_rand_elements.get_segment_elements(0)[3]);
     }
 }

--- a/air-script/tests/system/system.rs
+++ b/air-script/tests/system/system.rs
@@ -73,16 +73,18 @@ impl Air for SystemAir {
     }
 
     fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
-        let current = frame.current();
-        let next = frame.next();
-        result[0] = next[0] - (current[0] + E::from(1_u64));
+        let main_current = frame.current();
+        let main_next = frame.next();
+        result[0] = main_next[0] - (main_current[0] + E::from(1_u64));
     }
 
     fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])
     where F: FieldElement<BaseField = Felt>,
           E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
     {
-        let current = aux_frame.current();
-        let next = aux_frame.next();
+        let main_current = main_frame.current();
+        let main_next = main_frame.next();
+        let aux_current = aux_frame.current();
+        let aux_next = aux_frame.next();
     }
 }

--- a/air-script/tests/trace_col_groups/trace_col_groups.rs
+++ b/air-script/tests/trace_col_groups/trace_col_groups.rs
@@ -73,17 +73,19 @@ impl Air for TraceColGroupAir {
     }
 
     fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
-        let current = frame.current();
-        let next = frame.next();
-        result[0] = next[2] - (current[2] + E::from(1_u64));
-        result[1] = next[1] - (current[1] - (E::from(1_u64)));
+        let main_current = frame.current();
+        let main_next = frame.next();
+        result[0] = main_next[2] - (main_current[2] + E::from(1_u64));
+        result[1] = main_next[1] - (main_current[1] - (E::from(1_u64)));
     }
 
     fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])
     where F: FieldElement<BaseField = Felt>,
           E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
     {
-        let current = aux_frame.current();
-        let next = aux_frame.next();
+        let main_current = main_frame.current();
+        let main_next = main_frame.next();
+        let aux_current = aux_frame.current();
+        let aux_next = aux_frame.next();
     }
 }

--- a/air-script/tests/variables/variables.rs
+++ b/air-script/tests/variables/variables.rs
@@ -77,20 +77,22 @@ impl Air for VariablesAir {
     }
 
     fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
-        let current = frame.current();
-        let next = frame.next();
-        result[0] = (current[0]).exp(E::PositiveInteger::from(2_u64)) - (current[0]);
-        result[1] = (periodic_values[0]) * (next[0] - (current[0])) - (E::from(0_u64));
-        result[2] = (E::from(1_u64) - (current[0])) * (current[3] - (current[1]) + current[2]) - ((E::from(2_u64)) * (E::from(3_u64)) - (current[0]));
-        result[3] = (current[0]) * (current[3] - ((current[1]) * (current[2]))) - (next[0] - (E::from(3_u64)) - (E::from(4_u64) - (E::from(2_u64))));
+        let main_current = frame.current();
+        let main_next = frame.next();
+        result[0] = (main_current[0]).exp(E::PositiveInteger::from(2_u64)) - (main_current[0]);
+        result[1] = (periodic_values[0]) * (main_next[0] - (main_current[0])) - (E::from(0_u64));
+        result[2] = (E::from(1_u64) - (main_current[0])) * (main_current[3] - (main_current[1]) + main_current[2]) - ((E::from(2_u64)) * (E::from(3_u64)) - (main_current[0]));
+        result[3] = (main_current[0]) * (main_current[3] - ((main_current[1]) * (main_current[2]))) - (main_next[0] - (E::from(3_u64)) - (E::from(4_u64) - (E::from(2_u64))));
     }
 
     fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])
     where F: FieldElement<BaseField = Felt>,
           E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
     {
-        let current = aux_frame.current();
-        let next = aux_frame.next();
-        result[0] = next[0] - ((current[0]) * (current[3] + aux_rand_elements.get_segment_elements(0)[0]));
+        let main_current = main_frame.current();
+        let main_next = main_frame.next();
+        let aux_current = aux_frame.current();
+        let aux_next = aux_frame.next();
+        result[0] = aux_next[0] - ((aux_current[0]) * (main_current[3] + aux_rand_elements.get_segment_elements(0)[0]));
     }
 }

--- a/codegen/winterfell/src/air/transition_constraints.rs
+++ b/codegen/winterfell/src/air/transition_constraints.rs
@@ -16,8 +16,8 @@ pub(super) fn add_fn_evaluate_transition(impl_ref: &mut Impl, ir: &AirIR) {
         .arg("result", "&mut [E]");
 
     // declare current and next trace row arrays.
-    evaluate_transition.line("let current = frame.current();");
-    evaluate_transition.line("let next = frame.next();");
+    evaluate_transition.line("let main_current = frame.current();");
+    evaluate_transition.line("let main_next = frame.next();");
 
     // output the constraints.
     add_constraints(evaluate_transition, ir, 0);
@@ -40,8 +40,10 @@ pub(super) fn add_fn_evaluate_aux_transition(impl_ref: &mut Impl, ir: &AirIR) {
         .bound("E", "FieldElement<BaseField = Felt> + ExtensionOf<F>");
 
     // declare current and next trace row arrays.
-    evaluate_aux_transition.line("let current = aux_frame.current();");
-    evaluate_aux_transition.line("let next = aux_frame.next();");
+    evaluate_aux_transition.line("let main_current = main_frame.current();");
+    evaluate_aux_transition.line("let main_next = main_frame.next();");
+    evaluate_aux_transition.line("let aux_current = aux_frame.current();");
+    evaluate_aux_transition.line("let aux_next = aux_frame.next();");
 
     // output the constraints.
     add_constraints(evaluate_aux_transition, ir, 1);


### PR DESCRIPTION
This PR refactors the codegen to correctly generate code for constraints that use both aux trace columns and main trace columns.