### PR TITLE
Small fix of range checker constraints

### DIFF
--- a/constraints/miden-vm/range-checker.air
+++ b/constraints/miden-vm/range-checker.air
@@ -8,10 +8,6 @@ fn binary_not(e: scalar) -> scalar:
 
 ### Helper evaluators #############################################################################
 
-# Returns the change in value between current and next rows.
-fn delta(e: scalar) -> scalar:
-    return e' - e
-
 # Enforces that column must be binary.
 ev is_binary(main: [v]):
     enf v^2 = v
@@ -32,10 +28,10 @@ ev transition_8_to_16_bit_validity(main: [t, v]):
 ev range_checker(main: [t, s0, s1, v]):
     # Check selector flags are binary
     let selectors = [t, s0, s1]
-    enf check_binary([s]) for s in selectors
+    enf is_binary([s]) for s in selectors
 
     # Constrain the row transitions in the 8-bit section of the table
-    enf change(v) * (change(v) - 1) = 0 when !t0'
+    enf (v' - v) * (v' - v - 1) = 0 when !t'
 
     # Constrain the transition from 8-bit to 16-bit section of the table
     enf transition_8_to_16_bit_validity([t, v])


### PR DESCRIPTION
This PR fixes usage of old function names and incorrect usage of next row operator `'`.