### PR TITLE
refactor(ir): move constraints and graph to ConstraintBuilder

### DIFF
--- a/ir/src/constraint_builder/boundary_constraints.rs
+++ b/ir/src/constraint_builder/boundary_constraints.rs
@@ -65,7 +65,7 @@ impl ConstraintBuilder {
                 let lhs = self.insert_trace_access(&trace_access)?;
 
                 // get the trace segment and domain of the boundary column access
-                let (lhs_segment, lhs_domain) = self.constraints.node_details(&lhs, domain)?;
+                let (lhs_segment, lhs_domain) = self.graph.node_details(&lhs, domain)?;
                 debug_assert!(
                    lhs_domain == domain,
                    "The boundary constraint's domain should be {lhs_domain:?}, but the domain {domain:?} was inferred by the graph",
@@ -74,7 +74,7 @@ impl ConstraintBuilder {
                 // add its expression to the constraints graph.
                 let rhs = self.insert_expr(constraint.value())?;
                 // get the trace segment and domain of the expression
-                let (rhs_segment, rhs_domain) = self.constraints.node_details(&rhs, domain)?;
+                let (rhs_segment, rhs_domain) = self.graph.node_details(&rhs, domain)?;
 
                 // ensure that the inferred trace segment and domain of the rhs expression can be
                 // applied to column against which the boundary constraint is applied.

--- a/ir/src/constraint_builder/expression.rs
+++ b/ir/src/constraint_builder/expression.rs
@@ -10,7 +10,7 @@ impl ConstraintBuilder {
     /// TODO: we can optimize this in the future in the case where lhs or rhs equals zero to just
     /// return the other expression.
     pub(crate) fn merge_equal_exprs(&mut self, lhs: NodeIndex, rhs: NodeIndex) -> NodeIndex {
-        self.constraints.insert_graph_node(Operation::Sub(lhs, rhs))
+        self.insert_graph_node(Operation::Sub(lhs, rhs))
     }
 
     /// Adds the expression to the graph and returns the [ExprDetails] of the constraint.
@@ -52,7 +52,7 @@ impl ConstraintBuilder {
                 let lhs = self.insert_expr(lhs)?;
                 let rhs = self.insert_expr(rhs)?;
                 // add the expression.
-                let node_index = self.constraints.insert_graph_node(Operation::Add(lhs, rhs));
+                let node_index = self.insert_graph_node(Operation::Add(lhs, rhs));
                 Ok(node_index)
             }
             Expression::Sub(lhs, rhs) => {
@@ -60,7 +60,7 @@ impl ConstraintBuilder {
                 let lhs = self.insert_expr(lhs)?;
                 let rhs = self.insert_expr(rhs)?;
                 // add the expression.
-                let node_index = self.constraints.insert_graph_node(Operation::Sub(lhs, rhs));
+                let node_index = self.insert_graph_node(Operation::Sub(lhs, rhs));
                 Ok(node_index)
             }
             Expression::Mul(lhs, rhs) => {
@@ -68,7 +68,7 @@ impl ConstraintBuilder {
                 let lhs = self.insert_expr(lhs)?;
                 let rhs = self.insert_expr(rhs)?;
                 // add the expression.
-                let node_index = self.constraints.insert_graph_node(Operation::Mul(lhs, rhs));
+                let node_index = self.insert_graph_node(Operation::Mul(lhs, rhs));
                 Ok(node_index)
             }
             Expression::Exp(lhs, rhs) => self.insert_exp_op(lhs, rhs),
@@ -80,11 +80,9 @@ impl ConstraintBuilder {
     /// Inserts the specified constant value into the graph and returns the resulting expression
     /// details.
     fn insert_inline_constant(&mut self, value: u64) -> Result<NodeIndex, SemanticError> {
-        let node_index = self
-            .constraints
-            .insert_graph_node(Operation::Value(Value::Constant(ConstantValue::Inline(
-                value,
-            ))));
+        let node_index = self.insert_graph_node(Operation::Value(Value::Constant(
+            ConstantValue::Inline(value),
+        )));
 
         Ok(node_index)
     }
@@ -104,9 +102,8 @@ impl ConstraintBuilder {
     ) -> Result<NodeIndex, SemanticError> {
         self.symbol_table.validate_trace_access(trace_access)?;
 
-        let node_index = self
-            .constraints
-            .insert_graph_node(Operation::Value(Value::TraceElement(*trace_access)));
+        let node_index =
+            self.insert_graph_node(Operation::Value(Value::TraceElement(*trace_access)));
         Ok(node_index)
     }
 
@@ -122,8 +119,7 @@ impl ConstraintBuilder {
         let lhs = self.insert_expr(lhs)?;
         // add exponent subexpression.
         let node_index = if let Expression::Const(rhs) = *rhs {
-            self.constraints
-                .insert_graph_node(Operation::Exp(lhs, rhs as usize))
+            self.insert_graph_node(Operation::Exp(lhs, rhs as usize))
         } else {
             Err(SemanticError::InvalidUsage(
                 "Non const exponents are only allowed inside list comprehensions".to_string(),
@@ -159,7 +155,7 @@ impl ConstraintBuilder {
                 let value = symbol.get_value(&access_type)?;
 
                 // add a value node in the graph.
-                let node_index = self.constraints.insert_graph_node(Operation::Value(value));
+                let node_index = self.insert_graph_node(Operation::Value(value));
 
                 Ok(node_index)
             }
@@ -190,7 +186,7 @@ impl ConstraintBuilder {
                         ListFoldingType::Sum(_) => Operation::Add(acc, expr),
                         ListFoldingType::Prod(_) => Operation::Mul(acc, expr),
                     };
-                    acc = self.constraints.insert_graph_node(op);
+                    acc = self.insert_graph_node(op);
                 }
 
                 Ok(acc)

--- a/ir/src/constraint_builder/integrity_constraints/mod.rs
+++ b/ir/src/constraint_builder/integrity_constraints/mod.rs
@@ -35,9 +35,8 @@ impl ConstraintBuilder {
 
                 // get the trace segment and domain of the constraint
                 // the default domain for integrity constraints is `EveryRow`
-                let (trace_segment, domain) = self
-                    .constraints
-                    .node_details(&root, ConstraintDomain::EveryRow)?;
+                let (trace_segment, domain) =
+                    self.graph.node_details(&root, ConstraintDomain::EveryRow)?;
 
                 // save the constraint information
                 self.insert_constraint(root, trace_segment.into(), domain)?;

--- a/ir/src/constraints/graph.rs
+++ b/ir/src/constraints/graph.rs
@@ -98,7 +98,7 @@ impl AlgebraicGraph {
     // --- PUBLIC MUTATORS ------------------------------------------------------------------------
     /// Insert the operation and return its node index. If an identical node already exists, return
     /// that index instead.
-    pub(super) fn insert_op(&mut self, op: Operation) -> NodeIndex {
+    pub(crate) fn insert_node(&mut self, op: Operation) -> NodeIndex {
         self.nodes.iter().position(|n| *n.op() == op).map_or_else(
             || {
                 // create a new node.

--- a/ir/src/constraints/mod.rs
+++ b/ir/src/constraints/mod.rs
@@ -50,12 +50,15 @@ pub(crate) struct Constraints {
 impl Constraints {
     // --- CONSTRUCTOR ----------------------------------------------------------------------------
 
-    /// TODO: these constraint vectors should be initialized to the proper length
-    pub fn new(num_trace_segments: usize) -> Self {
+    pub fn new(
+        graph: AlgebraicGraph,
+        boundary_constraints: Vec<Vec<ConstraintRoot>>,
+        integrity_constraints: Vec<Vec<ConstraintRoot>>,
+    ) -> Self {
         Self {
-            boundary_constraints: vec![Vec::new(); num_trace_segments],
-            integrity_constraints: vec![Vec::new(); num_trace_segments],
-            graph: AlgebraicGraph::default(),
+            graph,
+            boundary_constraints,
+            integrity_constraints,
         }
     }
 
@@ -111,37 +114,5 @@ impl Constraints {
     /// Returns the [AlgebraicGraph] representing all constraints and sub-expressions.
     pub fn graph(&self) -> &AlgebraicGraph {
         &self.graph
-    }
-
-    // --- MUTATORS -------------------------------------------------------------------------------
-
-    /// TODO: docs
-    pub(super) fn insert_graph_node(&mut self, op: Operation) -> NodeIndex {
-        self.graph.insert_op(op)
-    }
-
-    /// TODO: docs
-    pub(super) fn node_details(
-        &self,
-        index: &NodeIndex,
-        default_domain: ConstraintDomain,
-    ) -> Result<(TraceSegment, ConstraintDomain), SemanticError> {
-        self.graph.node_details(index, default_domain)
-    }
-
-    pub(super) fn insert_constraint(
-        &mut self,
-        node_idx: NodeIndex,
-        trace_segment: usize,
-        domain: ConstraintDomain,
-    ) {
-        let constraint_root = ConstraintRoot::new(node_idx, domain);
-
-        // add the constraint to the appropriate set of constraints.
-        if domain.is_boundary() {
-            self.boundary_constraints[trace_segment].push(constraint_root);
-        } else {
-            self.integrity_constraints[trace_segment].push(constraint_root);
-        }
     }
 }

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -11,8 +11,7 @@ use constraint_builder::{ConstrainedBoundary, ConstraintBuilder};
 
 pub mod constraints;
 use constraints::{
-    AlgebraicGraph, ConstraintDomain, ConstraintRoot, Constraints, Operation, CURRENT_ROW,
-    MIN_CYCLE_LENGTH,
+    AlgebraicGraph, ConstraintDomain, ConstraintRoot, Constraints, CURRENT_ROW, MIN_CYCLE_LENGTH,
 };
 pub use constraints::{IntegrityConstraintDegree, NodeIndex};
 


### PR DESCRIPTION
This PR moves the graph and constraints to `ConstraintBuilder`.