### PR TITLE
Refactor the IR (2 of 4)

### DIFF
--- a/air-script-core/src/constant.rs
+++ b/air-script-core/src/constant.rs
@@ -28,6 +28,10 @@ impl Constant {
     pub fn value(&self) -> &ConstantType {
         &self.value
     }
+
+    pub fn into_parts(self) -> (String, ConstantType) {
+        (self.name.into_name(), self.value)
+    }
 }
 
 /// Type of constant. Constants can be of 3 types:

--- a/air-script-core/src/identifier.rs
+++ b/air-script-core/src/identifier.rs
@@ -9,6 +9,10 @@ impl Identifier {
     pub fn name(&self) -> &str {
         &self.0
     }
+
+    pub fn into_name(self) -> String {
+        self.0
+    }
 }
 
 impl fmt::Display for Identifier {

--- a/air-script-core/src/variable.rs
+++ b/air-script-core/src/variable.rs
@@ -18,6 +18,10 @@ impl Variable {
     pub fn value(&self) -> &VariableType {
         &self.value
     }
+
+    pub fn into_parts(self) -> (String, VariableType) {
+        (self.name.into_name(), self.value)
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/air-script/src/cli/transpile.rs
+++ b/air-script/src/cli/transpile.rs
@@ -57,7 +57,7 @@ impl TranspileCmd {
         }
         let parsed = parsed.unwrap();
 
-        let ir = AirIR::new(&parsed);
+        let ir = AirIR::new(parsed);
         if let Err(err) = ir {
             return Err(format!("{err:?}"));
         }

--- a/air-script/tests/helpers.rs
+++ b/air-script/tests/helpers.rs
@@ -36,7 +36,7 @@ impl Test {
             ))
         })?;
 
-        let ir = AirIR::new(&parsed).map_err(|_| {
+        let ir = AirIR::new(parsed).map_err(|_| {
             TestError::IR(format!(
                 "Failed to convert the input air file at {} to IR representation",
                 &self.input_path

--- a/ir/src/constraint_builder/mod.rs
+++ b/ir/src/constraint_builder/mod.rs
@@ -55,7 +55,7 @@ impl ConstraintBuilder {
     /// is then saved in the boundary_constraints matrix.
     pub(super) fn insert_boundary_stmt(
         &mut self,
-        stmt: &ast::BoundaryStmt,
+        stmt: ast::BoundaryStmt,
     ) -> Result<(), SemanticError> {
         match stmt {
             ast::BoundaryStmt::Constraint(constraint) => {
@@ -133,7 +133,7 @@ impl ConstraintBuilder {
     /// is then saved in the validity_constraints or transition_constraints matrices.
     pub(super) fn insert_integrity_stmt(
         &mut self,
-        stmt: &ast::IntegrityStmt,
+        stmt: ast::IntegrityStmt,
     ) -> Result<(), SemanticError> {
         match stmt {
             ast::IntegrityStmt::Constraint(constraint) => {
@@ -168,7 +168,7 @@ impl ConstraintBuilder {
                     let vector = unfold_lc(list_comprehension, &self.symbol_table)?;
                     self.symbol_table.insert_variable(
                         Scope::IntegrityConstraints,
-                        &Variable::new(
+                        Variable::new(
                             Identifier(variable.name().to_string()),
                             VariableType::Vector(vector),
                         ),

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -51,17 +51,18 @@ impl AirIR {
     // --- CONSTRUCTOR ----------------------------------------------------------------------------
 
     /// Consumes the provided source and generates a matching AirIR.
-    pub fn new(source: &ast::Source) -> Result<Self, SemanticError> {
+    pub fn new(source: ast::Source) -> Result<Self, SemanticError> {
         let ast::Source(source) = source;
 
         // set a default name.
-        let mut air_name = "CustomAir";
-
-        let mut validator = SourceValidator::new();
+        let mut air_name = String::from("CustomAir");
 
         // process the declarations of identifiers first, using a single symbol table to enforce
         // uniqueness.
         let mut symbol_table = SymbolTable::default();
+        let mut validator = SourceValidator::new();
+        let mut boundary_stmts = Vec::new();
+        let mut integrity_stmts = Vec::new();
 
         for section in source {
             match section {
@@ -95,37 +96,35 @@ impl AirIR {
                     symbol_table.insert_random_values(values)?;
                     validator.exists("random_values");
                 }
-                _ => {}
-            }
-        }
-
-        // then process the constraints & validate them against the symbol table.
-        let mut constraint_builder = ConstraintBuilder::new(symbol_table);
-        for section in source {
-            match section {
                 ast::SourceSection::BoundaryConstraints(stmts) => {
-                    for stmt in stmts {
-                        constraint_builder.insert_boundary_stmt(stmt)?
-                    }
+                    // save the boundary statements for processing after the SymbolTable is built.
+                    boundary_stmts.extend(stmts);
                     validator.exists("boundary_constraints");
                 }
                 ast::SourceSection::IntegrityConstraints(stmts) => {
-                    for stmt in stmts {
-                        constraint_builder.insert_integrity_stmt(stmt)?
-                    }
+                    // save the integrity statements for processing after the SymbolTable is built.
+                    integrity_stmts.extend(stmts);
                     validator.exists("integrity_constraints");
                 }
-                _ => {}
             }
         }
-
-        let (declarations, constraints) = constraint_builder.into_air();
 
         // validate sections
         validator.check()?;
 
+        // process the variable & constraint statements, and validate them against the symbol table.
+        let mut constraint_builder = ConstraintBuilder::new(symbol_table);
+        for stmt in boundary_stmts.into_iter() {
+            constraint_builder.insert_boundary_stmt(stmt)?;
+        }
+        for stmt in integrity_stmts.into_iter() {
+            constraint_builder.insert_integrity_stmt(stmt)?;
+        }
+
+        let (declarations, constraints) = constraint_builder.into_air();
+
         Ok(Self {
-            air_name: air_name.to_string(),
+            air_name,
             declarations,
             constraints,
         })

--- a/ir/src/tests/access.rs
+++ b/ir/src/tests/access.rs
@@ -17,7 +17,7 @@ fn err_bc_invalid_vector_access() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -38,7 +38,7 @@ fn err_bc_invalid_matrix_access() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 
     let source = "
@@ -56,7 +56,7 @@ fn err_bc_invalid_matrix_access() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -77,7 +77,7 @@ fn err_ic_invalid_vector_access() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -98,7 +98,7 @@ fn err_ic_invalid_matrix_access() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 
     let source = "
@@ -116,6 +116,6 @@ fn err_ic_invalid_matrix_access() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }

--- a/ir/src/tests/boundary_constraints.rs
+++ b/ir/src/tests/boundary_constraints.rs
@@ -14,7 +14,7 @@ fn boundary_constraints() {
         enf clk' = clk + 1";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -32,7 +32,7 @@ fn err_bc_duplicate_first() {
         enf clk' = clk + 1";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
 
     assert!(result.is_err());
 }
@@ -51,7 +51,7 @@ fn err_bc_duplicate_last() {
         enf clk' = clk + 1";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
 
     assert!(result.is_err());
 }

--- a/ir/src/tests/constant.rs
+++ b/ir/src/tests/constant.rs
@@ -17,7 +17,7 @@ fn bc_with_constants() {
         enf clk' = clk - 1";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -38,7 +38,7 @@ fn ic_with_constants() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -57,6 +57,6 @@ fn err_invalid_matrix_const() {
         enf clk' = clk + 1";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }

--- a/ir/src/tests/integrity_constraints.rs
+++ b/ir/src/tests/integrity_constraints.rs
@@ -14,7 +14,7 @@ fn integrity_constraints() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -32,7 +32,7 @@ fn ic_using_parens() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -49,7 +49,7 @@ fn ic_op_mul() {
         enf clk' * clk = 1";
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -66,7 +66,7 @@ fn ic_op_exp() {
         enf clk'^2 - clk = 1";
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -87,6 +87,6 @@ fn err_non_const_exp_outside_lc() {
         enf clk = 2^ctx";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }

--- a/ir/src/tests/list_comprehension.rs
+++ b/ir/src/tests/list_comprehension.rs
@@ -15,7 +15,7 @@ fn list_comprehension() {
         enf clk = x[1]";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -36,7 +36,7 @@ fn lc_with_const_exp() {
         enf clk = y[1] + z[1]";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -57,7 +57,7 @@ fn lc_with_non_const_exp() {
         enf clk = enumerate[3]";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -76,7 +76,7 @@ fn lc_with_two_lists() {
         enf clk = diff[0]";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -95,7 +95,7 @@ fn lc_with_two_slices() {
         enf clk = diff[1]";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -114,7 +114,7 @@ fn lc_with_multiple_lists() {
         enf a = x[0] + x[1] + x[2]";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -134,7 +134,7 @@ fn err_index_out_of_range_lc_ident() {
         enf clk = x[2]";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -155,7 +155,7 @@ fn err_index_out_of_range_lc_slice() {
         enf clk = x[3]";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -176,7 +176,7 @@ fn err_non_const_exp_ident_iterable() {
         enf clk = invalid_exp_lc[1]";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -197,7 +197,7 @@ fn err_non_const_exp_slice_iterable() {
         enf clk = invalid_exp_lc[1]";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -218,6 +218,6 @@ fn err_duplicate_member() {
         enf clk = duplicate_member_lc[1]";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }

--- a/ir/src/tests/list_folding.rs
+++ b/ir/src/tests/list_folding.rs
@@ -17,7 +17,7 @@ fn list_folding_on_const() {
         enf clk = y - x";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -38,7 +38,7 @@ fn list_folding_on_variable() {
         enf clk = z - y";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -58,7 +58,7 @@ fn list_folding_on_vector() {
         enf clk = y - x";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -79,7 +79,7 @@ fn list_folding_on_lc() {
         enf clk = y - x";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -101,7 +101,7 @@ fn list_folding_in_lc() {
         enf clk = y[0]";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
 
     assert!(result.is_ok());
 }

--- a/ir/src/tests/pub_inputs.rs
+++ b/ir/src/tests/pub_inputs.rs
@@ -13,6 +13,6 @@ fn bc_with_public_inputs() {
         enf clk' = clk - 1";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }

--- a/ir/src/tests/random_values.rs
+++ b/ir/src/tests/random_values.rs
@@ -17,7 +17,7 @@ fn random_values_indexed_access() {
         enf c' = $rand[3] + 1";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -38,7 +38,7 @@ fn random_values_custom_name() {
         enf c' = $alphas[3] + 1";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -59,7 +59,7 @@ fn random_values_named_access() {
         enf c' = m + n[2] + $rand[1]";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -80,7 +80,7 @@ fn err_random_values_out_of_bounds() {
         enf a' = $rand[4] + 1";
 
     let parsed = parse(source_fixed_list).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 
     let source_ident_vector_sub_vec = "
@@ -98,7 +98,7 @@ fn err_random_values_out_of_bounds() {
         enf a' = m + 1";
 
     let parsed = parse(source_ident_vector_sub_vec).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 
     let source_ident_vector_index = "
@@ -116,7 +116,7 @@ fn err_random_values_out_of_bounds() {
         enf a' = m + 1";
 
     let parsed = parse(source_ident_vector_index).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -136,7 +136,7 @@ fn err_random_values_without_aux_cols() {
         enf a' = a + 1";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -157,6 +157,6 @@ fn err_random_values_in_bc_against_main_cols() {
         enf c' = $rand[3] + 1";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }

--- a/ir/src/tests/source_sections.rs
+++ b/ir/src/tests/source_sections.rs
@@ -25,7 +25,7 @@ fn err_trace_cols_empty_or_omitted() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
 
     // this fails before the check for missing trace columns declaration since the clk column
     // used in constraints is not declared.
@@ -56,7 +56,7 @@ fn err_pub_inputs_empty_or_omitted() {
         enf clk' = clk + 1";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -84,7 +84,7 @@ fn err_bc_empty_or_omitted() {
         enf clk' = clk + 1";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -112,6 +112,6 @@ fn err_ic_empty_or_omitted() {
         enf clk.first = 0";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }

--- a/ir/src/tests/trace.rs
+++ b/ir/src/tests/trace.rs
@@ -15,7 +15,7 @@ fn trace_columns_index_access() {
         enf $aux[0]^3 - $aux[1]' = 0";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -37,7 +37,7 @@ fn trace_cols_groups() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -56,7 +56,7 @@ fn err_bc_column_undeclared() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -74,7 +74,7 @@ fn err_ic_column_undeclared() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -96,7 +96,7 @@ fn err_bc_trace_cols_access_out_of_bounds() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -119,7 +119,7 @@ fn err_ic_trace_cols_access_out_of_bounds() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -137,6 +137,6 @@ fn err_ic_trace_cols_group_used_as_scalar() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }

--- a/ir/src/tests/variables.rs
+++ b/ir/src/tests/variables.rs
@@ -15,7 +15,7 @@ fn bc_scalar_variable() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -34,7 +34,7 @@ fn bc_vector_variable() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -58,7 +58,7 @@ fn bc_with_variables() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -78,7 +78,7 @@ fn bc_variable_in_both_domains() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -117,7 +117,7 @@ fn ic_with_variables() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -141,7 +141,7 @@ fn ic_variables_access_vector_from_matrix() {
 
     let parsed = parse(source).expect("Parsing failed");
 
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
 
@@ -201,7 +201,7 @@ fn err_bc_variable_access_before_declaration() {
         enf clk' = clk + 1";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -221,7 +221,7 @@ fn err_ic_variable_access_before_declaration() {
         let a = 1";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -241,7 +241,7 @@ fn err_variable_def_in_other_section() {
         enf clk' = clk + a";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     println!("{result:?}");
     assert!(result.is_err());
 
@@ -259,7 +259,7 @@ fn err_variable_def_in_other_section() {
         enf clk.last = a";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -279,7 +279,7 @@ fn err_bc_variable_vector_invalid_access() {
         enf clk' = clk + 1";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -299,7 +299,7 @@ fn err_ic_variable_vector_invalid_access() {
         enf clk' = clk + a[2]";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -318,7 +318,7 @@ fn err_bc_variable_matrix_invalid_access() {
         enf clk' = clk + 1";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 
     let source = "
@@ -334,7 +334,7 @@ fn err_bc_variable_matrix_invalid_access() {
         enf clk' = clk + 1";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }
 
@@ -353,7 +353,7 @@ fn err_ic_variable_matrix_invalid_access() {
         enf clk' = clk + a[1][3]";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 
     let source = "
@@ -369,6 +369,6 @@ fn err_ic_variable_matrix_invalid_access() {
         enf clk' = clk + a[2][0]";
 
     let parsed = parse(source).expect("Parsing failed");
-    let result = AirIR::new(&parsed);
+    let result = AirIR::new(parsed);
     assert!(result.is_err());
 }

--- a/parser/src/ast/periodic_columns.rs
+++ b/parser/src/ast/periodic_columns.rs
@@ -30,4 +30,8 @@ impl PeriodicColumn {
     pub fn values(&self) -> &[u64] {
         &self.values
     }
+
+    pub fn into_parts(self) -> (String, Vec<u64>) {
+        (self.name.into_name(), self.values)
+    }
 }

--- a/parser/src/ast/pub_inputs.rs
+++ b/parser/src/ast/pub_inputs.rs
@@ -27,4 +27,8 @@ impl PublicInput {
     pub fn size(&self) -> usize {
         self.size
     }
+
+    pub fn into_parts(self) -> (String, usize) {
+        (self.name.into_name(), self.size)
+    }
 }

--- a/parser/src/ast/random_values.rs
+++ b/parser/src/ast/random_values.rs
@@ -59,6 +59,10 @@ impl RandomValues {
     pub fn bindings(&self) -> &Vec<RandBinding> {
         &self.bindings
     }
+
+    pub fn into_parts(self) -> (String, u64, Vec<RandBinding>) {
+        (self.name.into_name(), self.size, self.bindings)
+    }
 }
 
 /// Declaration of a random value binding used in [RandomValues]. It is represented by a named
@@ -81,5 +85,9 @@ impl RandBinding {
 
     pub fn size(&self) -> u64 {
         self.size
+    }
+
+    pub fn into_parts(self) -> (String, u64) {
+        (self.name.into_name(), self.size)
     }
 }


### PR DESCRIPTION
This is the second of 4 PRs refactoring the IR, addressing https://github.com/0xPolygonMiden/air-script/issues/150.

The primary goals are:

- simplify & clarify the code
- reduce duplication
- simplify error handling

In this PR, the AST is consumed during the construction of the IR, which will reduce some cloning of data.