### PR TITLE
feat(IR): insert evaluator subgraph to constraint graph

### DIFF
--- a/air-script/tests/bitwise/bitwise_with_evaluator.air
+++ b/air-script/tests/bitwise/bitwise_with_evaluator.air
@@ -1,0 +1,71 @@
+def BitwiseAir
+
+# Enforces that column must be binary
+ev check_binary(main: [x]):
+    enf x^2 - x = 0
+
+public_inputs:
+    stack_inputs: [16]
+
+trace_columns:
+    main: [s, a, b, a_limb[4], b_limb[4], zp, z, dummy]
+
+periodic_columns:
+    k0: [1, 0, 0, 0, 0, 0, 0, 0]
+    k1: [1, 1, 1, 1, 1, 1, 1, 0]
+
+boundary_constraints:
+    # This is a dummy trace column to satisfy requirement of at least one boundary constraint.
+    enf dummy.first = 0
+
+integrity_constraints:
+    # Enforce that selector must be binary
+    enf check_binary([s])
+
+    # Enforce that selector should stay the same throughout the cycle.
+    enf k1 * (s' - s) = 0
+
+    # Enforce that the input is decomposed into valid bits
+    enf check_binary([a_limb[0]])
+    enf check_binary([a_limb[1]])
+    enf check_binary([a_limb[2]])
+    enf check_binary([a_limb[3]])
+    enf check_binary([b_limb[0]])
+    enf check_binary([b_limb[1]])
+    enf check_binary([b_limb[2]])
+    enf check_binary([b_limb[3]])
+
+    # Enforce that the value in the first row of column `a` of the current 8-row cycle should be 
+    # the aggregation of the decomposed bit columns `a_limb`.
+    let a_aggr = sum([2^i * a for (i, a) in (0..4, a_limb)])
+    enf k0 * (a - a_aggr) = 0
+
+    # Enforce that the value in the first row of column `b` of the current 8-row cycle should be 
+    # the aggregation of the decomposed bit columns `b_limb`.
+    let b_aggr = sum([2^i * b for (i, b) in (0..4, b_limb)])
+    enf k0 * (b - b_aggr) = 0
+
+    # Enforce that for all rows in an 8-row cycle, except for the last one, the values in a and b
+    # columns are increased by the values contained in the individual bit columns a_limb and 
+    # b_limb.
+    enf k1 * (a' - (a * 16 + a_aggr)) = 0
+    enf k1 * (b' - (b * 16 + b_aggr)) = 0
+
+    # Enforce that in the first row, the aggregated output value of the previous row should be 0.
+    enf k0 * zp = 0
+
+    # Enforce that for each row except the last, the aggregated output value must equal the
+    # previous aggregated output value in the next row.
+    enf k1 * (z - zp') = 0
+
+    # Enforce that for all rows the value in the z column is computed by multiplying the previous
+    # output value (from the zp column in the current row) by 16 and then adding it to the bitwise
+    # operation applied to the row's set of bits of a_limb and b_limb. The entire constraint must 
+    # also be multiplied by the operation selector flag to ensure it is only applied for the 
+    # appropriate operation. The constraint for AND is enforced when s = 0 and the constraint for 
+    # XOR is enforced when s = 1. Because the selectors for the AND and XOR operations are mutually
+    # exclusive, the constraints for different operations can be aggregated into the same result
+    # indices.
+    let a_and_b = sum([2^i * a * b for (i, a, b) in (0..4, a_limb, b_limb)])
+    let a_xor_b = sum([2^i * (a + b - 2 * a * b) for (i, a, b) in (0..4, a_limb, b_limb)])
+    enf (1 - s) * (z - (zp * 16 + a_and_b)) + s * (z - (zp * 16 + a_xor_b)) = 0

--- a/air-script/tests/main.rs
+++ b/air-script/tests/main.rs
@@ -64,6 +64,14 @@ fn bitwise() {
 
     let expected = expect_file!["bitwise/bitwise.rs"];
     expected.assert_eq(&generated_air);
+
+    // bitwise constraints using evaluator should generate the same code
+    let generated_air = Test::new("tests/bitwise/bitwise_with_evaluator.air".to_string())
+        .transpile()
+        .unwrap();
+
+    let expected = expect_file!["bitwise/bitwise.rs"];
+    expected.assert_eq(&generated_air);
 }
 
 #[test]

--- a/ir/src/constraint_builder/integrity_constraints/mod.rs
+++ b/ir/src/constraint_builder/integrity_constraints/mod.rs
@@ -54,9 +54,13 @@ impl ConstraintBuilder {
                             }
                         }
                         // apply the evaluator to the arguments and return the resulting graph
-                        let (_subgraph, _constraint_nodes) = evaluator.apply(accesses)?;
+                        let (subgraph, mut constraint_nodes) = evaluator.apply(accesses)?;
 
-                        // TODO: insert the subgraph into the main graph and save the entry node index
+                        // insert the subgraph into the main graph and save the entry node index
+                        self.graph.insert_subgraph(&subgraph, &mut constraint_nodes);
+                        for constraint_node in constraint_nodes {
+                            self.integrity_constraints.push(constraint_node);
+                        }
                     }
                     None => {
                         todo!("Error");


### PR DESCRIPTION
This PR inserts the evaluator subgraph to the constraint subgraph. Insertion happens as follows:
1. for each node in the subgraph, if the node is already present in the constraint graph, we don't add a redundant node, instead adds a mapping for the new node to the existing node.
2. We use the above mapping to replace the subgraph nodes referenced in arithmetic operations with the existing nodes in the constraint graph instead.