### PR TITLE
Unroll exponentiation expressions during code generation

### DIFF
--- a/air-script/tests/binary/binary.rs
+++ b/air-script/tests/binary/binary.rs
@@ -75,8 +75,8 @@ impl Air for BinaryAir {
     fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
         let main_current = frame.current();
         let main_next = frame.next();
-        result[0] = main_current[0].exp(E::PositiveInteger::from(2_u64)) - main_current[0] - E::ZERO;
-        result[1] = main_current[1].exp(E::PositiveInteger::from(2_u64)) - main_current[1] - E::ZERO;
+        result[0] = (main_current[0] * main_current[0]) - main_current[0] - E::ZERO;
+        result[1] = (main_current[1] * main_current[1]) - main_current[1] - E::ZERO;
     }
 
     fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])

--- a/air-script/tests/bitwise/bitwise.rs
+++ b/air-script/tests/bitwise/bitwise.rs
@@ -75,23 +75,23 @@ impl Air for BitwiseAir {
     fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
         let main_current = frame.current();
         let main_next = frame.next();
-        result[0] = main_current[0].exp(E::PositiveInteger::from(2_u64)) - main_current[0] - E::ZERO;
+        result[0] = (main_current[0] * main_current[0]) - main_current[0] - E::ZERO;
         result[1] = periodic_values[1] * (main_next[0] - main_current[0]) - E::ZERO;
-        result[2] = main_current[3].exp(E::PositiveInteger::from(2_u64)) - main_current[3] - E::ZERO;
-        result[3] = main_current[4].exp(E::PositiveInteger::from(2_u64)) - main_current[4] - E::ZERO;
-        result[4] = main_current[5].exp(E::PositiveInteger::from(2_u64)) - main_current[5] - E::ZERO;
-        result[5] = main_current[6].exp(E::PositiveInteger::from(2_u64)) - main_current[6] - E::ZERO;
-        result[6] = main_current[7].exp(E::PositiveInteger::from(2_u64)) - main_current[7] - E::ZERO;
-        result[7] = main_current[8].exp(E::PositiveInteger::from(2_u64)) - main_current[8] - E::ZERO;
-        result[8] = main_current[9].exp(E::PositiveInteger::from(2_u64)) - main_current[9] - E::ZERO;
-        result[9] = main_current[10].exp(E::PositiveInteger::from(2_u64)) - main_current[10] - E::ZERO;
-        result[10] = periodic_values[0] * (main_current[1] - (E::ONE * main_current[3] + E::from(2_u64) * main_current[4] + E::from(2_u64).exp(E::PositiveInteger::from(2_u64)) * main_current[5] + E::from(2_u64).exp(E::PositiveInteger::from(3_u64)) * main_current[6])) - E::ZERO;
-        result[11] = periodic_values[0] * (main_current[2] - (E::ONE * main_current[7] + E::from(2_u64) * main_current[8] + E::from(2_u64).exp(E::PositiveInteger::from(2_u64)) * main_current[9] + E::from(2_u64).exp(E::PositiveInteger::from(3_u64)) * main_current[10])) - E::ZERO;
-        result[12] = periodic_values[1] * (main_next[1] - (main_current[1] * E::from(16_u64) + E::ONE * main_current[3] + E::from(2_u64) * main_current[4] + E::from(2_u64).exp(E::PositiveInteger::from(2_u64)) * main_current[5] + E::from(2_u64).exp(E::PositiveInteger::from(3_u64)) * main_current[6])) - E::ZERO;
-        result[13] = periodic_values[1] * (main_next[2] - (main_current[2] * E::from(16_u64) + E::ONE * main_current[7] + E::from(2_u64) * main_current[8] + E::from(2_u64).exp(E::PositiveInteger::from(2_u64)) * main_current[9] + E::from(2_u64).exp(E::PositiveInteger::from(3_u64)) * main_current[10])) - E::ZERO;
+        result[2] = (main_current[3] * main_current[3]) - main_current[3] - E::ZERO;
+        result[3] = (main_current[4] * main_current[4]) - main_current[4] - E::ZERO;
+        result[4] = (main_current[5] * main_current[5]) - main_current[5] - E::ZERO;
+        result[5] = (main_current[6] * main_current[6]) - main_current[6] - E::ZERO;
+        result[6] = (main_current[7] * main_current[7]) - main_current[7] - E::ZERO;
+        result[7] = (main_current[8] * main_current[8]) - main_current[8] - E::ZERO;
+        result[8] = (main_current[9] * main_current[9]) - main_current[9] - E::ZERO;
+        result[9] = (main_current[10] * main_current[10]) - main_current[10] - E::ZERO;
+        result[10] = periodic_values[0] * (main_current[1] - (E::ONE * main_current[3] + E::from(2_u64) * main_current[4] + (E::from(2_u64) * E::from(2_u64)) * main_current[5] + (E::from(2_u64) * E::from(2_u64) * E::from(2_u64)) * main_current[6])) - E::ZERO;
+        result[11] = periodic_values[0] * (main_current[2] - (E::ONE * main_current[7] + E::from(2_u64) * main_current[8] + (E::from(2_u64) * E::from(2_u64)) * main_current[9] + (E::from(2_u64) * E::from(2_u64) * E::from(2_u64)) * main_current[10])) - E::ZERO;
+        result[12] = periodic_values[1] * (main_next[1] - (main_current[1] * E::from(16_u64) + E::ONE * main_current[3] + E::from(2_u64) * main_current[4] + (E::from(2_u64) * E::from(2_u64)) * main_current[5] + (E::from(2_u64) * E::from(2_u64) * E::from(2_u64)) * main_current[6])) - E::ZERO;
+        result[13] = periodic_values[1] * (main_next[2] - (main_current[2] * E::from(16_u64) + E::ONE * main_current[7] + E::from(2_u64) * main_current[8] + (E::from(2_u64) * E::from(2_u64)) * main_current[9] + (E::from(2_u64) * E::from(2_u64) * E::from(2_u64)) * main_current[10])) - E::ZERO;
         result[14] = periodic_values[0] * main_current[11] - E::ZERO;
         result[15] = periodic_values[1] * (main_current[12] - main_next[11]) - E::ZERO;
-        result[16] = (E::ONE - main_current[0]) * (main_current[12] - (main_current[11] * E::from(16_u64) + E::ONE * main_current[3] * main_current[7] + E::from(2_u64) * main_current[4] * main_current[8] + E::from(2_u64).exp(E::PositiveInteger::from(2_u64)) * main_current[5] * main_current[9] + E::from(2_u64).exp(E::PositiveInteger::from(3_u64)) * main_current[6] * main_current[10])) + main_current[0] * (main_current[12] - (main_current[11] * E::from(16_u64) + E::ONE * (main_current[3] + main_current[7] - E::from(2_u64) * main_current[3] * main_current[7]) + E::from(2_u64) * (main_current[4] + main_current[8] - E::from(2_u64) * main_current[4] * main_current[8]) + E::from(2_u64).exp(E::PositiveInteger::from(2_u64)) * (main_current[5] + main_current[9] - E::from(2_u64) * main_current[5] * main_current[9]) + E::from(2_u64).exp(E::PositiveInteger::from(3_u64)) * (main_current[6] + main_current[10] - E::from(2_u64) * main_current[6] * main_current[10]))) - E::ZERO;
+        result[16] = (E::ONE - main_current[0]) * (main_current[12] - (main_current[11] * E::from(16_u64) + E::ONE * main_current[3] * main_current[7] + E::from(2_u64) * main_current[4] * main_current[8] + (E::from(2_u64) * E::from(2_u64)) * main_current[5] * main_current[9] + (E::from(2_u64) * E::from(2_u64) * E::from(2_u64)) * main_current[6] * main_current[10])) + main_current[0] * (main_current[12] - (main_current[11] * E::from(16_u64) + E::ONE * (main_current[3] + main_current[7] - E::from(2_u64) * main_current[3] * main_current[7]) + E::from(2_u64) * (main_current[4] + main_current[8] - E::from(2_u64) * main_current[4] * main_current[8]) + (E::from(2_u64) * E::from(2_u64)) * (main_current[5] + main_current[9] - E::from(2_u64) * main_current[5] * main_current[9]) + (E::from(2_u64) * E::from(2_u64) * E::from(2_u64)) * (main_current[6] + main_current[10] - E::from(2_u64) * main_current[6] * main_current[10]))) - E::ZERO;
     }
 
     fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])

--- a/air-script/tests/list_comprehension/list_comprehension.rs
+++ b/air-script/tests/list_comprehension/list_comprehension.rs
@@ -86,7 +86,7 @@ impl Air for ListComprehensionAir {
         let main_next = main_frame.next();
         let aux_current = aux_frame.current();
         let aux_next = aux_frame.next();
-        result[0] = aux_current[0] - E::from(main_current[0]) * E::from(2_u64).exp(E::PositiveInteger::from(3_u64)) * aux_current[7];
+        result[0] = aux_current[0] - E::from(main_current[0]) * (E::from(2_u64) * E::from(2_u64) * E::from(2_u64)) * aux_current[7];
         result[1] = aux_current[0] - E::from(main_current[0]) * (aux_next[4] - aux_next[8]);
         result[2] = aux_current[2] - E::from(main_current[0]) * (aux_current[5] - aux_current[10]);
         result[3] = aux_current[0] - (E::ZERO + aux_current[1] - aux_current[4] - aux_current[8] + E::ONE + aux_current[2] - aux_current[5] - aux_current[9] + E::from(2_u64) + aux_current[3] - aux_current[6] - aux_current[10]);

--- a/air-script/tests/variables/variables.rs
+++ b/air-script/tests/variables/variables.rs
@@ -79,7 +79,7 @@ impl Air for VariablesAir {
     fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
         let main_current = frame.current();
         let main_next = frame.next();
-        result[0] = main_current[0].exp(E::PositiveInteger::from(2_u64)) - main_current[0];
+        result[0] = (main_current[0] * main_current[0]) - main_current[0];
         result[1] = periodic_values[0] * (main_next[0] - main_current[0]) - E::ZERO;
         result[2] = (E::ONE - main_current[0]) * (main_current[3] - main_current[1] + main_current[2]) - (E::from(2_u64) * E::from(3_u64) - main_current[0]);
         result[3] = main_current[0] * (main_current[3] - main_current[1] * main_current[2]) - (main_next[0] - E::from(3_u64) - (E::from(4_u64) - E::from(2_u64)));

--- a/codegen/winterfell/src/air/graph.rs
+++ b/codegen/winterfell/src/air/graph.rs
@@ -130,12 +130,15 @@ impl Codegen for Operation {
                         ElemType::Ext => "E::ONE".to_string(),
                     },
                     1 => lhs, // x^1 = x
-                    _ => match elem_type {
-                        ElemType::Base => format!("{lhs}.exp(Felt::new({r_idx}))"),
-                        ElemType::Ext => {
-                            format!("{lhs}.exp(E::PositiveInteger::from({r_idx}_u64))")
+                    _ => {
+                        // x^y = (x * x * ... * x)
+                        let mut s = format!("({lhs}");
+                        for _ in 2..=*r_idx {
+                            s.push_str(&format!(" * {lhs}").to_string());
                         }
-                    },
+                        s.push(')');
+                        s
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #130.

Exponentiation expressions are now unrolled during code generation for better performance.