### PR TITLE
prepare v0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.2.0 (2023-02-22)
+## 0.2.0 (2023-02-23)
 
 - Added support for named constants (scalars, vectors, and matrices).
 - Added support for intermediate variables in `boundary_constraints` and `integrity_constraints` sections (scalars, vectors, and matrices).

--- a/air-script-core/Cargo.toml
+++ b/air-script-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "air-script-core"
-version = "0.1.0"
+version = "0.2.0"
 description="Core types for the AirScript compiler"
 authors = ["miden contributors"]
 readme="README.md"

--- a/air-script/Cargo.toml
+++ b/air-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "air-script"
-version = "0.1.0"
+version = "0.2.0"
 description="AirScript language compiler"
 authors = ["miden contributors"]
 readme="README.md"
@@ -17,15 +17,15 @@ name = "airc"
 path = "src/main.rs"
 
 [dependencies]
-codegen-winter = { package = "air-codegen-winter", path = "../codegen/winterfell", version = "0.1.0" }
-env_logger = "0.9"
-ir = { package = "air-ir", path = "../ir", version = "0.1.0" }
+codegen-winter = { package = "air-codegen-winter", path = "../codegen/winterfell", version = "0.2.0" }
+env_logger = "0.10.0"
+ir = { package = "air-ir", path = "../ir", version = "0.2.0" }
 log = { version = "0.4", default-features = false }
-parser = { package = "air-parser", path = "../parser", version = "0.1.0" }
+parser = { package = "air-parser", path = "../parser", version = "0.2.0" }
 structopt = "0.3.26"
 
 [dev-dependencies]
-winter-air = { package = "winter-air", version = "0.4.2", default-features = false }
-winter-math = { package = "winter-math", version = "0.4.2", default-features = false }
-winter-utils = { package = "winter-utils", version = "0.4.2", default-features = false }
+winter-air = { package = "winter-air", version = "0.5.1", default-features = false }
+winter-math = { package = "winter-math", version = "0.5.1", default-features = false }
+winter-utils = { package = "winter-utils", version = "0.5.1", default-features = false }
 expect-test = "1.4.0"

--- a/codegen/winterfell/Cargo.toml
+++ b/codegen/winterfell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "air-codegen-winter"
-version = "0.1.0"
+version = "0.2.0"
 description="Winterfell code generator for the AirScript language"
 authors = ["miden contributors"]
 readme="README.md"
@@ -12,6 +12,6 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-air-script-core = {package = "air-script-core", path="../../air-script-core", version="0.1.0" }
-ir = {package = "air-ir", path="../../ir", version="0.1.0" }
+air-script-core = { package = "air-script-core", path="../../air-script-core", version="0.2.0" }
+ir = { package = "air-ir", path="../../ir", version="0.2.0" }
 codegen = "0.2.0"

--- a/examples/example.air
+++ b/examples/example.air
@@ -13,6 +13,9 @@ public_inputs:
 periodic_columns:
     k0: [1, 1, 1, 1, 1, 1, 1, 0]
 
+random_values:
+    rand: [1]
+
 boundary_constraints:
     # define boundary constraints against the main trace at the first row of the trace.
     enf a.first = stack_inputs[0]

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "air-ir"
-version = "0.1.0"
+version = "0.2.0"
 description="Intermediate representation for the AirScript language"
 authors = ["miden contributors"]
 readme="README.md"
@@ -12,5 +12,5 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-air-script-core = {package = "air-script-core", path="../air-script-core", version="0.1.0" }
-parser = { package = "air-parser", path = "../parser", version = "0.1.0" }
+air-script-core = { package = "air-script-core", path="../air-script-core", version="0.2.0" }
+parser = { package = "air-parser", path = "../parser", version = "0.2.0" }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "air-parser"
-version = "0.1.0"
+version = "0.2.0"
 description="Parser for the AirScript language"
 authors = ["miden contributors"]
 readme="README.md"
@@ -14,7 +14,7 @@ rust-version = "1.65"
 lalrpop = "0.19.7"
 
 [dependencies]
-air-script-core = {package = "air-script-core", path="../air-script-core", version="0.1.0" }
+air-script-core = { package = "air-script-core", path="../air-script-core", version="0.2.0" }
 lalrpop-util = { version = "0.19.7" }
 logos = "0.12.0"
 regex = "1"


### PR DESCRIPTION
This PR fixes an issue with the provided AirScript example (random values weren't declared) and bumps versions and dependencies for the v0.2 release.