### PR TITLE
Write decoder constraints in AirScript

### DIFF
--- a/constraints/miden-vm/decoder.air
+++ b/constraints/miden-vm/decoder.air
@@ -2,6 +2,9 @@ mod DecoderAir
 
 ### Constants and periodic columns ################################################################
 
+const HASHER_LINEAR_HASH = 3
+const HASHER_RETURN_HASH = 1
+
 periodic_columns:
     cycle_row_0: [1, 0, 0, 0, 0, 0, 0, 0]
     cycle_row_7: [0, 0, 0, 0, 0, 0, 0, 1]
@@ -17,77 +20,77 @@ fn binary_not(value: scalar) -> scalar:
 # Returns the f_join operation flag which is set when JOIN control operation is executed.
 #
 # Flag degree: 6
-fn f_join(b: vector[7]) -> scalar:
+fn get_f_join(b: vector[7]) -> scalar:
     return b[6] & !b[5] & b[4] & b[3] & !b[2] & b[1]
 
 
 # Returns the f_split operation flag which is set when SPLIT control operation is executed.
 #
 # Flag degree: 6
-fn f_split(b: vector[7]) -> scalar:
+fn get_f_split(b: vector[7]) -> scalar:
     return b[6] & !b[5] & b[4] & b[3] & b[2] & !b[1]
 
 
 # Returns the f_loop operation flag which is set when LOOP control operation is executed.
 #
 # Flag degree: 6
-fn f_loop(b: vector[7]) -> scalar:
+fn get_f_loop(b: vector[7]) -> scalar:
     return b[6] & !b[5] & b[4] & b[3] & b[2] & b[1]
 
 
 # Returns the f_repeat operation flag which is set when REPEAT operation is executed.
 #
 # Flag degree: 4
-fn f_repeat(b: vector[7], extra: scalar) -> scalar:
+fn get_f_repeat(b: vector[7], extra: scalar) -> scalar:
     return extra & b[4] & !b[3] & b[2]
 
 
 # Returns the f_span operation flag which is set when SPAN operation is executed.
 #
 # Flag degree: 6
-fn f_span(b: vector[7]) -> scalar:
+fn get_f_span(b: vector[7]) -> scalar:
     return b[6] & !b[5] & b[4] & b[3] & !b[2] & !b[1]
 
 
 # Returns the f_respan operation flag which is set when RESPAN operation is executed.
 #
 # Flag degree: 4
-fn f_respan(b: vector[7], extra: scalar) -> scalar:
+fn get_f_respan(b: vector[7], extra: scalar) -> scalar:
     return extra & b[4] & b[3] & !b[2]
 
 
 # Returns the f_call operation flag which is set when CALL control operation is executed.
 #
 # Flag degree: 4
-fn f_call(b: vector[7], extra: scalar) -> scalar:
+fn get_f_call(b: vector[7], extra: scalar) -> scalar:
     return extra & !b[4] & b[3] & b[2]
 
 
 # Returns the f_syscall operation flag which is set when SYSCALL control operation is executed.
 #
 # Flag degree: 4
-fn f_syscall(b: vector[7], extra: scalar) -> scalar:
+fn get_f_syscall(b: vector[7], extra: scalar) -> scalar:
     return extra & !b[4] & b[3] & !b[2]
 
 
 # Returns the f_end operation flag which is set when END operation is executed.
 #
 # Flag degree: 4
-fn f_end(b: vector[7], extra: scalar) -> scalar:
+fn get_f_end(b: vector[7], extra: scalar) -> scalar:
     return extra & b[4] & !b[3] & !b[2]
 
 
 # Returns the f_halt operation flag which is set when HALT operation is executed.
 #
 # Flag degree: 4
-fn f_halt(b: vector[7], extra: scalar) -> scalar:
+fn get_f_halt(b: vector[7], extra: scalar) -> scalar:
     return extra & b[4] & b[3] & b[2]
 
 
 # Returns the f_push operation flag which is set when PUSH operation is executed.
 #
 # Flag degree: 4
-fn f_push(b: vector[7], extra: scalar) -> scalar:
+fn get_f_push(b: vector[7], extra: scalar) -> scalar:
     return extra & !b[4] & !b[3] & b[2]
 
 
@@ -95,22 +98,22 @@ fn f_push(b: vector[7], extra: scalar) -> scalar:
 # LOOP, REPEAT, SPAN, RESPAN, CALL, SYSCALL, END, HALT) is being executed.
 #
 # Flag degree: 4
-fn f_ctrl(b: vector[7], extra: scalar) -> scalar:
+fn get_f_ctrl(b: vector[7], extra: scalar) -> scalar:
     # flag for SPAN, JOIN, SPLIT, LOOP
     let f_sjsl = b[6] & !b[5] & b[4] & b[3]
 
     # flag for END, REPEAT, RESPAN, HALT
     let f_errh = b[6] & b[5] & b[4]
 
-    return f_sjsl + f_errh + f_call(b, extra) + f_syscall(b, extra)
+    return f_sjsl + f_errh + get_f_call(b, extra) + get_f_syscall(b, extra)
 
 
 # Returns f_ctrli flag which is set to 1 when a control flow operation that signifies the 
 # initialization of a control block (JOIN, SPLIT, LOOP, CALL, SYSCALL) is being executed on the VM.
 #
 # Flag degree: 6
-fn f_ctrli(b: vector[7], extra: scalar) -> scalar:
-    return f_join(b) + f_split(b) + f_loop(b) + f_call(b, extra) + f_syscall(b, extra)
+fn get_f_ctrli(b: vector[7], extra: scalar) -> scalar:
+    return get_f_join(b) + get_f_split(b) + get_f_loop(b) + get_f_call(b, extra) + get_f_syscall(b, extra)
 
 
 # Returns transition label, composed of the operation label and the periodic columns that uniquely 
@@ -154,25 +157,27 @@ ev is_unchanged([column]):
 # Enforces decoder general constraints.
 #
 # Constraint degree: 9
-ev general_constraints([addr, op_bits[7], hasher[8], is_span, s0], [extra]):
-    let op_bits_next = [op_bits[0]', op_bits[1]', op_bits[2]', op_bits[3]', op_bits[4]', op_bits[5]', op_bits[6]']
-    let extra_next = extra'
+ev general_constraints([addr, op_bits[7], hasher[8], is_span, s0, extra]):
+    # Get flags required for the general constraints
+    let f_repeat = get_f_repeat(op_bits, extra)
+    let f_end = get_f_end(op_bits, extra)
+    let f_halt = get_f_halt(op_bits, extra)
 
     # Enforce that `extra` column is set to 1 when op_bits[6] = 1 and op_bits[5] = 1
     enf extra = 1 when op_bits[6] & op_bits[5]
 
     # Enforce that when SPLIT or LOOP operation is executed, the top of the operand stack must 
     # contain a binary value.
-    enf is_binary([s0]) when f_split(op_bits) | f_loop(op_bits)
+    enf is_binary([s0]) when get_f_split(op_bits) | get_f_loop(op_bits)
 
     # Enforce that When REPEAT operation is executed, the value at the top of the operand stack 
     # must be 1.
-    enf s0 = 1 when f_repeat(op_bits, extra)
+    enf s0 = 1 when f_repeat
 
     # Enforce that when REPEAT operation is executed, the value in hasher[4] column (the 
     # is_loop_body flag), must be set to 1. This ensures that REPEAT operation can be executed only
     # inside a loop.
-    enf hasher[4] = 1 when f_repeat(op_bits, extra)
+    enf hasher[4] = 1 when f_repeat
 
     # Enforce that when RESPAN operation is executed, we need to make sure that the block ID is 
     # incremented by 8.
@@ -181,18 +186,18 @@ ev general_constraints([addr, op_bits[7], hasher[8], is_span, s0], [extra]):
     # Enforce that when END operation is executed and we are exiting a loop block (i.e., is_loop, 
     # value which is stored in hasher[5], is 1), the value at the top of the operand stack must be 
     # 0.
-    enf s0 = 0 when f_end(op_bits, extra) & hasher[5]
+    enf s0 = 0 when f_end & hasher[5]
 
     # Enforce that when END operation is executed and the next operation is REPEAT, values in 
     # hasher[0], ..., hasher[4] (the hash of the current block and the is_loop_body flag) must be 
     # copied to the next row.
-    enf is_unchanged([hasher[i]]) for i in 0..5 when f_end(op_bits, extra) & f_repeat(op_bits_next, extra_next)
+    enf is_unchanged([hasher[i]]) for i in 0..5 when f_end & get_f_repeat(op_bits', extra')
 
     # Enforce that a HALT instruction can be followed only by another HALT instruction.
-    enf f_halt(op_bits, extra) * !f_halt(op_bits_next, extra_next) = 0
+    enf f_halt * !get_f_halt(op_bits', extra') = 0
 
     # Enforce that when a HALT operation is executed, block address column (addr) must be 0.
-    enf addr = 0 when f_halt(op_bits, extra)
+    enf addr = 0 when f_halt
 
     # Enforce that values in op_bits columns must be binary.
     enf is_binary([b]) for b in op_bits
@@ -200,144 +205,176 @@ ev general_constraints([addr, op_bits[7], hasher[8], is_span, s0], [extra]):
     # Enforce that when the value in is_span column is set to 1, control flow operations cannot be 
     # executed on the VM, but when is_span flag is 0, only control flow operations can be executed
     # on the VM.
-    enf 1 - is_span - f_ctrl = 0
+    enf 1 - is_span - get_f_ctrl(op_bits, extra) = 0
 
 
-# Enforces constraint for computing block hashes.
+# Enforces the constraint for computing block hashes.
 #
 # Constraint degree: 8
-ev block_hash_computation_constraints([addr, op_bits[7], hasher[8]], [extra, p[4]]):
-    # Operation label for HASHER_LINER_HASH operation.
-    let op_linhash = 3
-
-    # Operation label for HASHER_RETURN_HASH operation.
-    let op_hout = 1
+ev block_hash_computation_constraints([addr, op_bits[7], hasher[8], extra], [p[4]]):
+    # Get flags required for the block hash conputation constraint
+    let f_ctrli = get_f_ctrli(op_bits, extra)
+    let f_span = get_f_span(op_bits)
+    let f_respan = get_f_respan(op_bits, extra)
+    let f_end = get_f_end(op_bits, extra)
 
     # Label specifying that we are starting a new hash computation.
-    let m_bp = get_transition_label(op_linhash)
+    let m_bp = get_transition_label(HASHER_LINEAR_HASH)
 
     # Label specifying that we are absorbing the next sequence of 8 elements into an ongoing hash 
     # computation.
-    let m_abp = get_transition_label(op_linhash)
+    let m_abp = get_transition_label(HASHER_LINEAR_HASH)
 
     # Label specifying that we are reading the result of a hash computation.
-    let m_hout = get_transition_label(op_hout)
+    let m_hout = get_transition_label(HASHER_RETURN_HASH)
 
-    # `alpha` is inherited random values array.
-    let rate_sum = sum([alpha[i + 8] * hasher[i] for i in 0..8])
-    let digest_sum = sum([alpha[i + 8] * hasher[i] for i in 0..4])
+    # `alpha` is the global random values array.
+    let rate_sum = sum([$alpha[i + 8] * hasher[i] for i in 0..8])
+    let digest_sum = sum([$alpha[i + 8] * hasher[i] for i in 0..4])
 
     # Variable for initiating a hasher with address addr' and absorbing 8 elements from the hasher
     # state (hasher[0], ..., hasher[7]) into it.
-    let h_init = alpha[0] + alpha[1] * m_bp + alpha[2] * addr' + rate_sum
+    let h_init = $alpha[0] + $alpha[1] * m_bp + $alpha[2] * addr' + rate_sum
 
     # Variable for the absorption.
-    let h_abp = alpha[0] + alpha[1] * m_abp + alpha[2] * addr' + rate_sum
+    let h_abp = $alpha[0] + $alpha[1] * m_abp + $alpha[2] * addr' + rate_sum
 
-    # Variable for the result
-    let h_res = alpha[0] + alpha[1] * m_hout + alpha[2] * (addr + 7) + digest_sum
+    # Variable for the result.
+    let h_res = $alpha[0] + $alpha[1] * m_hout + $alpha[2] * (addr + 7) + digest_sum
 
     # Opcode value of the opcode being executed on the virtual machine.
     let opcode_value = sum([op_bits[i] * 2^i for i in 0..7])
-    
+
     # When a control block initializer operation (JOIN, SPLIT, LOOP, CALL, SYSCALL) is executed, a 
     # new hasher is initialized and the contents of hasher[0], ..., hasher[7] are absorbed into the
     # hasher. 
-    let u_ctrli = f_ctrli(op_bits, extra) * (h_init + alpha[5] * opcode_value)
+    #
+    # Value degree: 7
+    let u_ctrli = f_ctrli * (h_init + $alpha[5] * opcode_value)
 
     # When SPAN operation is executed, a new hasher is initialized and contents of 
     # hasher[0], ..., hasher[7] are absorbed into the hasher.
-    let u_span = f_span(op_bits) * h_init
+    #
+    # Value degree: 7
+    let u_span = f_span * h_init
 
     # When RESPAN operation is executed, contents of hasher[0], ..., hasher[7] (which contain the 
     # new operation batch) are absorbed into the hasher.
-    let u_respan = f_respan(op_bits, extra) * h_abp
+    #
+    # Value degree: 5
+    let u_respan = f_respan * h_abp
 
     # When END operation is executed, the hash result is copied into registers 
     # hasher[0], ..., hasher[3].
-    let u_end = f_end(op_bits, extra) * h_res
+    #
+    # Value degree: 5
+    let u_end = f_end * h_res
 
-    # Enforce the block hash computation constraint.
-    enf p[0]' * (u_ctrli + u_span + u_respan + u_end + 1 - (f_ctrli(op_bits, extra) + 
-        f_span(op_bits) + f_respan(op_bits, extra) + f_end(op_bits, extra))) = p[0]
+    # Enforce the block hash computation constraint. We need to add 1 and subtract the sum of the 
+    # relevant operation flags to ensure that when none of the flags is set to 1, the above 
+    # constraint reduces to p[0]' = p[0].
+    enf p[0]' * (u_ctrli + u_span + u_respan + u_end + 1 - 
+        (f_ctrli + f_span + f_respan + f_end)) = p[0]
 
 
-# Enforces constraint for updating the block stack table.
+# Enforces the constraint for updating the block stack table.
 #
 # Constraint degree: 8
-ev block_stack_table_constraints([addr, op_bits[7], hasher[8], s0], [extra, p[4]]):
+ev block_stack_table_constraints([addr, op_bits[7], hasher[8], s0, extra], [p[4]]):
+    # Get flags required for the block stack table constraint
+    let f_join = get_f_join(op_bits)
+    let f_split = get_f_split(op_bits)
+    let f_loop = get_f_loop(op_bits)
+    let f_span = get_f_span(op_bits)
+    let f_respan = get_f_respan(op_bits, extra)
+    let f_end = get_f_end(op_bits, extra)
+
     # When JOIN operation is executed, row (addr', addr, 0) is added to the block stack table.
-    let v_join = f_join(op_bits) * (alpha[0] + alpha[1] * addr' + alpha[2] * addr)
+    let v_join = f_join * ($alpha[0] + $alpha[1] * addr' + $alpha[2] * addr)
 
     # When SPLIT operation is executed, row (addr', addr, 0) added to the block stack table.
-    let v_split = f_split(op_bits) * (alpha[0] + alpha[1] * addr' + alpha[2] * addr)
+    let v_split = f_split * ($alpha[0] + $alpha[1] * addr' + $alpha[2] * addr)
 
     # When LOOP operation is executed, row (addr', addr, 1) is added to the block stack table if 
     # the value at the top of the operand stack is 1, and row (addr', addr, 0) is added to the 
     # block stack table if the value at the top of the operand stack is 0.
-    let v_loop = f_loop(op_bits) * (alpha[0] + alpha[1] * addr' + alpha[2] * addr + alpha[3] * s0)
+    let v_loop = f_loop * ($alpha[0] + $alpha[1] * addr' + $alpha[2] * addr + $alpha[3] * s0)
 
     # When SPAN operation is executed, row (addr', addr, 0) is added to the block stack table.
-    let v_span = f_span(op_bits) * (alpha[0] + alpha[1] * addr' + alpha[2] * addr)
+    let v_span = f_span * ($alpha[0] + $alpha[1] * addr' + $alpha[2] * addr)
 
     # When RESPAN operation is executed, row (addr, hasher[1]', 0) is removed from the block stack 
     # table, and row (addr', hasher[1]', 0) is added to the table. The prover sets the value of 
     # register hasher[1] at the next row to the ID of the parent block:
-    let u_respan = f_respan(op_bits, extra) * (alpha[0] + alpha[1] * addr + alpha[2] * hasher[1]')
-    let v_respan = f_respan(op_bits, extra) * (alpha[0] + alpha[1] * addr' + alpha[2] * hasher[1]')
+    let u_respan = f_respan * ($alpha[0] + $alpha[1] * addr + $alpha[2] * hasher[1]')
+    let v_respan = f_respan * ($alpha[0] + $alpha[1] * addr' + $alpha[2] * hasher[1]')
 
     # When END operation is executed, row (addr, addr', hasher[5]) is removed from the block span 
     # table. Register hasher[5] contains the is_loop flag.
-    let u_end = f_end(op_bits, extra) * 
-        (alpha[0] + alpha[1] * addr + alpha[2] * addr' + alpha[3] * hasher[5])
+    let u_end = f_end * 
+            ($alpha[0] + $alpha[1] * addr + $alpha[2] * addr' + $alpha[3] * hasher[5])
 
-    # Enforce the block stack table constraint.
-    # TODO: do proper line wrapping
-    enf p[1]' * (u_end + u_respan + 1 - (f_end(op_bits, extra) + f_respan(op_bits, extra)))
-        = p[1] * (v_join + v_split + v_loop + v_span + v_respan + 1 - (f_join(op_bits) + 
-        f_split(op_bits) + f_loop(op_bits) + f_span(op_bits) + 
-        f_respan(op_bits, extra)))
+    # Enforce the block stack table constraint. We need to add 1 and subtract the sum of the 
+    # relevant operation flags from each side to ensure that when none of the flags is set to 1, 
+    # the above constraint reduces to p[1]' = p[1]
+    enf p[1]' * (u_end + u_respan + 1 - (f_end + f_respan)) = 
+            p[1] * (v_join + v_split + v_loop + v_span + v_respan + 1 - 
+            (f_join + f_split + f_loop + f_span + f_respan))
 
 
-# Enforces constraint for updating the block hash table.
+# Enforces the constraint for updating the block hash table.
 #
 # Constraint degree: 9
-ev block_hash_table_constraints([addr, op_bits[7], hasher[8], s0], [extra, p[4]]):
-    let op_bits_next = [op_bits[0]', op_bits[1]', op_bits[2]', op_bits[3]', op_bits[4]', op_bits[5]', op_bits[6]']
-    let extra_next = extra'
+ev block_hash_table_constraints([addr, op_bits[7], hasher[8], s0, extra], [p[4]]):
+    # Get flags required for the block hash table constraint
+    let f_join = get_f_join(op_bits)
+    let f_split = get_f_split(op_bits)
+    let f_loop = get_f_loop(op_bits)
+    let f_end = get_f_end(op_bits, extra)
+    let f_repeat = get_f_repeat(op_bits, extra)
 
     # Values representing left and right children of a block.
-    let ch1 = alpha[0] + alpha[1] * addr' + sum([alpha[i + 2] * hasher[i] for i in 0..4])
-    let ch2 = alpha[0] + alpha[1] * addr' + sum([alpha[i + 2] * hasher[i + 4] for i in 0..4])
+    let ch1 = $alpha[0] + $alpha[1] * addr' + sum([$alpha[i + 2] * hasher[i] for i in 0..4])
+    let ch2 = $alpha[0] + $alpha[1] * addr' + sum([$alpha[i + 2] * hasher[i + 4] for i in 0..4])
 
     # Value representing the result of hash computation.
-    let bh = alpha[0] + alpha[1] * addr + sum([alpha[i + 2] * hasher[i]]) + alpha[7] * hasher[4]
+    let bh = $alpha[0] + $alpha[1] * addr + sum([$alpha[i + 2] * hasher[i]]) + $alpha[7] * hasher[4]
 
     # When JOIN operation is executed, hashes of both child nodes are added to the block hash 
-    # table.
-    let v_join = f_join(op_bits) * (ch1 + alpha[6]) * ch2
+    # table. We add alpha[6] term to the first child value to differentiate it from the second 
+    # child (i.e., this sets is_first_child to 1).
+    let v_join = f_join * (ch1 + $alpha[6]) * ch2
 
     # When SPLIT operation is executed and the top of the stack is 1, hash of the true branch is 
     # added to the block hash table, but when the top of the stack is 0, hash of the false branch
     # is added to the block hash table.
-    let v_split = f_split(op_bits) * (s0 * ch1 + (1 - s0) * ch2)
+    let v_split = f_split * (s0 * ch1 + (1 - s0) * ch2)
 
     # When LOOP operation is executed and the top of the stack is 1, hash of loop body is added to
-    # the block hash table.
-    let v_loop = f_loop(op_bits) * s0 * (ch1 + alpha[7])
+    # the block hash table. We add alpha[7] term to indicate that the child is a body of a loop. 
+    # The below also means that if the top of the stack is 0, nothing is added to the block hash 
+    # table as the expression evaluates to 0.
+    let v_loop = f_loop * s0 * (ch1 + $alpha[7])
 
-    # When REPEAT operation is executed, hash of loop body is added to the block hash table.
-    let v_repeat = f_repeat(op_bits, extra) * (ch1 + alpha[7])
+    # When REPEAT operation is executed, hash of loop body is added to the block hash table. We add
+    # alpha[7] term to indicate that the child is a body of a loop.
+    let v_repeat = f_repeat * (ch1 + $alpha[7])
 
     # When END operation is executed, hash of the completed block is removed from the block hash 
-    # table.
-    let u_end = f_end(op_bits, extra) * 
-        (bh + alpha[6] * (1 - (f_end(op_bits_next, extra_next) + f_repeat(op_bits_next, extra_next))))
+    # table. However, we also need to differentiate between removing the first and the second child
+    # of a join block. We do this by looking at the next operation. Specifically, if the next 
+    # operation is neither END nor REPEAT we know that another block is about to be executed, and 
+    # thus, we have just finished executing the first child of a join block. Thus, if the next 
+    # operation is neither END nor REPEAT we need to set the term for alpha[6] coefficient to 1 as 
+    # shown below.
+    let u_end = f_end * 
+        (bh + $alpha[6] * (1 - (get_f_end(op_bits', extra') + get_f_repeat(op_bits', extra'))))
 
-    # Enforce the block hash table constraint.
-    enf p[2]' * (u_end + 1 - f_end(op_bits, extra)) = 
-        p[2] * (v_join + v_split + v_loop + v_repeat + 1 - 
-        (f_join(op_bits) + f_split(op_bits) + f_loop(op_bits) + f_repeat(op_bits, extra)))
+    # Enforce the block hash table constraint. We need to add 1 and subtract the sum of the 
+    # relevant operation flags from each side to ensure that when none of the flags is set to 1, 
+    # the above constraint reduces to p[2]' = p[2]
+    enf p[2]' * (u_end + 1 - f_end) = 
+        p[2] * (v_join + v_split + v_loop + v_repeat + 1 - (f_join + f_split + f_loop + f_repeat))
 
     # TODO: add boundary constraints to the p[2] column.
 
@@ -345,22 +382,24 @@ ev block_hash_table_constraints([addr, op_bits[7], hasher[8], s0], [extra, p[4]]
 # Enforce that values in is_span column are set correctly.
 #
 # Constraint degree: 7
-ev inspan_column_constraints([op_bits[7], is_span], [extra]):
-    let op_bits_next = [op_bits[0]', op_bits[1]', op_bits[2]', op_bits[3]', op_bits[4]', op_bits[5]', op_bits[6]']
-    let extra_next = extra'
+ev inspan_column_constraints([op_bits[7], is_span, extra]):
+    # Get flags required for the inspan column constraint
+    let f_span = get_f_span(op_bits)
+    let f_respan = get_f_respan(op_bits, extra)
+    let f_respan_next = get_f_respan(op_bits', extra')
+    let f_end_next = get_f_end(op_bits', extra')
 
     # Enforce that when executing SPAN or RESPAN operation, the next value in is_span column must 
     # be set to 1.
-    enf (f_span(op_bits) + f_respan(op_bits, extra)) * binary_not(is_span') = 0
+    enf (f_span + f_respan) * binary_not(is_span') = 0
 
     # Enforce that when the next operation is END or RESPAN, the next value in is_span column must 
     # be set 0.
-    enf (f_end(op_bits_next, extra_next) + f_respan(op_bits_next, extra_next)) * is_span' = 0
+    enf (f_end_next + f_respan_next) * is_span' = 0
 
     # Enforce that in all other cases, the value in is_span column must be copied over to the next 
     # row.
-    (1 - f_span(op_bits) - f_respan(op_bits, extra) - f_end(op_bits_next, extra_next) - 
-        f_respan(op_bits_next, extra_next)) * (is_span' - is_span) = 0
+    enf (1 - f_span - f_respan - f_end_next - f_respan_next) * (is_span' - is_span) = 0
 
     # TODO: add boundary constraint for is_span column.
 
@@ -378,61 +417,65 @@ ev block_address_constraints([addr, is_span]):
 # Enforce that values in group_count column are set correctly.
 #
 # Constraint degree: 7
-ev group_count_constraints([op_bits[7], hasher[8], is_span, group_count], [extra]):
-    let op_bits_next = [op_bits[0]', op_bits[1]', op_bits[2]', op_bits[3]', op_bits[4]', op_bits[5]', op_bits[6]']
-    let extra_next = extra'
-    
+ev group_count_constraints([op_bits[7], hasher[8], is_span, group_count, extra]):
+    # Get value of the f_push flag
+    let f_push = get_f_push(op_bits, extra)
+
     # Enforce that inside a span block, group count can either stay the same or decrease by one.
     enf is_span * (group_count' - group_count) * (group_count' - group_count - 1) = 0
     
     # Enforce that when group count is decremented inside a span block, either hasher[0] must be 0 
     # (we consumed all operations in a group) or we must be executing PUSH operation.
-    enf is_span * (group_count' - group_count) * (1 - f_push(op_bits, extra)) * hasher[0] = 0
+    enf is_span * (group_count' - group_count) * (1 - f_push) * hasher[0] = 0
 
     # Enforce that when executing a SPAN, a RESPAN, or a PUSH operation, group count must be 
     # decremented by 1.
-    enf (f_span(op_bits) + f_respan(op_bits, extra) + f_push(op_bits, extra)) * 
+    enf (f_span(op_bits) + get_f_respan(op_bits, extra) + f_push) * 
         (group_count' - group_count - 1) = 0
 
     # Enforce that if the next operation is either an END or a RESPAN, group count must remain the 
     # same.
-    enf (group_count' - group_count) * (f_end(op_bits_next, extra_next) + f_respan(op_bits_next, extra_next)) = 0
+    enf (group_count' - group_count) * 
+        (get_f_end(op_bits', extra') + get_f_respan(op_bits', extra')) = 0
 
     # Enforce that when an END operation is executed, group count must be 0.
-    enf f_end(op_bits, extra) * group_count = 0
+    enf get_f_end(op_bits, extra) * group_count = 0
 
 
 # Enforce that register hasher[0], which is used to keep track of operations to be executed in the 
 # current operation group, is set correctly.
 #
 # Constraint degree: 7
-ev op_group_decoding_constraints([op_bits[7], is_span, group_count, op_index], [extra]):
-    let op_bits_next = [op_bits[0]', op_bits[1]', op_bits[2]', op_bits[3]', op_bits[4]', op_bits[5]', op_bits[6]']
-    let extra_next = extra'
-    
+ev op_group_decoding_constraints([op_bits[7], is_span, group_count, op_index, extra]):
+    # opcode value
     let op = sum([op_bits[i] * 2^i for i in 0..7])
+
+    # Flag which is set to 1 when the group count within a span block does not change. We multiply 
+    # it by sp' to make sure the flag is 0 when we are about to end decoding of an operation batch. 
     let f_sgc = is_span * is_span' * (1 - group_count' + group_count)
 
     # Enforce that when a SPAN, a RESPAN, or a PUSH operation is executed or when the group count 
     # does not change, the value in hasher[0] should be decremented by the value of the opcode in 
     # the next row.
-    enf (f_span(op_bits) + f_respan(op_bits, extra) + f_push(op_bits, extra) + f_sgc) * 
+    enf (f_span(op_bits) + get_f_respan(op_bits, extra) + get_f_push(op_bits, extra) + f_sgc) * 
         (hasher[0] - hasher[0]' * 2^7 - op_index') = 0
 
     # Enforce that when we are in a span block and the next operation is END or RESPAN, the current
     # value in hasher[0] column must be 0.
-    enf is_span * (f_end(op_bits_next, extra_next) * f_respan(op_bits_next, extra_next)) * hasher[0] = 0
+    enf is_span * (get_f_end(op_bits', extra') * get_f_respan(op_bits', extra')) * hasher[0] = 0
 
 
 # Enforce that the values in op_index column are set correctly.
 #
 # Constraint degree: 9
-ev op_index_constraints([op_bits[7], is_span, group_count, op_index], [extra]):
-    let ng = group_count' - group_count - f_push(op_bits, extra)
+ev op_index_constraints([op_bits[7], is_span, group_count, op_index, extra]):
+    # ng is set to 1 when we are about to start executing a new operation group (i.e., group count 
+    # is decremented but we did not execute a PUSH operation).
+    let ng = group_count' - group_count - get_f_push(op_bits, extra)
 
     # Enforce that when executing SPAN or RESPAN operations the next value of op_index must be set 
     # to 0.
-    enf (f_span(op_bits) + f_respan(op_bits, extra)) * op_index' = 0
+    enf (f_span(op_bits) + get_f_respan(op_bits, extra)) * op_index' = 0
 
     # Enforce that when starting a new operation group inside a span block, the next value of 
     # op_index must be set to 0.
@@ -449,25 +492,30 @@ ev op_index_constraints([op_bits[7], is_span, group_count, op_index], [extra]):
 # Enforce that values in operation batch flag columns (denoted op_batch_flags[]) are set correctly.
 #
 # Constraint degree: 6
-ev op_batch_flag_constraints([op_bits[7], hasher[8], op_batch_flags[3]], [extra]):
+ev op_batch_flag_constraints([op_bits[7], hasher[8], op_batch_flags[3], extra]):
+    # Get flags required for the op batch flag constraints
+    let f_g1 = get_f_g1(op_batch_flags)
+    let f_g2 = get_f_g2(op_batch_flags)
+    let f_g4 = get_f_g4(op_batch_flags)
+
     # Enforce that all batch flags are binary.
     enf is_binary(bc) for bc in op_batch_flags
 
     # Enforce that when SPAN or RESPAN operations is executed, one of the batch flags must be set 
     # to 1.
-    (f_span(op_bits) + f_respan(op_bits, extra)) - (get_f_g1(op_batch_flags) + 
-        get_f_g2(op_batch_flags) + get_f_g4(op_batch_flags) + get_f_g8(op_batch_flags)) = 0
+    enf (f_span(op_bits) + get_f_respan(op_bits, extra)) - 
+        (f_g1 + f_g2 + f_g4 + get_f_g8(op_batch_flags)) = 0
 
     # Enforce that when we have at most 4 groups in a batch, registers h[4], ..., h[7] should be 
     # set to 0's.
-    enf (get_f_g1(op_batch_flags) + get_f_g2(op_batch_flags) + get_f_g4(op_batch_flags)) * hasher[i] = 0 for i in 4..8
+    enf (f_g1 + f_g2 + f_g4) * hasher[i] = 0 for i in 4..8
 
     # Enforce that When we have at most 2 groups in a batch, registers h[2] and h[3] should also be
     # set to 0's.
-    (get_f_g1(op_batch_flags) + get_f_g2(op_batch_flags)) * hasher[i] = 0 for i in 2..4
+    enf (f_g1 + f_g2) * hasher[i] = 0 for i in 2..4
 
     # Enforce that when we have at most 1 groups in a batch, register h[1] should also be set to 0.
-    enf get_f_g1(op_batch_flags) * hasher[1] = 0
+    enf f_g1 * hasher[1] = 0
 
 
 # Enforce that all operation groups in a given batch are consumed before a new batch is started 
@@ -475,60 +523,72 @@ ev op_batch_flag_constraints([op_bits[7], hasher[8], op_batch_flags[3]], [extra]
 # operation).
 #
 # Constraint degree: 9
-ev op_group_table_constraints([addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0], [extra, p[4]]):
+ev op_group_table_constraints([addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0, extra], [p[4]]):
+    # Get value of the f_push flag
+    let f_push = get_f_push(op_bits, extra)
+
     # Values of the rows to be added to the op group table when a SPAN or a RESPAN operation is 
     # executed.
-    let v_i = alpha[0] + alpha[1] * addr' + alpha[2] * (group_count - i) + alpha[3] * hasher[i]
+    let v_i = $alpha[0] + $alpha[1] * addr' + $alpha[2] * (group_count - i) + $alpha[3] * hasher[i]
 
     # Row value for group in hasher[1] to be added to the op group table when a SPAN or a RESPAN 
     # operation is executed.
-    let v_1 = alpha[0] + alpha[1] * addr' + alpha[2] * (group_count - 1) + alpha[3] * hasher[1]
+    let v_1 = $alpha[0] + $alpha[1] * addr' + $alpha[2] * (group_count - 1) + $alpha[3] * hasher[1]
 
-    let prod_v_3 = prod([alpha[0] + alpha[1] * addr' + alpha[2] * (group_count - i) + alpha[3] * hasher[i] for i in 1..4])
-    let prod_v_7 = prod([alpha[0] + alpha[1] * addr' + alpha[2] * (group_count - i) + alpha[3] * hasher[i] for i in 1..8])
+    let prod_v_3 = prod([$alpha[0] + 
+                         $alpha[1] * addr' + 
+                         $alpha[2] * (group_count - i) + 
+                         $alpha[3] * hasher[i] for i in 1..4])
+
+    let prod_v_7 = prod([$alpha[0] + 
+                         $alpha[1] * addr' + 
+                         $alpha[2] * (group_count - i) + 
+                         $alpha[3] * hasher[i] for i in 1..8])
 
     # The value of the row to be removed from the op group table.
-    let u = alpha[0] + alpha[1] * addr + alpha[2] * group_count + alpha[3] * 
-        ((hasher[0]' * 2^7 + op_index') * 
-        (1 - f_push(op_bits, extra) + s0' * f_push(op_bits, extra))) = 0
+    let u = $alpha[0] + $alpha[1] * addr + $alpha[2] * group_count + $alpha[3] * 
+        ((hasher[0]' * 2^7 + op_index') * (1 - f_push + s0' * f_push)) = 0
     
     # A flag which is set to 1 when a group needs to be removed from the op group table.
     let f_dg = is_span * (group_count' - group_count)
 
-    # Enforce the constraint for updating op group table
+    # Enforce the constraint for updating op group table. The constraint specifies that when SPAN 
+    # or RESPAN operations are executed, we add between 1 and 7 groups to the op group table, and 
+    # when group count is decremented inside a span block, we remove a group from the op group 
+    # table.
     enf p[3]' * (f_dg * u + 1 - f_dg) = 
         p[3] * (get_f_g2(op_batch_flags) * v_1 + get_f_g4(op_batch_flags) * 
         prod_v_3 + get_f_g8(op_batch_flags) * 
-        prod_v_7 - 1 + (f_span(op_bits) + f_respan(op_bits, extra)))
+        prod_v_7 - 1 + (f_span(op_bits) + get_f_respan(op_bits, extra)))
     
 
 # Enforces proper decoding of span blocks.
 #
 # Constraint degree: 9
-ev span_block_constraints([addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0], [extra, p[4]]):
-    enf inspan_column_constraints([op_bits, is_span], [extra])
+ev span_block_constraints([addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0, extra], [p[4]]):
+    enf inspan_column_constraints([op_bits, is_span, extra])
     enf block_address_constraints([addr, is_span])
-    enf group_count_constraints([op_bits, hasher, is_span, group_count], [extra])
-    enf op_group_decoding_constraints([op_bits, is_span, group_count, op_index], [extra])
-    enf op_index_constraints([op_bits, is_span, group_count, op_index], [extra])
-    enf op_batch_flag_constraints([op_bits, hasher, op_batch_flags], [extra])
-    enf op_group_table_constraints([addr, op_bits, hasher, is_span, group_count, op_index, op_batch_flags, s0], [extra, p])
+    enf group_count_constraints([op_bits, hasher, is_span, group_count, extra])
+    enf op_group_decoding_constraints([op_bits, is_span, group_count, op_index, extra])
+    enf op_index_constraints([op_bits, is_span, group_count, op_index, extra])
+    enf op_batch_flag_constraints([op_bits, hasher, op_batch_flags, extra])
+    enf op_group_table_constraints([addr, op_bits, hasher, is_span, group_count, op_index, op_batch_flags, s0, extra], [p])
 
 
 ### Decoder Air Constraints #######################################################################
 
-# Enforces the constraints on the decoder. The register `s0` in the main segment denotes the value 
-# at the top of the stack. In the aux segment `extra` denotes the register for degree reduxtion 
-# during flags computation, and p[4] columns denote multiset check columns.
+# Enforces the constraints on the decoder. The register `s0` denotes the value at the top of the 
+# stack. `extra` denotes the register for degree reduxtion during flags computation, and p[4] 
+# columns denote multiset check columns.
 #
 # Constraint degree: 9
-ev decoder_constraints([addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0], [extra, p[4]]):
-    enf general_constraints([addr, op_bits[7], hasher[8], is_span, s0], [extra])
+ev decoder_constraints([addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0, extra], [p[4]]):
+    enf general_constraints([addr, op_bits[7], hasher[8], is_span, s0, extra])
     
-    enf block_hash_computation_constraints([addr, op_bits[7], hasher[8]], [extra, p[4]])
+    enf block_hash_computation_constraints([addr, op_bits[7], hasher[8], extra], [p[4]])
 
-    enf block_stack_table_constraints([addr, op_bits[7], hasher[8], s0], [extra, p[4]])
+    enf block_stack_table_constraints([addr, op_bits[7], hasher[8], s0, extra], [p[4]])
 
-    ev block_hash_table_constraints([addr, op_bits, hasher, s0], [extra, p[4]])
+    enf block_hash_table_constraints([addr, op_bits, hasher, s0, extra], [p[4]])
 
-    enf span_block_constraints([addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0], [extra, p[4]])
+    enf span_block_constraints([addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0, extra], [p[4]])

--- a/constraints/miden-vm/decoder.air
+++ b/constraints/miden-vm/decoder.air
@@ -12,11 +12,6 @@ periodic_columns:
 
 ### Helper functions ##############################################################################
 
-# Returns binary negation of the value.
-fn binary_not(value: scalar) -> scalar:
-    return 1 - value
-
-
 # Returns the f_join operation flag which is set when JOIN control operation is executed.
 #
 # Flag degree: 6
@@ -145,74 +140,87 @@ fn get_f_g1(op_batch_flags: vector[3]) -> scalar:
 ### Helper evaluators #############################################################################
 
 # Enforces that column must be binary.
+# Constraint degree: 2
 ev is_binary([a]):
     enf a^2 = a
 
 
 # Enforces that value in column is copied over to the next row.
+# Constraint degree: 1
 ev is_unchanged([column]):
     enf column' = column
 
 
 # Enforces decoder general constraints.
 #
-# Constraint degree: 9
-ev general_constraints([addr, op_bits[7], hasher[8], is_span, s0, extra]):
+# Max constraint degree: 9
+ev general([addr, op_bits[7], hasher[8], in_span, s0, extra]):
     # Get flags required for the general constraints
     let f_repeat = get_f_repeat(op_bits, extra)
     let f_end = get_f_end(op_bits, extra)
     let f_halt = get_f_halt(op_bits, extra)
 
     # Enforce that `extra` column is set to 1 when op_bits[6] = 1 and op_bits[5] = 1
+    # Constraint degree: 3
     enf extra = 1 when op_bits[6] & op_bits[5]
 
     # Enforce that when SPLIT or LOOP operation is executed, the top of the operand stack must 
     # contain a binary value.
+    # Constraint degree: 8
     enf is_binary([s0]) when get_f_split(op_bits) | get_f_loop(op_bits)
 
     # Enforce that When REPEAT operation is executed, the value at the top of the operand stack 
     # must be 1.
+    # Constraint degree: 5
     enf s0 = 1 when f_repeat
 
     # Enforce that when REPEAT operation is executed, the value in hasher[4] column (the 
     # is_loop_body flag), must be set to 1. This ensures that REPEAT operation can be executed only
     # inside a loop.
+    # Constraint degree: 5
     enf hasher[4] = 1 when f_repeat
 
     # Enforce that when RESPAN operation is executed, we need to make sure that the block ID is 
     # incremented by 8.
+    # Constraint degree: 5
     enf addr' = addr + 8 when f_respan(op_bits, extra)
 
     # Enforce that when END operation is executed and we are exiting a loop block (i.e., is_loop, 
     # value which is stored in hasher[5], is 1), the value at the top of the operand stack must be 
     # 0.
+    # Constraint degree: 6
     enf s0 = 0 when f_end & hasher[5]
 
     # Enforce that when END operation is executed and the next operation is REPEAT, values in 
     # hasher[0], ..., hasher[4] (the hash of the current block and the is_loop_body flag) must be 
     # copied to the next row.
+    # Constraint degree: 9
     enf is_unchanged([hasher[i]]) for i in 0..5 when f_end & get_f_repeat(op_bits', extra')
 
     # Enforce that a HALT instruction can be followed only by another HALT instruction.
+    # Constraint degree: 8
     enf f_halt * !get_f_halt(op_bits', extra') = 0
 
     # Enforce that when a HALT operation is executed, block address column (addr) must be 0.
+    # Constraint degree: 5
     enf addr = 0 when f_halt
 
     # Enforce that values in op_bits columns must be binary.
+    # Constraint degree: 2
     enf is_binary([b]) for b in op_bits
 
-    # Enforce that when the value in is_span column is set to 1, control flow operations cannot be 
-    # executed on the VM, but when is_span flag is 0, only control flow operations can be executed
+    # Enforce that when the value in in_span column is set to 1, control flow operations cannot be 
+    # executed on the VM, but when in_span flag is 0, only control flow operations can be executed
     # on the VM.
-    enf 1 - is_span - get_f_ctrl(op_bits, extra) = 0
+    # Constraint degree: 4
+    enf 1 - in_span - get_f_ctrl(op_bits, extra) = 0
 
 
 # Enforces the constraint for computing block hashes.
 #
-# Constraint degree: 8
-ev block_hash_computation_constraints([addr, op_bits[7], hasher[8], extra], [p[4]]):
-    # Get flags required for the block hash conputation constraint
+# Max constraint degree: 8
+ev block_hash_computation([addr, op_bits[7], hasher[8], extra], [p[4]]):
+    # Get flags required for the block hash computation constraint
     let f_ctrli = get_f_ctrli(op_bits, extra)
     let f_span = get_f_span(op_bits)
     let f_respan = get_f_respan(op_bits, extra)
@@ -273,14 +281,15 @@ ev block_hash_computation_constraints([addr, op_bits[7], hasher[8], extra], [p[4
     # Enforce the block hash computation constraint. We need to add 1 and subtract the sum of the 
     # relevant operation flags to ensure that when none of the flags is set to 1, the above 
     # constraint reduces to p[0]' = p[0].
+    # Constraint degree: 8
     enf p[0]' * (u_ctrli + u_span + u_respan + u_end + 1 - 
         (f_ctrli + f_span + f_respan + f_end)) = p[0]
 
 
 # Enforces the constraint for updating the block stack table.
 #
-# Constraint degree: 8
-ev block_stack_table_constraints([addr, op_bits[7], hasher[8], s0, extra], [p[4]]):
+# Max constraint degree: 8
+ev block_stack_table([addr, op_bits[7], hasher[8], s0, extra], [p[4]]):
     # Get flags required for the block stack table constraint
     let f_join = get_f_join(op_bits)
     let f_split = get_f_split(op_bits)
@@ -290,33 +299,41 @@ ev block_stack_table_constraints([addr, op_bits[7], hasher[8], s0, extra], [p[4]
     let f_end = get_f_end(op_bits, extra)
 
     # When JOIN operation is executed, row (addr', addr, 0) is added to the block stack table.
+    # Value degree: 7
     let v_join = f_join * ($alpha[0] + $alpha[1] * addr' + $alpha[2] * addr)
 
     # When SPLIT operation is executed, row (addr', addr, 0) added to the block stack table.
+    # Value degree: 7
     let v_split = f_split * ($alpha[0] + $alpha[1] * addr' + $alpha[2] * addr)
 
     # When LOOP operation is executed, row (addr', addr, 1) is added to the block stack table if 
     # the value at the top of the operand stack is 1, and row (addr', addr, 0) is added to the 
     # block stack table if the value at the top of the operand stack is 0.
+    # Value degree: 7
     let v_loop = f_loop * ($alpha[0] + $alpha[1] * addr' + $alpha[2] * addr + $alpha[3] * s0)
 
     # When SPAN operation is executed, row (addr', addr, 0) is added to the block stack table.
+    # Value degree: 7
     let v_span = f_span * ($alpha[0] + $alpha[1] * addr' + $alpha[2] * addr)
 
     # When RESPAN operation is executed, row (addr, hasher[1]', 0) is removed from the block stack 
     # table, and row (addr', hasher[1]', 0) is added to the table. The prover sets the value of 
-    # register hasher[1] at the next row to the ID of the parent block:
+    # register hasher[1] at the next row to the ID of the parent block.
+    # Value degree: 5
     let u_respan = f_respan * ($alpha[0] + $alpha[1] * addr + $alpha[2] * hasher[1]')
+    # Value degree: 5
     let v_respan = f_respan * ($alpha[0] + $alpha[1] * addr' + $alpha[2] * hasher[1]')
 
     # When END operation is executed, row (addr, addr', hasher[5]) is removed from the block span 
     # table. Register hasher[5] contains the is_loop flag.
+    # Value degree: 5
     let u_end = f_end * 
             ($alpha[0] + $alpha[1] * addr + $alpha[2] * addr' + $alpha[3] * hasher[5])
 
     # Enforce the block stack table constraint. We need to add 1 and subtract the sum of the 
     # relevant operation flags from each side to ensure that when none of the flags is set to 1, 
     # the above constraint reduces to p[1]' = p[1]
+    # Constraint degree: 8
     enf p[1]' * (u_end + u_respan + 1 - (f_end + f_respan)) = 
             p[1] * (v_join + v_split + v_loop + v_span + v_respan + 1 - 
             (f_join + f_split + f_loop + f_span + f_respan))
@@ -324,8 +341,8 @@ ev block_stack_table_constraints([addr, op_bits[7], hasher[8], s0, extra], [p[4]
 
 # Enforces the constraint for updating the block hash table.
 #
-# Constraint degree: 9
-ev block_hash_table_constraints([addr, op_bits[7], hasher[8], s0, extra], [p[4]]):
+# Max constraint degree: 9
+ev block_hash_table([addr, op_bits[7], hasher[8], s0, extra], [p[4]]):
     # Get flags required for the block hash table constraint
     let f_join = get_f_join(op_bits)
     let f_split = get_f_split(op_bits)
@@ -334,30 +351,37 @@ ev block_hash_table_constraints([addr, op_bits[7], hasher[8], s0, extra], [p[4]]
     let f_repeat = get_f_repeat(op_bits, extra)
 
     # Values representing left and right children of a block.
+    # Value degree: 1
     let ch1 = $alpha[0] + $alpha[1] * addr' + sum([$alpha[i + 2] * hasher[i] for i in 0..4])
+    # Value degree: 1
     let ch2 = $alpha[0] + $alpha[1] * addr' + sum([$alpha[i + 2] * hasher[i + 4] for i in 0..4])
 
     # Value representing the result of hash computation.
+    # Value degree: 1
     let bh = $alpha[0] + $alpha[1] * addr + sum([$alpha[i + 2] * hasher[i]]) + $alpha[7] * hasher[4]
 
     # When JOIN operation is executed, hashes of both child nodes are added to the block hash 
     # table. We add alpha[6] term to the first child value to differentiate it from the second 
     # child (i.e., this sets is_first_child to 1).
+    # Value degree: 8
     let v_join = f_join * (ch1 + $alpha[6]) * ch2
 
     # When SPLIT operation is executed and the top of the stack is 1, hash of the true branch is 
     # added to the block hash table, but when the top of the stack is 0, hash of the false branch
     # is added to the block hash table.
+    # Value degree: 8
     let v_split = f_split * (s0 * ch1 + (1 - s0) * ch2)
 
     # When LOOP operation is executed and the top of the stack is 1, hash of loop body is added to
     # the block hash table. We add alpha[7] term to indicate that the child is a body of a loop. 
     # The below also means that if the top of the stack is 0, nothing is added to the block hash 
     # table as the expression evaluates to 0.
+    # Value degree: 8
     let v_loop = f_loop * s0 * (ch1 + $alpha[7])
 
     # When REPEAT operation is executed, hash of loop body is added to the block hash table. We add
     # alpha[7] term to indicate that the child is a body of a loop.
+    # Value degree: 5
     let v_repeat = f_repeat * (ch1 + $alpha[7])
 
     # When END operation is executed, hash of the completed block is removed from the block hash 
@@ -367,228 +391,257 @@ ev block_hash_table_constraints([addr, op_bits[7], hasher[8], s0, extra], [p[4]]
     # thus, we have just finished executing the first child of a join block. Thus, if the next 
     # operation is neither END nor REPEAT we need to set the term for alpha[6] coefficient to 1 as 
     # shown below.
+    # Value degree: 8
     let u_end = f_end * 
         (bh + $alpha[6] * (1 - (get_f_end(op_bits', extra') + get_f_repeat(op_bits', extra'))))
 
     # Enforce the block hash table constraint. We need to add 1 and subtract the sum of the 
     # relevant operation flags from each side to ensure that when none of the flags is set to 1, 
     # the above constraint reduces to p[2]' = p[2]
+    # Constraint degree: 9
     enf p[2]' * (u_end + 1 - f_end) = 
         p[2] * (v_join + v_split + v_loop + v_repeat + 1 - (f_join + f_split + f_loop + f_repeat))
 
-    # TODO: add boundary constraints to the p[2] column.
+    # TODO: add boundary constraints to the p[2] column:
+    #   1. The first value in the column represents a row for the entire program. Specifically, the 
+    #      row tuple would be (0, program_hash, 0, 0). This row should be removed from the table 
+    #      when the last END operation is executed.
+    #   2. The last value in the column is 1 - i.e., the block hash table is empty.        
 
 
-# Enforce that values in is_span column are set correctly.
+# Enforce that values in in_span column, which is used to identify rows which execute non-control 
+# flow operations, are set correctly.
 #
 # Constraint degree: 7
-ev inspan_column_constraints([op_bits[7], is_span, extra]):
+ev in_span_column([op_bits[7], in_span, extra]):
     # Get flags required for the inspan column constraint
     let f_span = get_f_span(op_bits)
     let f_respan = get_f_respan(op_bits, extra)
     let f_respan_next = get_f_respan(op_bits', extra')
     let f_end_next = get_f_end(op_bits', extra')
 
-    # Enforce that when executing SPAN or RESPAN operation, the next value in is_span column must 
+    # Enforce that when executing SPAN or RESPAN operation, the next value in in_span column must 
     # be set to 1.
-    enf (f_span + f_respan) * binary_not(is_span') = 0
+    # Constraint degree: 7
+    enf in_span' = 1 when f_span | f_respan
 
-    # Enforce that when the next operation is END or RESPAN, the next value in is_span column must 
-    # be set 0.
-    enf (f_end_next + f_respan_next) * is_span' = 0
+    # Enforce that when the next operation is END or RESPAN, the next value in in_span column must 
+    # be set to 0.
+    # Constraint degree: 5
+    enf in_span' = 0 when f_end_next | f_respan_next
 
-    # Enforce that in all other cases, the value in is_span column must be copied over to the next 
+    # Enforce that in all other cases, the value in in_span column must be copied over to the next 
     # row.
-    enf (1 - f_span - f_respan - f_end_next - f_respan_next) * (is_span' - is_span) = 0
+    # Constraint degree: 7
+    enf is_unchanged(in_span) when !f_span & !f_respan & !f_end_next & !f_respan_next
 
-    # TODO: add boundary constraint for is_span column.
+    # TODO: add boundary constraint for in_span column: in_span.first = 0
 
 
-# Enforce that when we are inside a span block, values in block address columns (denoted as addr) 
+# Enforce that when we are inside a span block, values in the block address column (denoted as addr) 
 # must remain the same.
 #
 # Constraint degree: 2
-ev block_address_constraints([addr, is_span]):
-    # Enforce that when we are inside a span block, values in block address columns must remain the
-    # same.
-    enf is_span * (addr' - addr) = 0
+ev block_address([addr, in_span]):
+    enf is_unchanged(addr) when in_span
 
 
-# Enforce that values in group_count column are set correctly.
+# Enforce that values in group_count column, which is used to keep track of the number of operation
+# groups which remains to be executed in a span block, are set correctly.
 #
-# Constraint degree: 7
-ev group_count_constraints([op_bits[7], hasher[8], is_span, group_count, extra]):
+# Max constraint degree: 7
+ev group_count([op_bits[7], hasher[8], in_span, group_count, extra]):
     # Get value of the f_push flag
     let f_push = get_f_push(op_bits, extra)
 
     # Enforce that inside a span block, group count can either stay the same or decrease by one.
-    enf is_span * (group_count' - group_count) * (group_count' - group_count - 1) = 0
+    # Constraint degree: 3
+    enf (group_count' - group_count) * (group_count' - group_count - 1) = 0 when in_span
     
     # Enforce that when group count is decremented inside a span block, either hasher[0] must be 0 
     # (we consumed all operations in a group) or we must be executing PUSH operation.
-    enf is_span * (group_count' - group_count) * (1 - f_push) * hasher[0] = 0
+    # Constraint degree: 7
+    enf (1 - f_push) * hasher[0] = 0 when in_span & (group_count' - group_count)
 
     # Enforce that when executing a SPAN, a RESPAN, or a PUSH operation, group count must be 
     # decremented by 1.
-    enf (f_span(op_bits) + get_f_respan(op_bits, extra) + f_push) * 
-        (group_count' - group_count - 1) = 0
+    # Constraint degree: 7
+    enf group_count' - group_count = 1 when f_span(op_bits) | get_f_respan(op_bits, extra) | f_push
 
     # Enforce that if the next operation is either an END or a RESPAN, group count must remain the 
     # same.
-    enf (group_count' - group_count) * 
-        (get_f_end(op_bits', extra') + get_f_respan(op_bits', extra')) = 0
+    # Constraint degree: 5
+    enf is_unchanged(group_count) when get_f_end(op_bits', extra') | get_f_respan(op_bits', extra')
 
     # Enforce that when an END operation is executed, group count must be 0.
-    enf get_f_end(op_bits, extra) * group_count = 0
+    # Constraint degree: 5
+    enf group_count = 0 when get_f_end(op_bits, extra)
 
 
 # Enforce that register hasher[0], which is used to keep track of operations to be executed in the 
 # current operation group, is set correctly.
 #
-# Constraint degree: 7
-ev op_group_decoding_constraints([op_bits[7], is_span, group_count, op_index, extra]):
-    # opcode value
-    let op = sum([op_bits[i] * 2^i for i in 0..7])
+# Max constraint degree: 7
+ev op_group_decoding([op_bits[7], in_span, group_count, extra]):
+    # opcode value for the next row.
+    let op_next = sum([op_bits[i]' * 2^i for i in 0..7])
 
     # Flag which is set to 1 when the group count within a span block does not change. We multiply 
     # it by sp' to make sure the flag is 0 when we are about to end decoding of an operation batch. 
-    let f_sgc = is_span * is_span' * (1 - group_count' + group_count)
+    let f_sgc = in_span * in_span' * (1 - group_count' + group_count)
 
     # Enforce that when a SPAN, a RESPAN, or a PUSH operation is executed or when the group count 
     # does not change, the value in hasher[0] should be decremented by the value of the opcode in 
     # the next row.
-    enf (f_span(op_bits) + get_f_respan(op_bits, extra) + get_f_push(op_bits, extra) + f_sgc) * 
-        (hasher[0] - hasher[0]' * 2^7 - op_index') = 0
+    # Constraint degree: 7
+    enf hasher[0] - hasher[0]' * 2^7 - op_next = 0 
+        when f_span(op_bits) | get_f_respan(op_bits, extra) | get_f_push(op_bits, extra) | f_sgc
 
     # Enforce that when we are in a span block and the next operation is END or RESPAN, the current
     # value in hasher[0] column must be 0.
-    enf is_span * (get_f_end(op_bits', extra') * get_f_respan(op_bits', extra')) * hasher[0] = 0
+    # Constraint degree: 6
+    enf (get_f_end(op_bits', extra') + get_f_respan(op_bits', extra')) * hasher[0] = 0 when in_span
 
 
-# Enforce that the values in op_index column are set correctly.
+# Enforce that the values in op_index column, which tracks index of an operation within its 
+# operation group, are set correctly.
 #
-# Constraint degree: 9
-ev op_index_constraints([op_bits[7], is_span, group_count, op_index, extra]):
+# Max constraint degree: 9
+ev op_index([op_bits[7], in_span, group_count, op_index, extra]):
     # ng is set to 1 when we are about to start executing a new operation group (i.e., group count 
     # is decremented but we did not execute a PUSH operation).
     let ng = group_count' - group_count - get_f_push(op_bits, extra)
 
     # Enforce that when executing SPAN or RESPAN operations the next value of op_index must be set 
     # to 0.
-    enf (f_span(op_bits) + get_f_respan(op_bits, extra)) * op_index' = 0
+    # Constraint degree: 7
+    enf op_index' = 0 when f_span(op_bits) | get_f_respan(op_bits, extra)
 
     # Enforce that when starting a new operation group inside a span block, the next value of 
     # op_index must be set to 0.
-    enf is_span * ng * op_index' = 0
+    # Constraint degree: 6
+    enf op_index' = 0 when in_span & ng
 
     # Enforce that when inside a span block but not starting a new operation group, op_index must 
     # be incremented by 1.
-    enf is_span * is_span' * (1 - ng) * (op_index' - op_index - 1) = 0
+    # Constraint degree: 7
+    enf op_index' - op_index = 1 when in_span & in_span' & !ng
 
     # Enforce that values of op_index must be in the range [0, 8].
+    # Constraint degree: 9
     enf prod([op_index - i for i in 0..9]) = 0
 
 
-# Enforce that values in operation batch flag columns (denoted op_batch_flags[]) are set correctly.
+# Enforce that values in operation batch flag columns (denoted op_batch_flags[]), which are used to
+# specify how many operation groups are present in an operation batch, are set correctly.
 #
-# Constraint degree: 6
-ev op_batch_flag_constraints([op_bits[7], hasher[8], op_batch_flags[3], extra]):
+# Max constraint degree: 6
+ev op_batch_flags([op_bits[7], hasher[8], op_batch_flags[3], extra]):
     # Get flags required for the op batch flag constraints
     let f_g1 = get_f_g1(op_batch_flags)
     let f_g2 = get_f_g2(op_batch_flags)
     let f_g4 = get_f_g4(op_batch_flags)
+    let f_g8 = get_f_g8(op_batch_flags)
 
     # Enforce that all batch flags are binary.
+    # Constraint degree: 2
     enf is_binary(bc) for bc in op_batch_flags
 
     # Enforce that when SPAN or RESPAN operations is executed, one of the batch flags must be set 
     # to 1.
-    enf (f_span(op_bits) + get_f_respan(op_bits, extra)) - 
-        (f_g1 + f_g2 + f_g4 + get_f_g8(op_batch_flags)) = 0
+    # Constraint degree: 6
+    enf f_g1 + f_g2 + f_g4 + f_g8 = 1 when f_span(op_bits) | get_f_respan(op_bits, extra)
 
     # Enforce that when we have at most 4 groups in a batch, registers h[4], ..., h[7] should be 
     # set to 0's.
-    enf (f_g1 + f_g2 + f_g4) * hasher[i] = 0 for i in 4..8
+    # Constraint degree: 4
+    enf hasher[i] = 0 for i in 4..8 when f_g1 | f_g2 | f_g4
 
     # Enforce that When we have at most 2 groups in a batch, registers h[2] and h[3] should also be
     # set to 0's.
-    enf (f_g1 + f_g2) * hasher[i] = 0 for i in 2..4
+    # Constraint degree: 4
+    enf hasher[i] = 0 for i in 2..4 when f_g1 | f_g2
 
-    # Enforce that when we have at most 1 groups in a batch, register h[1] should also be set to 0.
-    enf f_g1 * hasher[1] = 0
+    # Enforce that when we have at most 1 group in a batch, register h[1] should also be set to 0.
+    # Constraint degree: 4
+    enf hasher[1] = 0 when f_g1
 
 
 # Enforce that all operation groups in a given batch are consumed before a new batch is started 
 # (i.e., via a RESPAN operation) or the execution of a span block is complete (i.e., via an END 
 # operation).
 #
-# Constraint degree: 9
-ev op_group_table_constraints([addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0, extra], [p[4]]):
+# Max constraint degree: 9
+ev op_group_table([addr, op_bits[7], hasher[8], in_span, group_count, op_index, op_batch_flags[3], s0, extra], [p[4]]):
     # Get value of the f_push flag
     let f_push = get_f_push(op_bits, extra)
 
-    # Values of the rows to be added to the op group table when a SPAN or a RESPAN operation is 
-    # executed.
-    let v_i = $alpha[0] + $alpha[1] * addr' + $alpha[2] * (group_count - i) + $alpha[3] * hasher[i]
+    # opcode value for the next row.
+    let op_next = sum([op_bits[i]' * 2^i for i in 0..7])
 
     # Row value for group in hasher[1] to be added to the op group table when a SPAN or a RESPAN 
     # operation is executed.
+    # Value degree: 1
     let v_1 = $alpha[0] + $alpha[1] * addr' + $alpha[2] * (group_count - 1) + $alpha[3] * hasher[1]
 
+    # Value degree: 1
     let prod_v_3 = prod([$alpha[0] + 
                          $alpha[1] * addr' + 
                          $alpha[2] * (group_count - i) + 
                          $alpha[3] * hasher[i] for i in 1..4])
 
+    # Value degree: 1
     let prod_v_7 = prod([$alpha[0] + 
                          $alpha[1] * addr' + 
                          $alpha[2] * (group_count - i) + 
                          $alpha[3] * hasher[i] for i in 1..8])
 
     # The value of the row to be removed from the op group table.
+    # Value degree: 5
     let u = $alpha[0] + $alpha[1] * addr + $alpha[2] * group_count + $alpha[3] * 
-        ((hasher[0]' * 2^7 + op_index') * (1 - f_push + s0' * f_push)) = 0
+        ((hasher[0]' * 2^7 + op_next) * (1 - f_push) + s0' * f_push) = 0
     
     # A flag which is set to 1 when a group needs to be removed from the op group table.
-    let f_dg = is_span * (group_count' - group_count)
+    let f_dg = in_span * (group_count' - group_count)
 
     # Enforce the constraint for updating op group table. The constraint specifies that when SPAN 
     # or RESPAN operations are executed, we add between 1 and 7 groups to the op group table, and 
     # when group count is decremented inside a span block, we remove a group from the op group 
     # table.
-    enf p[3]' * (f_dg * u + 1 - f_dg) = 
-        p[3] * (get_f_g2(op_batch_flags) * v_1 + get_f_g4(op_batch_flags) * 
-        prod_v_3 + get_f_g8(op_batch_flags) * 
-        prod_v_7 - 1 + (f_span(op_bits) + get_f_respan(op_bits, extra)))
+    # Constraint degree: 9
+    enf p[3]' * (f_dg * u + 1 - f_dg) = p[3] * (get_f_g2(op_batch_flags) * v_1 + 
+                                                get_f_g4(op_batch_flags) * prod_v_3 + 
+                                                get_f_g8(op_batch_flags) * prod_v_7 - 1 + 
+                                                (f_span(op_bits) + get_f_respan(op_bits, extra)))
     
 
-# Enforces proper decoding of span blocks.
+# Enforce proper decoding of span blocks.
 #
-# Constraint degree: 9
-ev span_block_constraints([addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0, extra], [p[4]]):
-    enf inspan_column_constraints([op_bits, is_span, extra])
-    enf block_address_constraints([addr, is_span])
-    enf group_count_constraints([op_bits, hasher, is_span, group_count, extra])
-    enf op_group_decoding_constraints([op_bits, is_span, group_count, op_index, extra])
-    enf op_index_constraints([op_bits, is_span, group_count, op_index, extra])
-    enf op_batch_flag_constraints([op_bits, hasher, op_batch_flags, extra])
-    enf op_group_table_constraints([addr, op_bits, hasher, is_span, group_count, op_index, op_batch_flags, s0, extra], [p])
+# Max constraint degree: 9
+ev span_block([addr, op_bits[7], hasher[8], in_span, group_count, op_index, op_batch_flags[3], s0, extra], [p[4]]):
+    enf in_span_column([op_bits, in_span, extra])
+    enf block_address([addr, in_span])
+    enf group_count([op_bits, hasher, in_span, group_count, extra])
+    enf op_group_decoding([op_bits, in_span, group_count, extra])
+    enf op_index([op_bits, in_span, group_count, op_index, extra])
+    enf op_batch_flags([op_bits, hasher, op_batch_flags, extra])
+    enf op_group_table([addr, op_bits, hasher, in_span, group_count, op_index, op_batch_flags, s0, extra], [p])
 
 
 ### Decoder Air Constraints #######################################################################
 
 # Enforces the constraints on the decoder. The register `s0` denotes the value at the top of the 
-# stack. `extra` denotes the register for degree reduxtion during flags computation, and p[4] 
+# stack. `extra` denotes the register for degree reduction during flag computations, and p[4] 
 # columns denote multiset check columns.
 #
-# Constraint degree: 9
-ev decoder_constraints([addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0, extra], [p[4]]):
-    enf general_constraints([addr, op_bits[7], hasher[8], is_span, s0, extra])
+# Max constraint degree: 9
+ev decoder_constraints([addr, op_bits[7], hasher[8], in_span, group_count, op_index, op_batch_flags[3], s0, extra], [p[4]]):
+    enf general([addr, op_bits[7], hasher[8], in_span, s0, extra])
     
-    enf block_hash_computation_constraints([addr, op_bits[7], hasher[8], extra], [p[4]])
+    enf block_hash_computation([addr, op_bits[7], hasher[8], extra], [p[4]])
 
-    enf block_stack_table_constraints([addr, op_bits[7], hasher[8], s0, extra], [p[4]])
+    enf block_stack_table([addr, op_bits[7], hasher[8], s0, extra], [p[4]])
 
-    enf block_hash_table_constraints([addr, op_bits, hasher, s0, extra], [p[4]])
+    enf block_hash_table([addr, op_bits, hasher, s0, extra], [p[4]])
 
-    enf span_block_constraints([addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0, extra], [p[4]])
+    enf span_block([addr, op_bits[7], hasher[8], in_span, group_count, op_index, op_batch_flags[3], s0, extra], [p[4]])

--- a/constraints/miden-vm/decoder.air
+++ b/constraints/miden-vm/decoder.air
@@ -15,62 +15,86 @@ fn binary_not(value: scalar) -> scalar:
 
 
 # Returns the f_join operation flag which is set when JOIN control operation is executed.
+#
+# Flag degree: 6
 fn f_join(b: vector[7]) -> scalar:
     return b[6] & !b[5] & b[4] & b[3] & !b[2] & b[1]
 
 
 # Returns the f_split operation flag which is set when SPLIT control operation is executed.
+#
+# Flag degree: 6
 fn f_split(b: vector[7]) -> scalar:
     return b[6] & !b[5] & b[4] & b[3] & b[2] & !b[1]
 
 
 # Returns the f_loop operation flag which is set when LOOP control operation is executed.
+#
+# Flag degree: 6
 fn f_loop(b: vector[7]) -> scalar:
     return b[6] & !b[5] & b[4] & b[3] & b[2] & b[1]
 
 
 # Returns the f_repeat operation flag which is set when REPEAT operation is executed.
+#
+# Flag degree: 4
 fn f_repeat(b: vector[7], extra: scalar) -> scalar:
     return extra & b[4] & !b[3] & b[2]
 
 
 # Returns the f_span operation flag which is set when SPAN operation is executed.
+#
+# Flag degree: 6
 fn f_span(b: vector[7]) -> scalar:
     return b[6] & !b[5] & b[4] & b[3] & !b[2] & !b[1]
 
 
 # Returns the f_respan operation flag which is set when RESPAN operation is executed.
+#
+# Flag degree: 4
 fn f_respan(b: vector[7], extra: scalar) -> scalar:
     return extra & b[4] & b[3] & !b[2]
 
 
 # Returns the f_call operation flag which is set when CALL control operation is executed.
+#
+# Flag degree: 4
 fn f_call(b: vector[7], extra: scalar) -> scalar:
     return extra & !b[4] & b[3] & b[2]
 
 
 # Returns the f_syscall operation flag which is set when SYSCALL control operation is executed.
+#
+# Flag degree: 4
 fn f_syscall(b: vector[7], extra: scalar) -> scalar:
     return extra & !b[4] & b[3] & !b[2]
 
 
 # Returns the f_end operation flag which is set when END operation is executed.
+#
+# Flag degree: 4
 fn f_end(b: vector[7], extra: scalar) -> scalar:
     return extra & b[4] & !b[3] & !b[2]
 
 
 # Returns the f_halt operation flag which is set when HALT operation is executed.
+#
+# Flag degree: 4
 fn f_halt(b: vector[7], extra: scalar) -> scalar:
     return extra & b[4] & b[3] & b[2]
 
 
 # Returns the f_push operation flag which is set when PUSH operation is executed.
+#
+# Flag degree: 4
 fn f_push(b: vector[7], extra: scalar) -> scalar:
     return extra & !b[4] & !b[3] & b[2]
 
 
-# Returns the f_ctrl flag which is set when any one of the control flow operations that has flags 
-# above (JOIN, SPLIT, LOOP, CALL, SYSCALL) is being executed.
+# Returns the f_ctrl flag which is set when any one of the control flow operations (JOIN, SPLIT, 
+# LOOP, REPEAT, SPAN, RESPAN, CALL, SYSCALL, END, HALT) is being executed.
+#
+# Flag degree: 4
 fn f_ctrl(b: vector[7], extra: scalar) -> scalar:
     # flag for SPAN, JOIN, SPLIT, LOOP
     let f_sjsl = b[6] & !b[5] & b[4] & b[3]
@@ -82,8 +106,10 @@ fn f_ctrl(b: vector[7], extra: scalar) -> scalar:
 
 
 # Returns f_ctrli flag which is set to 1 when a control flow operation that signifies the 
-# initialization of a control block is being executed on the VM.
-fn f_ctrli(b: vector[7], extra: scalar) -< scalar:
+# initialization of a control block (JOIN, SPLIT, LOOP, CALL, SYSCALL) is being executed on the VM.
+#
+# Flag degree: 6
+fn f_ctrli(b: vector[7], extra: scalar) -> scalar:
     return f_join(b) + f_split(b) + f_loop(b) + f_call(b, extra) + f_syscall(b, extra)
 
 
@@ -116,19 +142,24 @@ fn get_f_g1(op_batch_flags: vector[3]) -> scalar:
 ### Helper evaluators #############################################################################
 
 # Enforces that column must be binary.
-ev is_binary(main: [a]):
+ev is_binary([a]):
     enf a^2 = a
 
 
 # Enforces that value in column is copied over to the next row.
-ev is_unchanged(main: [column]):
-    ev column' = column
+ev is_unchanged([column]):
+    enf column' = column
 
 
 # Enforces decoder general constraints.
-ev general_constraints(main: [addr, op_bits[7], hasher[8], is_span, s0], aux: [extra]):
+#
+# Constraint degree: 9
+ev general_constraints([addr, op_bits[7], hasher[8], is_span, s0], [extra]):
     let op_bits_next = [op_bits[0]', op_bits[1]', op_bits[2]', op_bits[3]', op_bits[4]', op_bits[5]', op_bits[6]']
     let extra_next = extra'
+
+    # Enforce that `extra` column is set to 1 when op_bits[6] = 1 and op_bits[5] = 1
+    enf extra = 1 when op_bits[6] & op_bits[5]
 
     # Enforce that when SPLIT or LOOP operation is executed, the top of the operand stack must 
     # contain a binary value.
@@ -173,7 +204,9 @@ ev general_constraints(main: [addr, op_bits[7], hasher[8], is_span, s0], aux: [e
 
 
 # Enforces constraint for computing block hashes.
-ev block_hash_computation_constraints(main: [addr, op_bits[7], hasher[8]], aux: [extra, p[4]]):
+#
+# Constraint degree: 8
+ev block_hash_computation_constraints([addr, op_bits[7], hasher[8]], [extra, p[4]]):
     # Operation label for HASHER_LINER_HASH operation.
     let op_linhash = 3
 
@@ -230,7 +263,9 @@ ev block_hash_computation_constraints(main: [addr, op_bits[7], hasher[8]], aux: 
 
 
 # Enforces constraint for updating the block stack table.
-ev block_stack_table_constraints(main: [addr, op_bits[7], hasher[8], s0], aux: [extra, p[4]]):
+#
+# Constraint degree: 8
+ev block_stack_table_constraints([addr, op_bits[7], hasher[8], s0], [extra, p[4]]):
     # When JOIN operation is executed, row (addr', addr, 0) is added to the block stack table.
     let v_join = f_join(op_bits) * (alpha[0] + alpha[1] * addr' + alpha[2] * addr)
 
@@ -265,7 +300,9 @@ ev block_stack_table_constraints(main: [addr, op_bits[7], hasher[8], s0], aux: [
 
 
 # Enforces constraint for updating the block hash table.
-ev block_hash_table_constraints(main: [addr, op_bits[7], hasher[8], s0], aux: [extra, p[4]]):
+#
+# Constraint degree: 9
+ev block_hash_table_constraints([addr, op_bits[7], hasher[8], s0], [extra, p[4]]):
     let op_bits_next = [op_bits[0]', op_bits[1]', op_bits[2]', op_bits[3]', op_bits[4]', op_bits[5]', op_bits[6]']
     let extra_next = extra'
 
@@ -305,8 +342,10 @@ ev block_hash_table_constraints(main: [addr, op_bits[7], hasher[8], s0], aux: [e
     # TODO: add boundary constraints to the p[2] column.
 
 
-# Enforce that values in is_span column are set correctly. 
-ev inspan_column_constraints(main: [op_bits[7], is_span], aux: [extra]):
+# Enforce that values in is_span column are set correctly.
+#
+# Constraint degree: 7
+ev inspan_column_constraints([op_bits[7], is_span], [extra]):
     let op_bits_next = [op_bits[0]', op_bits[1]', op_bits[2]', op_bits[3]', op_bits[4]', op_bits[5]', op_bits[6]']
     let extra_next = extra'
 
@@ -328,14 +367,18 @@ ev inspan_column_constraints(main: [op_bits[7], is_span], aux: [extra]):
 
 # Enforce that when we are inside a span block, values in block address columns (denoted as addr) 
 # must remain the same.
-ev block_address_constraints(main: [addr, is_span]):
+#
+# Constraint degree: 2
+ev block_address_constraints([addr, is_span]):
     # Enforce that when we are inside a span block, values in block address columns must remain the
     # same.
     enf is_span * (addr' - addr) = 0
 
 
 # Enforce that values in group_count column are set correctly.
-ev group_count_constraints(main: [op_bits[7], hasher[8], is_span, group_count], aux: [extra]):
+#
+# Constraint degree: 7
+ev group_count_constraints([op_bits[7], hasher[8], is_span, group_count], [extra]):
     let op_bits_next = [op_bits[0]', op_bits[1]', op_bits[2]', op_bits[3]', op_bits[4]', op_bits[5]', op_bits[6]']
     let extra_next = extra'
     
@@ -361,7 +404,9 @@ ev group_count_constraints(main: [op_bits[7], hasher[8], is_span, group_count], 
 
 # Enforce that register hasher[0], which is used to keep track of operations to be executed in the 
 # current operation group, is set correctly.
-ev op_group_decoding_constraints(main: [op_bits[7], is_span, group_count, op_index], aux: [extra]):
+#
+# Constraint degree: 7
+ev op_group_decoding_constraints([op_bits[7], is_span, group_count, op_index], [extra]):
     let op_bits_next = [op_bits[0]', op_bits[1]', op_bits[2]', op_bits[3]', op_bits[4]', op_bits[5]', op_bits[6]']
     let extra_next = extra'
     
@@ -380,7 +425,9 @@ ev op_group_decoding_constraints(main: [op_bits[7], is_span, group_count, op_ind
 
 
 # Enforce that the values in op_index column are set correctly.
-ev op_index_constraints(main: [op_bits[7], is_span, group_count, op_index], aux: [extra]):
+#
+# Constraint degree: 9
+ev op_index_constraints([op_bits[7], is_span, group_count, op_index], [extra]):
     let ng = group_count' - group_count - f_push(op_bits, extra)
 
     # Enforce that when executing SPAN or RESPAN operations the next value of op_index must be set 
@@ -400,7 +447,9 @@ ev op_index_constraints(main: [op_bits[7], is_span, group_count, op_index], aux:
 
 
 # Enforce that values in operation batch flag columns (denoted op_batch_flags[]) are set correctly.
-ev op_batch_flag_constraints(main: [op_bits[7], hasher[8], op_batch_flags[3]], aux: [extra]):
+#
+# Constraint degree: 6
+ev op_batch_flag_constraints([op_bits[7], hasher[8], op_batch_flags[3]], [extra]):
     # Enforce that all batch flags are binary.
     enf is_binary(bc) for bc in op_batch_flags
 
@@ -424,7 +473,9 @@ ev op_batch_flag_constraints(main: [op_bits[7], hasher[8], op_batch_flags[3]], a
 # Enforce that all operation groups in a given batch are consumed before a new batch is started 
 # (i.e., via a RESPAN operation) or the execution of a span block is complete (i.e., via an END 
 # operation).
-ev op_group_table_constraints(main: [addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0], aux: [extra, p[4]]):
+#
+# Constraint degree: 9
+ev op_group_table_constraints([addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0], [extra, p[4]]):
     # Values of the rows to be added to the op group table when a SPAN or a RESPAN operation is 
     # executed.
     let v_i = alpha[0] + alpha[1] * addr' + alpha[2] * (group_count - i) + alpha[3] * hasher[i]
@@ -452,11 +503,13 @@ ev op_group_table_constraints(main: [addr, op_bits[7], hasher[8], is_span, group
     
 
 # Enforces proper decoding of span blocks.
-ev span_block_constraints(main: [addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0], aux: [extra, p[4]]):
+#
+# Constraint degree: 9
+ev span_block_constraints([addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0], [extra, p[4]]):
     enf inspan_column_constraints([op_bits, is_span], [extra])
     enf block_address_constraints([addr, is_span])
     enf group_count_constraints([op_bits, hasher, is_span, group_count], [extra])
-    enf op_group_decoding_constraints([op_bits, is_span, group_count, op_index], aux: [extra])
+    enf op_group_decoding_constraints([op_bits, is_span, group_count, op_index], [extra])
     enf op_index_constraints([op_bits, is_span, group_count, op_index], [extra])
     enf op_batch_flag_constraints([op_bits, hasher, op_batch_flags], [extra])
     enf op_group_table_constraints([addr, op_bits, hasher, is_span, group_count, op_index, op_batch_flags, s0], [extra, p])
@@ -467,7 +520,9 @@ ev span_block_constraints(main: [addr, op_bits[7], hasher[8], is_span, group_cou
 # Enforces the constraints on the decoder. The register `s0` in the main segment denotes the value 
 # at the top of the stack. In the aux segment `extra` denotes the register for degree reduxtion 
 # during flags computation, and p[4] columns denote multiset check columns.
-ev decoder_constraints(main: [addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0], aux: [extra, p[4]]):
+#
+# Constraint degree: 9
+ev decoder_constraints([addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0], [extra, p[4]]):
     enf general_constraints([addr, op_bits[7], hasher[8], is_span, s0], [extra])
     
     enf block_hash_computation_constraints([addr, op_bits[7], hasher[8]], [extra, p[4]])

--- a/constraints/miden-vm/decoder.air
+++ b/constraints/miden-vm/decoder.air
@@ -1,0 +1,495 @@
+mod DecoderAir
+
+### Constants and periodic columns ################################################################
+
+periodic_columns:
+    cycle_row_0: [1, 0, 0, 0, 0, 0, 0, 0]
+    cycle_row_7: [0, 0, 0, 0, 0, 0, 0, 1]
+
+
+### Helper functions ##############################################################################
+
+# Returns binary negation of the value.
+fn binary_not(value: scalar) -> scalar:
+    return 1 - value
+
+
+# Returns the delta between the value in the next row and in the current row.
+fn delta(v: scalar) -> scalar:
+    return v' - v
+
+
+# Returns the f_join operation flag which is set when JOIN control operation is executed.
+fn f_join(b: vector[7]) -> scalar:
+    return b[6] & !b[5] & b[4] & b[3] & !b[2] & b[1]
+
+
+# Returns the f_split operation flag which is set when SPLIT control operation is executed.
+fn f_split(b: vector[7]) -> scalar:
+    return b[6] & !b[5] & b[4] & b[3] & b[2] & !b[1]
+
+
+# Returns the f_loop operation flag which is set when LOOP control operation is executed.
+fn f_loop(b: vector[7]) -> scalar:
+    return b[6] & !b[5] & b[4] & b[3] & b[2] & b[1]
+
+
+# Returns the f_repeat operation flag which is set when REPEAT operation is executed.
+fn f_repeat(b: vector[7], extra: scalar) -> scalar:
+    return extra & b[4] & !b[3] & b[2]
+
+
+# Returns the f_repeat operation flag which is set when REPEAT operation is executed in the next 
+# row.
+fn f_repeat_next(b: vector[7], extra: scalar) -> scalar:
+    return extra' & b[4]' & !b[3]' & b[2]'
+    
+
+# Returns the f_span operation flag which is set when SPAN operation is executed.
+fn f_span(b: vector[7]) -> scalar:
+    return b[6] & !b[5] & b[4] & b[3] & !b[2] & !b[1]
+
+
+# Returns the f_respan operation flag which is set when RESPAN operation is executed.
+fn f_respan(b: vector[7], extra: scalar) -> scalar:
+    return extra & b[4] & b[3] & !b[2]
+
+
+# Returns the f_respan operation flag which is set when RESPAN operation is executed in the next 
+# row.
+fn f_respan_next(b: vector[7], extra: scalar) -> scalar:
+    return extra' & b[4]' & b[3]' & !b[2]'
+
+
+# Returns the f_call operation flag which is set when CALL control operation is executed.
+fn f_call(b: vector[7], extra: scalar) -> scalar:
+    return extra & !b[4] & b[3] & b[2]
+
+
+# Returns the f_syscall operation flag which is set when SYSCALL control operation is executed.
+fn f_syscall(b: vector[7], extra: scalar) -> scalar:
+    return extra & !b[4] & b[3] & !b[2]
+
+
+# Returns the f_end operation flag which is set when END operation is executed.
+fn f_end(b: vector[7], extra: scalar) -> scalar:
+    return extra & b[4] & !b[3] & !b[2]
+
+
+# Returns the f_end operation flag which is set when END operation is executed in the next 
+# row.
+fn f_end_next(b: vector[7], extra: scalar) -> scalar:
+    return extra' & b[4]' & !b[3]' & !b[2]'
+
+
+# Returns the f_halt operation flag which is set when HALT operation is executed.
+fn f_halt(b: vector[7], extra: scalar) -> scalar:
+    return extra & b[4] & b[3] & b[2]
+
+
+# Returns the f_halt operation flag which is set when HALT operation is executed in the next 
+# row.
+fn f_halt_next(b: vector[7], extra: scalar) -> scalar:
+    return extra' & b[4]' & b[3]' & b[2]'
+
+
+# Returns the f_push operation flag which is set when PUSH operation is executed.
+fn f_push(b: vector[7], extra: scalar) -> scalar:
+    return extra & !b[4] & !b[3] & b[2]
+
+
+# Returns the f_ctrl flag which is set when any one of the control flow operations that has flags 
+# above (JOIN, SPLIT, LOOP, CALL, SYSCALL) is being executed.
+fn f_ctrl(b: vector[7], extra: scalar) -> scalar:
+    # flag for SPAN, JOIN, SPLIT, LOOP
+    let f_sjsl = b[6] & !b[5] & b[4] & b[3]
+
+    # flag for END, REPEAT, RESPAN, HALT
+    let f_errh = b[6] & b[5] & b[4]
+
+    return f_sjsl + f_errh + f_call(b, extra) + f_syscall(b, extra)
+
+
+# Returns f_ctrli flag which is set to 1 when a control flow operation that signifies the 
+# initialization of a control block is being executed on the VM.
+fn f_ctrli(b: vector[7], extra: scalar) -< scalar:
+    return f_join(b) + f_split(b) + f_loop(b) + f_call(b, extra) + f_syscall(b, extra)
+
+
+# Returns transition label, composed of the operation label and the periodic columns that uniquely 
+# identify each transition function.
+fn get_transition_label(op_label: scalar) -> scalar:
+    return op_label + 2^4 * cycle_row_7 + 2^5 * cycle_row_0
+
+
+# Returns f_g8 flag which is set to 1 if there are 8 operation groups in the batch.
+fn get_f_g8(op_batch_flags: vector[3]) -> scalar:
+    return op_batch_flags[0]
+
+
+# Returns f_g4 flag which is set to 1 if there are 4 operation groups in the batch.
+fn get_f_g4(op_batch_flags: vector[3]) -> scalar:
+    return !op_batch_flags[0] & op_batch_flags[1] & op_batch_flags[2]
+
+
+# Returns f_g2 flag which is set to 1 if there are 2 operation groups in the batch.
+fn get_f_g2(op_batch_flags: vector[3]) -> scalar:
+    return !op_batch_flags[0] & !op_batch_flags[1] & op_batch_flags[2]
+
+
+# Returns f_g1 flag which is set to 1 if there are 1 operation groups in the batch.
+fn get_f_g1(op_batch_flags: vector[3]) -> scalar:
+    return !op_batch_flags[0] & op_batch_flags[1] & !op_batch_flags[2]
+
+
+### Helper evaluators #############################################################################
+
+# Enforces that column must be binary.
+ev is_binary(main: [a]):
+    enf a^2 = a
+
+
+# Enforces that value in column is copied over to the next row.
+ev is_unchanged(main: [column]):
+    ev column' = column
+
+
+# Enforces decoder general constraints.
+ev general_constraints(main: [addr, op_bits[7], hasher[8], is_span, s0], aux: [extra]):
+    # TODO: add constraints to check not used operational bits.
+
+    # Enforce that when SPLIT or LOOP operation is executed, the top of the operand stack must 
+    # contain a binary value.
+    enf is_binary([s0]) when f_split(op_bits) | f_loop(op_bits)
+
+    # Enforce that When REPEAT operation is executed, the value at the top of the operand stack 
+    # must be 1.
+    enf s0 = 1 when f_repeat(op_bits, extra)
+
+    # Enforce that when REPEAT operation is executed, the value in hasher[4] column (the 
+    # is_loop_body flag), must be set to 1. This ensures that REPEAT operation can be executed only
+    # inside a loop.
+    enf hasher[4] = 1 when f_repeat(op_bits, extra)
+
+    # Enforce that when RESPAN operation is executed, we need to make sure that the block ID is 
+    # incremented by 8.
+    enf addr' = addr + 8 when f_respan(op_bits, extra)
+
+    # Enforce that when END operation is executed and we are exiting a loop block (i.e., is_loop, 
+    # value which is stored in hasher[5], is 1), the value at the top of the operand stack must be 
+    # 0.
+    enf s0 = 0 when f_end(op_bits, extra) & hasher[5]
+
+    # Enforce that when END operation is executed and the next operation is REPEAT, values in 
+    # hasher[0], ..., hasher[4] (the hash of the current block and the is_loop_body flag) must be 
+    # copied to the next row.
+    enf is_unchanged([hasher[i]]) for i in 0..5 when f_end(op_bits, extra) & f_repeat_next(op_bits, extra)
+
+    # Enforce that a HALT instruction can be followed only by another HALT instruction.
+    enf f_halt(op_bits, extra) * !f_halt_next = 0
+
+    # Enforce that when a HALT operation is executed, block address column (addr) must be 0.
+    enf addr = 0 when f_halt(op_bits, extra)
+
+    # Enforce that values in op_bits columns must be binary.
+    enf is_binary([b]) for b in op_bits
+
+    # Enforce that when the value in is_span column is set to 1, control flow operations cannot be 
+    # executed on the VM, but when is_span flag is 0, only control flow operations can be executed
+    # on the VM.
+    enf 1 - is_span - f_ctrl = 0
+
+
+# Enforces constraint for computing block hashes.
+ev block_hash_computation_constraints(main: [addr, op_bits[7], hasher[8]], aux: [extra, p[4]]):
+    # Operation label for HASHER_LINER_HASH operation.
+    let op_linhash = 3
+
+    # Operation label for HASHER_RETURN_HASH operation.
+    let op_hout = 1
+
+    # Label specifying that we are starting a new hash computation.
+    let m_bp = get_transition_label(op_linhash)
+
+    # Label specifying that we are absorbing the next sequence of 8 elements into an ongoing hash 
+    # computation.
+    let m_abp = get_transition_label(op_linhash)
+
+    # Label specifying that we are reading the result of a hash computation.
+    let m_hout = get_transition_label(op_hout)
+
+    # `alpha` is inherited random values array.
+    let rate_sum = sum([alpha[i + 8] * hasher[i] for i in 0..8])
+    let digest_sum = sum([alpha[i + 8] * hasher[i] for i in 0..4])
+
+    # Variable for initiating a hasher with address addr' and absorbing 8 elements from the hasher
+    # state (hasher[0], ..., hasher[7]) into it.
+    let h_init = alpha[0] + alpha[1] * m_bp + alpha[2] * addr' + rate_sum
+
+    # Variable for the absorption.
+    let h_abp = alpha[0] + alpha[1] * m_abp + alpha[2] * addr' + rate_sum
+
+    # Variable for the result
+    let h_res = alpha[0] + alpha[1] * m_hout + alpha[2] * (addr + 7) + digest_sum
+
+    # Opcode value of the opcode being executed on the virtual machine.
+    let opcode_value = sum([op_bits[i] * 2^i for i in 0..7])
+    
+    # When a control block initializer operation (JOIN, SPLIT, LOOP, CALL, SYSCALL) is executed, a 
+    # new hasher is initialized and the contents of hasher[0], ..., hasher[7] are absorbed into the
+    # hasher. 
+    let u_ctrli = f_ctrli(op_bits, extra) * (h_init + alpha[5] * opcode_value)
+
+    # When SPAN operation is executed, a new hasher is initialized and contents of 
+    # hasher[0], ..., hasher[7] are absorbed into the hasher.
+    let u_span = f_span(op_bits) * h_init
+
+    # When RESPAN operation is executed, contents of hasher[0], ..., hasher[7] (which contain the 
+    # new operation batch) are absorbed into the hasher.
+    let u_respan = f_respan(op_bits, extra) * h_abp
+
+    # When END operation is executed, the hash result is copied into registers 
+    # hasher[0], ..., hasher[3].
+    let u_end = f_end(op_bits, extra) * h_res
+
+    # Enforce the block hash computation constraint.
+    enf p[0]' * (u_ctrli + u_span + u_respan + u_end + 1 - (f_ctrli(op_bits, extra) + 
+        f_span(op_bits) + f_respan(op_bits, extra) + f_end(op_bits, extra))) = p[0]
+
+
+# Enforces constraint for updating the block stack table.
+ev block_stack_table_constraints(main: [addr, op_bits[7], hasher[8], s0], aux: [extra, p[4]]):
+    # When JOIN operation is executed, row (addr', addr, 0) is added to the block stack table.
+    let v_join = f_join(op_bits) * (alpha[0] + alpha[1] * addr' + alpha[2] * addr)
+
+    # When SPLIT operation is executed, row (addr', addr, 0) added to the block stack table.
+    let v_split = f_split(op_bits) * (alpha[0] + alpha[1] * addr' + alpha[2] * addr)
+
+    # When LOOP operation is executed, row (addr', addr, 1) is added to the block stack table if 
+    # the value at the top of the operand stack is 1, and row (addr', addr, 0) is added to the 
+    # block stack table if the value at the top of the operand stack is 0.
+    let v_loop = f_loop(op_bits) * (alpha[0] + alpha[1] * addr' + alpha[2] * addr + alpha[3] * s0)
+
+    # When SPAN operation is executed, row (addr', addr, 0) is added to the block stack table.
+    let v_span = f_span(op_bits) * (alpha[0] + alpha[1] * addr' + alpha[2] * addr)
+
+    # When RESPAN operation is executed, row (addr, hasher[1]', 0) is removed from the block stack 
+    # table, and row (addr', hasher[1]', 0) is added to the table. The prover sets the value of 
+    # register hasher[1] at the next row to the ID of the parent block:
+    let u_respan = f_respan(op_bits, extra) * (alpha[0] + alpha[1] * addr + alpha[2] * hasher[1]')
+    let v_respan = f_respan(op_bits, extra) * (alpha[0] + alpha[1] * addr' + alpha[2] * hasher[1]')
+
+    # When END operation is executed, row (addr, addr', hasher[5]) is removed from the block span 
+    # table. Register hasher[5] contains the is_loop flag.
+    let u_end = f_end(op_bits, extra) * 
+        (alpha[0] + alpha[1] * addr + alpha[2] * addr' + alpha[3] * hasher[5])
+
+    # Enforce the block stack table constraint.
+    # TODO: do proper line wrapping
+    enf p[1]' * (u_end + u_respan + 1 - (f_end(op_bits, extra) + f_respan(op_bits, extra)))
+        = p[1] * (v_join + v_split + v_loop + v_span + v_respan + 1 - (f_join(op_bits) + 
+        f_split(op_bits) + f_loop(op_bits) + f_span(op_bits) + 
+        f_respan(op_bits, extra)))
+
+
+# Enforces constraint for updating the block hash table.
+ev block_hash_table_constraints(main: [addr, op_bits[7], hasher[8], s0], aux: [extra, p[4]]):
+    # Values representing left and right children of a block.
+    let ch1 = alpha[0] + alpha[1] * addr' + sum([alpha[i + 2] * hasher[i] for i in 0..4])
+    let ch2 = alpha[0] + alpha[1] * addr' + sum([alpha[i + 2] * hasher[i + 4] for i in 0..4])
+
+    # Value representing the result of hash computation.
+    let bh = alpha[0] + alpha[1] * addr + sum([alpha[i + 2] * hasher[i]]) + alpha[7] * hasher[4]
+
+    # When JOIN operation is executed, hashes of both child nodes are added to the block hash 
+    # table.
+    let v_join = f_join(op_bits) * (ch1 + alpha[6]) * ch2
+
+    # When SPLIT operation is executed and the top of the stack is 1, hash of the true branch is 
+    # added to the block hash table, but when the top of the stack is 0, hash of the false branch
+    # is added to the block hash table.
+    let v_split = f_split(op_bits) * (s0 * ch1 + (1 - s0) * ch2)
+
+    # When LOOP operation is executed and the top of the stack is 1, hash of loop body is added to
+    # the block hash table.
+    let v_loop = f_loop(op_bits) * s0 * (ch1 + alpha[7])
+
+    # When REPEAT operation is executed, hash of loop body is added to the block hash table.
+    let v_repeat = f_repeat(op_bits, extra) * (ch1 + alpha[7])
+
+    # When END operation is executed, hash of the completed block is removed from the block hash 
+    # table.
+    let u_end = f_end(op_bits, extra) * 
+        (bh + alpha[6] * (1 - (f_end_next(op_bits, extra) + f_repeat_next(op_bits, extra))))
+
+    # Enforce the block hash table constraint.
+    enf p[2]' * (u_end + 1 - f_end(op_bits, extra)) = 
+        p[2] * (v_join + v_split + v_loop + v_repeat + 1 - 
+        (f_join(op_bits) + f_split(op_bits) + f_loop(op_bits) + f_repeat(op_bits, extra)))
+
+    # TODO: add boundary constraints to the p[2] column.
+
+
+# Enforce that values in is_span column are set correctly. 
+ev inspan_column_constraints(main: [op_bits[7], is_span], aux: [extra]):
+    # Enforce that when executing SPAN or RESPAN operation, the next value in is_span column must 
+    # be set to 1.
+    enf (f_span(op_bits) + f_respan(op_bits, extra)) * binary_not(is_span') = 0
+
+    # Enforce that when the next operation is END or RESPAN, the next value in is_span column must 
+    # be set 0.
+    enf (f_end_next(op_bits, extra) + f_respan_next(op_bits, extra)) * is_span' = 0
+
+    # Enforce that in all other cases, the value in is_span column must be copied over to the next 
+    # row.
+    (1 - f_span(op_bits) - f_respan(op_bits, extra) - f_end_next(op_bits, extra) - 
+        f_respan_next(op_bits, extra)) * (is_span' - is_span) = 0
+
+    # TODO: add boundary constraint for is_span column.
+
+
+# Enforce that when we are inside a span block, values in block address columns (denoted as addr) 
+# must remain the same.
+ev block_address_constraints(main: [addr, is_span]):
+    # Enforce that when we are inside a span block, values in block address columns must remain the
+    # same.
+    enf is_span * delta(addr) = 0
+
+
+# Enforce that values in group_count column are set correctly.
+ev group_count_constraints(main: [op_bits[7], hasher[8], is_span, group_count], aux: [extra]):
+    # Enforce that inside a span block, group count can either stay the same or decrease by one.
+    enf is_span * delta(group_count) * (delta(group_count) - 1) = 0
+    
+    # Enforce that when group count is decremented inside a span block, either hasher[0] must be 0 
+    # (we consumed all operations in a group) or we must be executing PUSH operation.
+    enf is_span * delta(group_count) * (1 - f_push(op_bits, extra)) * hasher[0] = 0
+
+    # Enforce that when executing a SPAN, a RESPAN, or a PUSH operation, group count must be 
+    # decremented by 1.
+    enf (f_span(op_bits) + f_respan(op_bits, extra) + f_push(op_bits, extra)) * 
+        (delta(group_count) - 1) = 0
+
+    # Enforce that if the next operation is either an END or a RESPAN, group count must remain the 
+    # same.
+    enf delta(group_count) * (f_end_next(op_bits, extra) + f_respan_next(op_bits, extra)) = 0
+
+    # Enforce that when an END operation is executed, group count must be 0.
+    enf f_end(op_bits, extra) * group_count = 0
+
+
+# Enforce that register hasher[0], which is used to keep track of operations to be executed in the 
+# current operation group, is set correctly.
+ev op_group_decoding_constraints(main: [op_bits[7], is_span, group_count, op_index], aux: [extra]):
+    let op = sum([op_bits[i] * 2^i for i in 0..7])
+    let f_sgc = is_span * is_span' * (1 - delta(group_count))
+
+    # Enforce that when a SPAN, a RESPAN, or a PUSH operation is executed or when the group count 
+    # does not change, the value in hasher[0] should be decremented by the value of the opcode in 
+    # the next row.
+    enf (f_span(op_bits) + f_respan(op_bits, extra) + f_push(op_bits, extra) + f_sgc) * 
+        (hasher[0] - hasher[0]' * 2^7 - op_index') = 0
+
+    # Enforce that when we are in a span block and the next operation is END or RESPAN, the current
+    # value in hasher[0] column must be 0.
+    enf is_span * (f_end_next(op_bits, extra) * f_respan_next(op_bits, extra)) * hasher[0] = 0
+
+
+# Enforce that the values in op_index column are set correctly.
+ev op_index_constraints(main: [op_bits[7], is_span, group_count, op_index], aux: [extra]):
+    let ng = delta(group_count) - f_push(op_bits, extra)
+
+    # Enforce that when executing SPAN or RESPAN operations the next value of op_index must be set 
+    # to 0.
+    enf (f_span(op_bits) + f_respan(op_bits, extra)) * op_index' = 0
+
+    # Enforce that when starting a new operation group inside a span block, the next value of 
+    # op_index must be set to 0.
+    enf is_span * ng * op_index' = 0
+
+    # Enforce that when inside a span block but not starting a new operation group, op_index must 
+    # be incremented by 1.
+    enf is_span * is_span' * (1 - ng) * (delta(op_index) - 1) = 0
+
+    # Enforce that values of op_index must be in the range [0, 8].
+    enf prod([op_index - i for i in 0..9]) = 0
+
+
+# Enforce that values in operation batch flag columns (denoted op_batch_flags[]) are set correctly.
+ev op_batch_flag_constraints(main: [op_bits[7], hasher[8], op_batch_flags[3]], aux: [extra]):
+    # Enforce that all batch flags are binary.
+    enf is_binary(bc) for bc in op_batch_flags
+
+    # Enforce that when SPAN or RESPAN operations is executed, one of the batch flags must be set 
+    # to 1.
+    (f_span(op_bits) + f_respan(op_bits, extra)) - (get_f_g1(op_batch_flags) + 
+        get_f_g2(op_batch_flags) + get_f_g4(op_batch_flags) + get_f_g8(op_batch_flags)) = 0
+
+    # Enforce that when we have at most 4 groups in a batch, registers h[4], ..., h[7] should be 
+    # set to 0's.
+    enf (get_f_g1(op_batch_flags) + get_f_g2(op_batch_flags) + get_f_g4(op_batch_flags)) * hasher[i] = 0 for i in 4..8
+
+    # Enforce that When we have at most 2 groups in a batch, registers h[2] and h[3] should also be
+    # set to 0's.
+    (get_f_g1(op_batch_flags) + get_f_g2(op_batch_flags)) * hasher[i] = 0 for i in 2..4
+
+    # Enforce that when we have at most 1 groups in a batch, register h[1] should also be set to 0.
+    enf get_f_g1(op_batch_flags) * hasher[1] = 0
+
+
+# Enforce that all operation groups in a given batch are consumed before a new batch is started 
+# (i.e., via a RESPAN operation) or the execution of a span block is complete (i.e., via an END 
+# operation).
+ev op_group_table_constraints(main: [addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0], aux: [extra, p[4]]):
+    # Values of the rows to be added to the op group table when a SPAN or a RESPAN operation is 
+    # executed.
+    let v_i = alpha[0] + alpha[1] * addr' + alpha[2] * (group_count - i) + alpha[3] * hasher[i]
+
+    # Row value for group in hasher[1] to be added to the op group table when a SPAN or a RESPAN 
+    # operation is executed.
+    let v_1 = alpha[0] + alpha[1] * addr' + alpha[2] * (group_count - 1) + alpha[3] * hasher[1]
+
+    let prod_v_3 = prod([alpha[0] + alpha[1] * addr' + alpha[2] * (group_count - i) + alpha[3] * hasher[i] for i in 1..4])
+    let prod_v_7 = prod([alpha[0] + alpha[1] * addr' + alpha[2] * (group_count - i) + alpha[3] * hasher[i] for i in 1..8])
+
+    # The value of the row to be removed from the op group table.
+    let u = alpha[0] + alpha[1] * addr + alpha[2] * group_count + alpha[3] * 
+        ((hasher[0]' * 2^7 + op_index') * 
+        (1 - f_push(op_bits, extra) + s0' * f_push(op_bits, extra))) = 0
+    
+    # A flag which is set to 1 when a group needs to be removed from the op group table.
+    let f_dg = is_span * delta(group_count)
+
+    # Enforce the constraint for updating op group table
+    enf p[3]' * (f_dg * u + 1 - f_dg) = 
+        p[3] * (get_f_g2(op_batch_flags) * v_1 + get_f_g4(op_batch_flags) * 
+        prod_v_3 + get_f_g8(op_batch_flags) * 
+        prod_v_7 - 1 + (f_span(op_bits) + f_respan(op_bits, extra)))
+    
+
+# Enforces proper decoding of span blocks.
+ev span_block_constraints(main: [addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0], aux: [extra, p[4]]):
+    enf inspan_column_constraints([op_bits, is_span], [extra])
+    enf block_address_constraints([addr, is_span])
+    enf group_count_constraints([op_bits, hasher, is_span, group_count], [extra])
+    enf op_group_decoding_constraints([op_bits, is_span, group_count, op_index], aux: [extra])
+    enf op_index_constraints([op_bits, is_span, group_count, op_index], [extra])
+    enf op_batch_flag_constraints([op_bits, hasher, op_batch_flags], [extra])
+    enf op_group_table_constraints([addr, op_bits, hasher, is_span, group_count, op_index, op_batch_flags, s0], [extra, p])
+
+
+### Decoder Air Constraints #######################################################################
+
+# Enforces the constraints on the decoder. The register `s0` in the main segment denotes the value 
+# at the top of the stack. In the aux segment `extra` denotes the register for degree reduxtion 
+# during flags computation, and p[4] columns denote multiset check columns.
+ev decoder_constraints(main: [addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0], aux: [extra, p[4]]):
+    enf general_constraints([addr, op_bits[7], hasher[8], is_span, s0], [extra])
+    
+    enf block_hash_computation_constraints([addr, op_bits[7], hasher[8]], [extra, p[4]])
+
+    enf block_stack_table_constraints([addr, op_bits[7], hasher[8], s0], [extra, p[4]])
+
+    ev block_hash_table_constraints([addr, op_bits, hasher, s0], [extra, p[4]])
+
+    enf span_block_constraints([addr, op_bits[7], hasher[8], is_span, group_count, op_index, op_batch_flags[3], s0], [extra, p[4]])

--- a/constraints/miden-vm/decoder.air
+++ b/constraints/miden-vm/decoder.air
@@ -14,11 +14,6 @@ fn binary_not(value: scalar) -> scalar:
     return 1 - value
 
 
-# Returns the delta between the value in the next row and in the current row.
-fn delta(v: scalar) -> scalar:
-    return v' - v
-
-
 # Returns the f_join operation flag which is set when JOIN control operation is executed.
 fn f_join(b: vector[7]) -> scalar:
     return b[6] & !b[5] & b[4] & b[3] & !b[2] & b[1]
@@ -39,12 +34,6 @@ fn f_repeat(b: vector[7], extra: scalar) -> scalar:
     return extra & b[4] & !b[3] & b[2]
 
 
-# Returns the f_repeat operation flag which is set when REPEAT operation is executed in the next 
-# row.
-fn f_repeat_next(b: vector[7], extra: scalar) -> scalar:
-    return extra' & b[4]' & !b[3]' & b[2]'
-    
-
 # Returns the f_span operation flag which is set when SPAN operation is executed.
 fn f_span(b: vector[7]) -> scalar:
     return b[6] & !b[5] & b[4] & b[3] & !b[2] & !b[1]
@@ -53,12 +42,6 @@ fn f_span(b: vector[7]) -> scalar:
 # Returns the f_respan operation flag which is set when RESPAN operation is executed.
 fn f_respan(b: vector[7], extra: scalar) -> scalar:
     return extra & b[4] & b[3] & !b[2]
-
-
-# Returns the f_respan operation flag which is set when RESPAN operation is executed in the next 
-# row.
-fn f_respan_next(b: vector[7], extra: scalar) -> scalar:
-    return extra' & b[4]' & b[3]' & !b[2]'
 
 
 # Returns the f_call operation flag which is set when CALL control operation is executed.
@@ -76,21 +59,9 @@ fn f_end(b: vector[7], extra: scalar) -> scalar:
     return extra & b[4] & !b[3] & !b[2]
 
 
-# Returns the f_end operation flag which is set when END operation is executed in the next 
-# row.
-fn f_end_next(b: vector[7], extra: scalar) -> scalar:
-    return extra' & b[4]' & !b[3]' & !b[2]'
-
-
 # Returns the f_halt operation flag which is set when HALT operation is executed.
 fn f_halt(b: vector[7], extra: scalar) -> scalar:
     return extra & b[4] & b[3] & b[2]
-
-
-# Returns the f_halt operation flag which is set when HALT operation is executed in the next 
-# row.
-fn f_halt_next(b: vector[7], extra: scalar) -> scalar:
-    return extra' & b[4]' & b[3]' & b[2]'
 
 
 # Returns the f_push operation flag which is set when PUSH operation is executed.
@@ -156,7 +127,8 @@ ev is_unchanged(main: [column]):
 
 # Enforces decoder general constraints.
 ev general_constraints(main: [addr, op_bits[7], hasher[8], is_span, s0], aux: [extra]):
-    # TODO: add constraints to check not used operational bits.
+    let op_bits_next = [op_bits[0]', op_bits[1]', op_bits[2]', op_bits[3]', op_bits[4]', op_bits[5]', op_bits[6]']
+    let extra_next = extra'
 
     # Enforce that when SPLIT or LOOP operation is executed, the top of the operand stack must 
     # contain a binary value.
@@ -183,10 +155,10 @@ ev general_constraints(main: [addr, op_bits[7], hasher[8], is_span, s0], aux: [e
     # Enforce that when END operation is executed and the next operation is REPEAT, values in 
     # hasher[0], ..., hasher[4] (the hash of the current block and the is_loop_body flag) must be 
     # copied to the next row.
-    enf is_unchanged([hasher[i]]) for i in 0..5 when f_end(op_bits, extra) & f_repeat_next(op_bits, extra)
+    enf is_unchanged([hasher[i]]) for i in 0..5 when f_end(op_bits, extra) & f_repeat(op_bits_next, extra_next)
 
     # Enforce that a HALT instruction can be followed only by another HALT instruction.
-    enf f_halt(op_bits, extra) * !f_halt_next = 0
+    enf f_halt(op_bits, extra) * !f_halt(op_bits_next, extra_next) = 0
 
     # Enforce that when a HALT operation is executed, block address column (addr) must be 0.
     enf addr = 0 when f_halt(op_bits, extra)
@@ -294,6 +266,9 @@ ev block_stack_table_constraints(main: [addr, op_bits[7], hasher[8], s0], aux: [
 
 # Enforces constraint for updating the block hash table.
 ev block_hash_table_constraints(main: [addr, op_bits[7], hasher[8], s0], aux: [extra, p[4]]):
+    let op_bits_next = [op_bits[0]', op_bits[1]', op_bits[2]', op_bits[3]', op_bits[4]', op_bits[5]', op_bits[6]']
+    let extra_next = extra'
+
     # Values representing left and right children of a block.
     let ch1 = alpha[0] + alpha[1] * addr' + sum([alpha[i + 2] * hasher[i] for i in 0..4])
     let ch2 = alpha[0] + alpha[1] * addr' + sum([alpha[i + 2] * hasher[i + 4] for i in 0..4])
@@ -320,7 +295,7 @@ ev block_hash_table_constraints(main: [addr, op_bits[7], hasher[8], s0], aux: [e
     # When END operation is executed, hash of the completed block is removed from the block hash 
     # table.
     let u_end = f_end(op_bits, extra) * 
-        (bh + alpha[6] * (1 - (f_end_next(op_bits, extra) + f_repeat_next(op_bits, extra))))
+        (bh + alpha[6] * (1 - (f_end(op_bits_next, extra_next) + f_repeat(op_bits_next, extra_next))))
 
     # Enforce the block hash table constraint.
     enf p[2]' * (u_end + 1 - f_end(op_bits, extra)) = 
@@ -332,18 +307,21 @@ ev block_hash_table_constraints(main: [addr, op_bits[7], hasher[8], s0], aux: [e
 
 # Enforce that values in is_span column are set correctly. 
 ev inspan_column_constraints(main: [op_bits[7], is_span], aux: [extra]):
+    let op_bits_next = [op_bits[0]', op_bits[1]', op_bits[2]', op_bits[3]', op_bits[4]', op_bits[5]', op_bits[6]']
+    let extra_next = extra'
+
     # Enforce that when executing SPAN or RESPAN operation, the next value in is_span column must 
     # be set to 1.
     enf (f_span(op_bits) + f_respan(op_bits, extra)) * binary_not(is_span') = 0
 
     # Enforce that when the next operation is END or RESPAN, the next value in is_span column must 
     # be set 0.
-    enf (f_end_next(op_bits, extra) + f_respan_next(op_bits, extra)) * is_span' = 0
+    enf (f_end(op_bits_next, extra_next) + f_respan(op_bits_next, extra_next)) * is_span' = 0
 
     # Enforce that in all other cases, the value in is_span column must be copied over to the next 
     # row.
-    (1 - f_span(op_bits) - f_respan(op_bits, extra) - f_end_next(op_bits, extra) - 
-        f_respan_next(op_bits, extra)) * (is_span' - is_span) = 0
+    (1 - f_span(op_bits) - f_respan(op_bits, extra) - f_end(op_bits_next, extra_next) - 
+        f_respan(op_bits_next, extra_next)) * (is_span' - is_span) = 0
 
     # TODO: add boundary constraint for is_span column.
 
@@ -353,26 +331,29 @@ ev inspan_column_constraints(main: [op_bits[7], is_span], aux: [extra]):
 ev block_address_constraints(main: [addr, is_span]):
     # Enforce that when we are inside a span block, values in block address columns must remain the
     # same.
-    enf is_span * delta(addr) = 0
+    enf is_span * (addr' - addr) = 0
 
 
 # Enforce that values in group_count column are set correctly.
 ev group_count_constraints(main: [op_bits[7], hasher[8], is_span, group_count], aux: [extra]):
+    let op_bits_next = [op_bits[0]', op_bits[1]', op_bits[2]', op_bits[3]', op_bits[4]', op_bits[5]', op_bits[6]']
+    let extra_next = extra'
+    
     # Enforce that inside a span block, group count can either stay the same or decrease by one.
-    enf is_span * delta(group_count) * (delta(group_count) - 1) = 0
+    enf is_span * (group_count' - group_count) * (group_count' - group_count - 1) = 0
     
     # Enforce that when group count is decremented inside a span block, either hasher[0] must be 0 
     # (we consumed all operations in a group) or we must be executing PUSH operation.
-    enf is_span * delta(group_count) * (1 - f_push(op_bits, extra)) * hasher[0] = 0
+    enf is_span * (group_count' - group_count) * (1 - f_push(op_bits, extra)) * hasher[0] = 0
 
     # Enforce that when executing a SPAN, a RESPAN, or a PUSH operation, group count must be 
     # decremented by 1.
     enf (f_span(op_bits) + f_respan(op_bits, extra) + f_push(op_bits, extra)) * 
-        (delta(group_count) - 1) = 0
+        (group_count' - group_count - 1) = 0
 
     # Enforce that if the next operation is either an END or a RESPAN, group count must remain the 
     # same.
-    enf delta(group_count) * (f_end_next(op_bits, extra) + f_respan_next(op_bits, extra)) = 0
+    enf (group_count' - group_count) * (f_end(op_bits_next, extra_next) + f_respan(op_bits_next, extra_next)) = 0
 
     # Enforce that when an END operation is executed, group count must be 0.
     enf f_end(op_bits, extra) * group_count = 0
@@ -381,8 +362,11 @@ ev group_count_constraints(main: [op_bits[7], hasher[8], is_span, group_count], 
 # Enforce that register hasher[0], which is used to keep track of operations to be executed in the 
 # current operation group, is set correctly.
 ev op_group_decoding_constraints(main: [op_bits[7], is_span, group_count, op_index], aux: [extra]):
+    let op_bits_next = [op_bits[0]', op_bits[1]', op_bits[2]', op_bits[3]', op_bits[4]', op_bits[5]', op_bits[6]']
+    let extra_next = extra'
+    
     let op = sum([op_bits[i] * 2^i for i in 0..7])
-    let f_sgc = is_span * is_span' * (1 - delta(group_count))
+    let f_sgc = is_span * is_span' * (1 - group_count' + group_count)
 
     # Enforce that when a SPAN, a RESPAN, or a PUSH operation is executed or when the group count 
     # does not change, the value in hasher[0] should be decremented by the value of the opcode in 
@@ -392,12 +376,12 @@ ev op_group_decoding_constraints(main: [op_bits[7], is_span, group_count, op_ind
 
     # Enforce that when we are in a span block and the next operation is END or RESPAN, the current
     # value in hasher[0] column must be 0.
-    enf is_span * (f_end_next(op_bits, extra) * f_respan_next(op_bits, extra)) * hasher[0] = 0
+    enf is_span * (f_end(op_bits_next, extra_next) * f_respan(op_bits_next, extra_next)) * hasher[0] = 0
 
 
 # Enforce that the values in op_index column are set correctly.
 ev op_index_constraints(main: [op_bits[7], is_span, group_count, op_index], aux: [extra]):
-    let ng = delta(group_count) - f_push(op_bits, extra)
+    let ng = group_count' - group_count - f_push(op_bits, extra)
 
     # Enforce that when executing SPAN or RESPAN operations the next value of op_index must be set 
     # to 0.
@@ -409,7 +393,7 @@ ev op_index_constraints(main: [op_bits[7], is_span, group_count, op_index], aux:
 
     # Enforce that when inside a span block but not starting a new operation group, op_index must 
     # be incremented by 1.
-    enf is_span * is_span' * (1 - ng) * (delta(op_index) - 1) = 0
+    enf is_span * is_span' * (1 - ng) * (op_index' - op_index - 1) = 0
 
     # Enforce that values of op_index must be in the range [0, 8].
     enf prod([op_index - i for i in 0..9]) = 0
@@ -458,7 +442,7 @@ ev op_group_table_constraints(main: [addr, op_bits[7], hasher[8], is_span, group
         (1 - f_push(op_bits, extra) + s0' * f_push(op_bits, extra))) = 0
     
     # A flag which is set to 1 when a group needs to be removed from the op group table.
-    let f_dg = is_span * delta(group_count)
+    let f_dg = is_span * (group_count' - group_count)
 
     # Enforce the constraint for updating op group table
     enf p[3]' * (f_dg * u + 1 - f_dg) = 


### PR DESCRIPTION
Addressing: #206 
This PR adds:
- general constraints
- block hash computation constraints
- block stack table constraints
- block hash table constraints
- span block constraints