### PR TITLE
Refactoring: Use specialized SemanticError constructors

### DIFF
--- a/ir/src/constraints/constraint.rs
+++ b/ir/src/constraints/constraint.rs
@@ -96,9 +96,7 @@ impl ConstraintDomain {
                 Ok(ConstraintDomain::EveryFrame(*a.max(b)))
             }
             // otherwise, the domains are not compatible.
-            _ => Err(SemanticError::InvalidConstraintDomain(format!(
-                "The specified constraint domain {other:?} is not compatible with the base domain {self:?}",
-            ))),
+            _ => Err(SemanticError::incompatible_constraint_domains(self, other)),
         }
     }
 }

--- a/ir/src/constraints/graph.rs
+++ b/ir/src/constraints/graph.rs
@@ -360,9 +360,7 @@ impl AlgebraicGraph {
                         variable_expr,
                     )
                 } else {
-                    Err(SemanticError::InvalidUsage(format!(
-                        "Identifier {ident} was declared as a {elem_type} which is not a supported type."
-                    )))
+                    Err(SemanticError::unsupported_identifer_type(ident, elem_type))
                 }
             }
             IdentifierType::PeriodicColumn(index, cycle_len) => {
@@ -376,9 +374,7 @@ impl AlgebraicGraph {
                 let node_index = self.insert_op(Operation::TraceElement(trace_access));
                 Ok(ExprDetails::new(node_index, trace_segment, domain))
             }
-            _ => Err(SemanticError::InvalidUsage(format!(
-                "Identifier {ident} was declared as a {elem_type} which is not a supported type."
-            ))),
+            _ => Err(SemanticError::unsupported_identifer_type(ident, elem_type)),
         }
     }
 
@@ -510,9 +506,7 @@ impl AlgebraicGraph {
             IdentifierType::RandomValuesBinding(_, _) => {
                 self.insert_random_value(symbol_table, index, trace_segment, domain)
             }
-            _ => Err(SemanticError::InvalidUsage(format!(
-                "Identifier {name} was declared as a {elem_type} not as a random values"
-            ))),
+            _ => Err(SemanticError::unsupported_identifer_type(name, elem_type)),
         }
     }
 }

--- a/ir/src/constraints/mod.rs
+++ b/ir/src/constraints/mod.rs
@@ -6,7 +6,7 @@ use super::{
 use std::collections::{BTreeMap, BTreeSet};
 
 mod constraint;
-use constraint::ConstrainedBoundary;
+pub use constraint::ConstrainedBoundary;
 pub use constraint::{ConstraintDomain, ConstraintRoot};
 
 mod degree;
@@ -264,9 +264,9 @@ impl Constraints {
                 // add the boundary to the set of constrained boundaries.
                 if !self.constrained_boundaries.insert(constrained_boundary) {
                     // raise an error if the same boundary was previously constrained
-                    return Err(SemanticError::TooManyConstraints(format!(
-                        "A constraint was already defined at {constrained_boundary}",
-                    )));
+                    return Err(SemanticError::boundary_already_constrained(
+                        &constrained_boundary,
+                    ));
                 }
 
                 // add the trace access at the specified boundary to the graph.
@@ -288,7 +288,7 @@ impl Constraints {
                 // trace segment inference defaults to the lowest segment (the main trace) and is
                 // adjusted according to the use of random values and trace columns.
                 if lhs.trace_segment() < rhs.trace_segment() {
-                    return Err(SemanticError::InvalidUsage("Random values cannot be used in boundary constraints defined against prior trace segments".to_string()));
+                    return Err(SemanticError::trace_segment_mismatch(&lhs.trace_segment()));
                 }
 
                 // merge the two sides of the expression into a constraint.
@@ -316,8 +316,8 @@ impl Constraints {
 
         // the constraint should not be against an undeclared trace segment.
         if symbol_table.num_trace_segments() <= trace_segment {
-            return Err(SemanticError::InvalidConstraint(
-                "Constraint against undeclared trace segment".to_string(),
+            return Err(SemanticError::trace_segment_mismatch(
+                &constraint.trace_segment,
             ));
         }
 

--- a/ir/src/error.rs
+++ b/ir/src/error.rs
@@ -1,5 +1,8 @@
-use super::{MatrixAccess, VectorAccess};
-use crate::symbol_table::IdentifierType;
+use super::{
+    constraints::{ConstrainedBoundary, ConstraintDomain},
+    Constant, IdentifierType, IndexedTraceAccess, MatrixAccess, NamedTraceAccess, TraceSegment,
+    VectorAccess, MIN_CYCLE_LENGTH,
+};
 
 #[derive(Debug)]
 pub enum SemanticError {
@@ -17,6 +20,8 @@ pub enum SemanticError {
 }
 
 impl SemanticError {
+    // --- INVALID ACCESS ERRORS ------------------------------------------------------------------
+
     pub(super) fn invalid_vector_access(
         access: &VectorAccess,
         symbol_type: &IdentifierType,
@@ -72,6 +77,153 @@ impl SemanticError {
             access.name(),
             matrix_row_len,
             matrix_col_len
+        ))
+    }
+
+    pub(super) fn named_trace_column_access_out_of_bounds(
+        access: &NamedTraceAccess,
+        size: usize,
+    ) -> Self {
+        SemanticError::IndexOutOfRange(format!(
+            "Out-of-range index '{}' while accessing named trace column group '{}' of length {}",
+            access.idx(),
+            access.name(),
+            size
+        ))
+    }
+
+    pub(super) fn trace_segment_access_out_of_bounds(
+        access: &IndexedTraceAccess,
+        size: usize,
+    ) -> Self {
+        SemanticError::IndexOutOfRange(format!(
+            "Segment index '{}' is greater than the number of segments in the trace ({}).",
+            access.trace_segment(),
+            size
+        ))
+    }
+
+    pub(super) fn indexed_trace_column_access_out_of_bounds(
+        access: &IndexedTraceAccess,
+        segment_width: u16,
+    ) -> Self {
+        SemanticError::IndexOutOfRange(format!(
+            "Out-of-range index '{}' in trace segment '{}' of length {}",
+            access.col_idx(),
+            access.trace_segment(),
+            segment_width
+        ))
+    }
+
+    pub(super) fn random_value_access_out_of_bounds(index: usize, size: u16) -> Self {
+        SemanticError::IndexOutOfRange(format!(
+            "Random value index {index} is greater than or equal to the total number of random values ({size})."
+        ))
+    }
+
+    // --- DECLARATION ERRORS ---------------------------------------------------------------------
+
+    fn missing_section_declaration(missing_section: &str) -> Self {
+        SemanticError::MissingDeclaration(format!("{missing_section} section is missing"))
+    }
+
+    pub(super) fn missing_trace_columns_declaration() -> Self {
+        Self::missing_section_declaration("trace_declaration")
+    }
+
+    pub(super) fn missing_public_inputs_declaration() -> Self {
+        Self::missing_section_declaration("public_inputs")
+    }
+
+    pub(super) fn missing_boundary_constraints_declaration() -> Self {
+        Self::missing_section_declaration("boundary_constraints")
+    }
+
+    pub(super) fn missing_integrity_constraints_declaration() -> Self {
+        Self::missing_section_declaration("integrity_constraints")
+    }
+
+    pub(super) fn has_random_values_but_missing_aux_trace_columns_declaration() -> Self {
+        SemanticError::MissingDeclaration(
+            "random_values section requires aux_trace_columns section, which is missing"
+                .to_string(),
+        )
+    }
+
+    // --- ILLEGAL IDENTIFIER ERRORS --------------------------------------------------------------
+
+    pub(super) fn duplicate_identifer(
+        ident_name: &str,
+        ident_type: IdentifierType,
+        prev_type: IdentifierType,
+    ) -> Self {
+        SemanticError::DuplicateIdentifier(format!(
+            "Cannot declare {ident_name} as a {ident_type}, since it was already defined as a {prev_type}"))
+    }
+
+    pub(super) fn undeclared_identifier(ident_name: &str) -> Self {
+        SemanticError::InvalidIdentifier(format!("Identifier {ident_name} was not declared"))
+    }
+
+    // --- ILLEGAL VALUE ERRORS -------------------------------------------------------------------
+
+    pub(super) fn periodic_cycle_length_not_power_of_two(length: usize, cycle_name: &str) -> Self {
+        SemanticError::InvalidPeriodicColumn(format!(
+            "cycle length must be a power of two, but was {length} for cycle {cycle_name}"
+        ))
+    }
+
+    pub(super) fn periodic_cycle_length_too_small(length: usize, cycle_name: &str) -> Self {
+        SemanticError::InvalidPeriodicColumn(format!(
+            "cycle length must be at least {MIN_CYCLE_LENGTH}, but was {length} for cycle {cycle_name}"
+        ))
+    }
+
+    pub(super) fn invalid_matrix_constant(constant: &Constant) -> Self {
+        SemanticError::InvalidConstant(format!(
+            "The matrix value of constant {} is invalid",
+            constant.name()
+        ))
+    }
+
+    // --- TYPE ERRORS ----------------------------------------------------------------------------
+
+    pub(super) fn unsupported_identifer_type(
+        ident_name: &str,
+        ident_type: &IdentifierType,
+    ) -> Self {
+        SemanticError::InvalidUsage(format!(
+            "Identifier {ident_name} was declared as a {ident_type} which is not a supported type."
+        ))
+    }
+
+    pub(super) fn not_a_trace_column_identifier(
+        ident_name: &str,
+        ident_type: &IdentifierType,
+    ) -> Self {
+        SemanticError::InvalidUsage(format!(
+            "Identifier {ident_name} was declared as a {ident_type} not as a trace column"
+        ))
+    }
+
+    // --- INVALID CONSTRAINT ERRORS --------------------------------------------------------------
+
+    pub(super) fn incompatible_constraint_domains(
+        base: &ConstraintDomain,
+        other: &ConstraintDomain,
+    ) -> Self {
+        SemanticError::InvalidConstraintDomain(format!(
+            "The specified constraint domains {base:?} and {other:?} are not compatible"
+        ))
+    }
+
+    pub(super) fn boundary_already_constrained(boundary: &ConstrainedBoundary) -> Self {
+        SemanticError::TooManyConstraints(format!("A constraint was already defined at {boundary}"))
+    }
+
+    pub(super) fn trace_segment_mismatch(segment: &TraceSegment) -> Self {
+        SemanticError::InvalidUsage(format!(
+            "The constraint expression cannot be enforced against trace segment {segment}"
         ))
     }
 }

--- a/ir/src/helpers.rs
+++ b/ir/src/helpers.rs
@@ -39,34 +39,25 @@ impl SourceValidator {
     pub fn check(&self) -> Result<(), SemanticError> {
         // make sure trace_columns are declared.
         if !self.main_trace_columns_exists {
-            return Err(SemanticError::MissingDeclaration(
-                "trace_columns section is missing".to_string(),
-            ));
+            return Err(SemanticError::missing_trace_columns_declaration());
         }
         // make sure public_inputs are declared.
         if !self.public_inputs_exists {
-            return Err(SemanticError::MissingDeclaration(
-                "public_inputs section is missing".to_string(),
-            ));
+            return Err(SemanticError::missing_public_inputs_declaration());
         }
         // make sure boundary_constraints are declared.
         if !self.boundary_constraints_exists {
-            return Err(SemanticError::MissingDeclaration(
-                "boundary_constraints section is missing".to_string(),
-            ));
+            return Err(SemanticError::missing_boundary_constraints_declaration());
         }
         // make sure integrity_constraints are declared.
         if !self.integrity_constraints_exists {
-            return Err(SemanticError::MissingDeclaration(
-                "integrity_constraints section is missing".to_string(),
-            ));
+            return Err(SemanticError::missing_integrity_constraints_declaration());
         }
         // make sure random_values are declared only if aux trace columns are declared
         if !self.aux_trace_columns_exists && self.random_values_exists {
-            return Err(SemanticError::MissingDeclaration(
-                "random_values section requires aux_trace_columns section, which is missing"
-                    .to_string(),
-            ));
+            return Err(
+                SemanticError::has_random_values_but_missing_aux_trace_columns_declaration(),
+            );
         }
 
         Ok(())

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -6,7 +6,7 @@ pub use parser::ast::{self, Boundary, BoundaryStmt, IntegrityStmt, PublicInput};
 use std::collections::BTreeMap;
 
 mod symbol_table;
-use symbol_table::{Scope, SymbolTable};
+use symbol_table::{IdentifierType, Scope, SymbolTable};
 
 pub mod constraints;
 use constraints::{AlgebraicGraph, ConstraintRoot, Constraints, MIN_CYCLE_LENGTH};

--- a/ir/src/symbol_table.rs
+++ b/ir/src/symbol_table.rs
@@ -88,9 +88,9 @@ impl SymbolTable {
             .identifiers
             .insert(ident_name.to_owned(), ident_type.clone());
         match result {
-            Some(prev_type) => Err(SemanticError::DuplicateIdentifier(format!(
-                "Cannot declare {ident_name} as a {ident_type}, since it was already defined as a {prev_type}"
-            ))),
+            Some(prev_type) => Err(SemanticError::duplicate_identifer(
+                ident_name, ident_type, prev_type,
+            )),
             None => Ok(()),
         }
     }
@@ -238,9 +238,7 @@ impl SymbolTable {
         if let Some(ident_type) = self.identifiers.get(name) {
             Ok(ident_type)
         } else {
-            Err(SemanticError::InvalidIdentifier(format!(
-                "Identifier {name} was not declared"
-            )))
+            Err(SemanticError::undeclared_identifier(name))
         }
     }
 
@@ -259,12 +257,10 @@ impl SymbolTable {
         match elem_type {
             IdentifierType::TraceColumns(columns) => {
                 if trace_access.idx() >= columns.size() {
-                    return Err(SemanticError::IndexOutOfRange(format!(
-                        "Out-of-range index '{}' while accessing named trace column group '{}' of length {}",
-                        trace_access.idx(),
-                        trace_access.name(),
-                        columns.size()
-                    )));
+                    return Err(SemanticError::named_trace_column_access_out_of_bounds(
+                        trace_access,
+                        columns.size(),
+                    ));
                 }
 
                 Ok(IndexedTraceAccess::new(
@@ -273,11 +269,10 @@ impl SymbolTable {
                     trace_access.row_offset(),
                 ))
             }
-            _ => Err(SemanticError::InvalidUsage(format!(
-                "Identifier {} was declared as a {} not as a trace column",
+            _ => Err(SemanticError::not_a_trace_column_identifier(
                 trace_access.name(),
-                elem_type
-            ))),
+                elem_type,
+            )),
         }
     }
 
@@ -397,19 +392,16 @@ impl SymbolTable {
     ) -> Result<(), SemanticError> {
         let segment_idx = trace_access.trace_segment() as usize;
         if segment_idx > self.segment_widths().len() {
-            return Err(SemanticError::IndexOutOfRange(format!(
-                "Segment index '{}' is greater than the number of segments in the trace ({}).",
-                segment_idx,
-                self.segment_widths().len()
-            )));
+            return Err(SemanticError::trace_segment_access_out_of_bounds(
+                trace_access,
+                self.segment_widths().len(),
+            ));
         }
         if trace_access.col_idx() as u16 >= self.segment_widths()[segment_idx] {
-            return Err(SemanticError::IndexOutOfRange(format!(
-                "Out-of-range index '{}' in trace segment '{}' of length {}",
-                trace_access.col_idx(),
-                trace_access.trace_segment(),
-                self.segment_widths()[segment_idx]
-            )));
+            return Err(SemanticError::indexed_trace_column_access_out_of_bounds(
+                trace_access,
+                self.segment_widths()[segment_idx],
+            ));
         }
 
         Ok(())
@@ -419,11 +411,10 @@ impl SymbolTable {
     /// the number of declared random values.
     pub(super) fn validate_rand_access(&self, index: usize) -> Result<(), SemanticError> {
         if index >= usize::from(self.num_random_values()) {
-            return Err(SemanticError::IndexOutOfRange(format!(
-                "Random value index {} is greater than or equal to the total number of random values ({}).", 
+            return Err(SemanticError::random_value_access_out_of_bounds(
                 index,
-                self.num_random_values()
-            )));
+                self.num_random_values(),
+            ));
         }
 
         Ok(())
@@ -439,15 +430,13 @@ fn validate_cycles(column: &PeriodicColumn) -> Result<(), SemanticError> {
     let cycle = column.values().len();
 
     if !cycle.is_power_of_two() {
-        return Err(SemanticError::InvalidPeriodicColumn(format!(
-            "cycle length must be a power of two, but was {cycle} for cycle {name}"
-        )));
+        return Err(SemanticError::periodic_cycle_length_not_power_of_two(
+            cycle, name,
+        ));
     }
 
     if cycle < MIN_CYCLE_LENGTH {
-        return Err(SemanticError::InvalidPeriodicColumn(format!(
-            "cycle length must be at least {MIN_CYCLE_LENGTH}, but was {cycle} for cycle {name}"
-        )));
+        return Err(SemanticError::periodic_cycle_length_too_small(cycle, name));
     }
 
     Ok(())
@@ -462,10 +451,7 @@ fn validate_constant(constant: &Constant) -> Result<(), SemanticError> {
             if matrix.iter().skip(1).all(|row| row.len() == row_len) {
                 Ok(())
             } else {
-                Err(SemanticError::InvalidConstant(format!(
-                    "The matrix value of constant {} is invalid",
-                    constant.name()
-                )))
+                Err(SemanticError::invalid_matrix_constant(constant))
             }
         }
         _ => Ok(()),


### PR DESCRIPTION
Fixes #109.

This PR introduces specialized constructors for SemanticError for the various errors that can occur in the IR. This makes for better code readability, and for more standardized error messages.

I'm unsure whether I've picked appropriate names for the constructors, and I'm also not sure whether the `SemanticError` enum should be extended.