### PR TITLE
Rename core types for clarity

### DIFF
--- a/air-script-core/README.md
+++ b/air-script-core/README.md
@@ -3,7 +3,7 @@
 This crate contains the core components used by other crates in AirScript. These components include:
 
 - Access structures defined in [VectorAccess and MatrixAccess](./access.rs) structs
-- Constant structure defined in [Constant](./constant.rs) struct
+- Constant structure defined in [ConstantBinding](./constant.rs) struct
 - Expression set defined in [Expression](./expression.rs) enum
 - Identifier structure defined in [Identifier](./identifier.rs) struct
 - Trace Access structures defined in [TraceBindingAccess and TraceAccess](./trace.rs) structs

--- a/air-script-core/src/comprehension.rs
+++ b/air-script-core/src/comprehension.rs
@@ -32,12 +32,12 @@ impl ListComprehension {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ListFolding {
-    Sum(ListFoldingValueType),
-    Prod(ListFoldingValueType),
+    Sum(ListFoldingValueExpr),
+    Prod(ListFoldingValueExpr),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum ListFoldingValueType {
+pub enum ListFoldingValueExpr {
     Identifier(Identifier),
     Vector(Vec<Expression>),
     ListComprehension(ListComprehension),

--- a/air-script-core/src/constant.rs
+++ b/air-script-core/src/constant.rs
@@ -10,12 +10,12 @@ use super::Identifier;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConstantBinding {
     name: Identifier,
-    value: ConstantType,
+    value: ConstantValueExpr,
 }
 
 impl ConstantBinding {
     /// Returns a new instance of a [ConstantBinding]
-    pub fn new(name: Identifier, value: ConstantType) -> Self {
+    pub fn new(name: Identifier, value: ConstantValueExpr) -> Self {
         Self { name, value }
     }
 
@@ -25,21 +25,21 @@ impl ConstantBinding {
     }
 
     /// Returns the value of the [ConstantBinding]
-    pub fn value(&self) -> &ConstantType {
+    pub fn value(&self) -> &ConstantValueExpr {
         &self.value
     }
 
-    pub fn into_parts(self) -> (String, ConstantType) {
+    pub fn into_parts(self) -> (String, ConstantValueExpr) {
         (self.name.into_name(), self.value)
     }
 }
 
-/// Type of constant. Constants can be of 3 types:
+/// Value of a constant. Constants can be of 3 value types:
 /// - Scalar: 123
 /// - Vector: \[1, 2, 3\]
 /// - Matrix: \[\[1, 2, 3\], \[4, 5, 6\]\]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum ConstantType {
+pub enum ConstantValueExpr {
     Scalar(u64),
     Vector(Vec<u64>),
     Matrix(Vec<Vec<u64>>),

--- a/air-script-core/src/constant.rs
+++ b/air-script-core/src/constant.rs
@@ -8,23 +8,23 @@ use super::Identifier;
 /// - Vector: \[1, 2, 3\]
 /// - Matrix: \[\[1, 2, 3\], \[4, 5, 6\]\]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Constant {
+pub struct ConstantBinding {
     name: Identifier,
     value: ConstantType,
 }
 
-impl Constant {
-    /// Returns a new instance of a [Constant]
+impl ConstantBinding {
+    /// Returns a new instance of a [ConstantBinding]
     pub fn new(name: Identifier, value: ConstantType) -> Self {
         Self { name, value }
     }
 
-    /// Returns the name of the [Constant]
+    /// Returns the name of the [ConstantBinding]
     pub fn name(&self) -> &Identifier {
         &self.name
     }
 
-    /// Returns the value of the [Constant]
+    /// Returns the value of the [ConstantBinding]
     pub fn value(&self) -> &ConstantType {
         &self.value
     }

--- a/air-script-core/src/lib.rs
+++ b/air-script-core/src/lib.rs
@@ -2,11 +2,11 @@ mod access;
 pub use access::{Iterable, MatrixAccess, Range, VectorAccess};
 
 mod constant;
-pub use constant::{ConstantBinding, ConstantType};
+pub use constant::{ConstantBinding, ConstantValueExpr};
 
 mod comprehension;
 pub use comprehension::{
-    ComprehensionContext, ListComprehension, ListFolding, ListFoldingValueType,
+    ComprehensionContext, ListComprehension, ListFolding, ListFoldingValueExpr,
 };
 
 mod expression;
@@ -21,4 +21,4 @@ pub use trace::{
 };
 
 mod variable;
-pub use variable::{VariableBinding, VariableType};
+pub use variable::{VariableBinding, VariableValueExpr};

--- a/air-script-core/src/lib.rs
+++ b/air-script-core/src/lib.rs
@@ -2,7 +2,7 @@ mod access;
 pub use access::{Iterable, MatrixAccess, Range, VectorAccess};
 
 mod constant;
-pub use constant::{Constant, ConstantType};
+pub use constant::{ConstantBinding, ConstantType};
 
 mod comprehension;
 pub use comprehension::{
@@ -21,4 +21,4 @@ pub use trace::{
 };
 
 mod variable;
-pub use variable::{Variable, VariableType};
+pub use variable::{VariableBinding, VariableType};

--- a/air-script-core/src/variable.rs
+++ b/air-script-core/src/variable.rs
@@ -4,11 +4,11 @@ use std::fmt::Display;
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct VariableBinding {
     name: Identifier,
-    value: VariableType,
+    value: VariableValueExpr,
 }
 
 impl VariableBinding {
-    pub fn new(name: Identifier, value: VariableType) -> Self {
+    pub fn new(name: Identifier, value: VariableValueExpr) -> Self {
         Self { name, value }
     }
 
@@ -16,24 +16,25 @@ impl VariableBinding {
         self.name.name()
     }
 
-    pub fn value(&self) -> &VariableType {
+    pub fn value(&self) -> &VariableValueExpr {
         &self.value
     }
 
-    pub fn into_parts(self) -> (String, VariableType) {
+    pub fn into_parts(self) -> (String, VariableValueExpr) {
         (self.name.into_name(), self.value)
     }
 }
 
+/// The expression or expressions that define the value of a variable binding.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum VariableType {
+pub enum VariableValueExpr {
     Scalar(Expression),
     Vector(Vec<Expression>),
     Matrix(Vec<Vec<Expression>>),
     ListComprehension(ListComprehension),
 }
 
-impl Display for VariableType {
+impl Display for VariableValueExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Scalar(_) => write!(f, "scalar"),

--- a/air-script-core/src/variable.rs
+++ b/air-script-core/src/variable.rs
@@ -2,12 +2,12 @@ use super::{Expression, Identifier, ListComprehension};
 use std::fmt::Display;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Variable {
+pub struct VariableBinding {
     name: Identifier,
     value: VariableType,
 }
 
-impl Variable {
+impl VariableBinding {
     pub fn new(name: Identifier, value: VariableType) -> Self {
         Self { name, value }
     }

--- a/codegen/winterfell/src/air/constants.rs
+++ b/codegen/winterfell/src/air/constants.rs
@@ -1,4 +1,4 @@
-use super::{AirIR, Constant, ConstantType, Scope};
+use super::{AirIR, ConstantBinding, ConstantType, Scope};
 
 /// Updates the provided scope with constant declarations.
 pub(super) fn add_constants(scope: &mut Scope, ir: &AirIR) {
@@ -37,7 +37,7 @@ trait Codegen {
     fn to_string(&self) -> String;
 }
 
-impl Codegen for Constant {
+impl Codegen for ConstantBinding {
     fn to_string(&self) -> String {
         match self.value() {
             ConstantType::Scalar(scalar_const) => match scalar_const {

--- a/codegen/winterfell/src/air/constants.rs
+++ b/codegen/winterfell/src/air/constants.rs
@@ -1,4 +1,4 @@
-use super::{AirIR, ConstantBinding, ConstantType, Scope};
+use super::{AirIR, ConstantBinding, ConstantValueExpr, Scope};
 
 /// Updates the provided scope with constant declarations.
 pub(super) fn add_constants(scope: &mut Scope, ir: &AirIR) {
@@ -6,20 +6,20 @@ pub(super) fn add_constants(scope: &mut Scope, ir: &AirIR) {
     let mut consts = vec![];
     for constant in constants {
         let const_str = match constant.value() {
-            ConstantType::Scalar(_) => {
+            ConstantValueExpr::Scalar(_) => {
                 format!(
                     "const {}: Felt = {};",
                     constant.name(),
                     constant.to_string()
                 )
             }
-            ConstantType::Vector(vector) => format!(
+            ConstantValueExpr::Vector(vector) => format!(
                 "const {}: [Felt; {}] = {};",
                 constant.name(),
                 vector.len(),
                 constant.to_string()
             ),
-            ConstantType::Matrix(matrix) => format!(
+            ConstantValueExpr::Matrix(matrix) => format!(
                 "const {}: [[Felt; {}]; {}] = {};",
                 constant.name(),
                 matrix[0].len(),
@@ -40,14 +40,14 @@ trait Codegen {
 impl Codegen for ConstantBinding {
     fn to_string(&self) -> String {
         match self.value() {
-            ConstantType::Scalar(scalar_const) => match scalar_const {
+            ConstantValueExpr::Scalar(scalar_const) => match scalar_const {
                 0 => "Felt::ZERO".to_string(),
                 1 => "Felt::ONE".to_string(),
                 _ => {
                     format!("Felt::new({scalar_const})")
                 }
             },
-            ConstantType::Vector(vector_const) => format!(
+            ConstantValueExpr::Vector(vector_const) => format!(
                 "[{}]",
                 vector_const
                     .iter()
@@ -61,7 +61,7 @@ impl Codegen for ConstantBinding {
                     .collect::<Vec<String>>()
                     .join(", ")
             ),
-            ConstantType::Matrix(matrix_const) => {
+            ConstantValueExpr::Matrix(matrix_const) => {
                 let mut rows = vec![];
                 for row in matrix_const {
                     rows.push(format!(

--- a/codegen/winterfell/src/air/mod.rs
+++ b/codegen/winterfell/src/air/mod.rs
@@ -1,5 +1,5 @@
 use super::{AirIR, Impl, Scope};
-use air_script_core::{Constant, ConstantType, TraceAccess};
+use air_script_core::{ConstantBinding, ConstantType, TraceAccess};
 use ir::{
     constraints::{AlgebraicGraph, ConstraintDomain, Operation},
     ConstantValue, IntegrityConstraintDegree, NodeIndex, PeriodicColumn, Value,

--- a/codegen/winterfell/src/air/mod.rs
+++ b/codegen/winterfell/src/air/mod.rs
@@ -1,5 +1,5 @@
 use super::{AirIR, Impl, Scope};
-use air_script_core::{ConstantBinding, ConstantType, TraceAccess};
+use air_script_core::{ConstantBinding, ConstantValueExpr, TraceAccess};
 use ir::{
     constraints::{AlgebraicGraph, ConstraintDomain, Operation},
     ConstantValue, IntegrityConstraintDegree, NodeIndex, PeriodicColumn, Value,

--- a/ir/src/constraint_builder/boundary_constraints.rs
+++ b/ir/src/constraint_builder/boundary_constraints.rs
@@ -96,7 +96,9 @@ impl ConstraintBuilder {
                 // save the constraint information
                 self.insert_constraint(root, lhs_segment.into(), domain)?
             }
-            BoundaryStmt::Variable(variable) => self.symbol_table.insert_variable(variable)?,
+            BoundaryStmt::VariableBinding(variable) => {
+                self.symbol_table.insert_variable(variable)?
+            }
             BoundaryStmt::ConstraintComprehension(_, _) => todo!(),
         }
 

--- a/ir/src/constraint_builder/integrity_constraints/list_comprehension.rs
+++ b/ir/src/constraint_builder/integrity_constraints/list_comprehension.rs
@@ -1,7 +1,7 @@
 use super::{
     BTreeMap, ConstraintBuilder, Expression, Identifier, Iterable, ListComprehension, ListFolding,
-    ListFoldingValueType, SemanticError, Symbol, SymbolType, TraceAccess, TraceBindingAccess,
-    TraceBindingAccessSize, VariableType, VectorAccess, CURRENT_ROW,
+    ListFoldingValueExpr, SemanticError, Symbol, SymbolType, TraceAccess, TraceBindingAccess,
+    TraceBindingAccessSize, VariableValueExpr, VectorAccess, CURRENT_ROW,
 };
 
 /// Maps each identifier in the list comprehension to its corresponding [Iterable].
@@ -185,7 +185,7 @@ impl ConstraintBuilder {
             ListFolding::Sum(lf_value_type) | ListFolding::Prod(lf_value_type) => {
                 let list = self.build_list_from_list_folding_value(lf_value_type)?;
                 let iterable_context =
-                    if let ListFoldingValueType::ListComprehension(lc) = lf_value_type {
+                    if let ListFoldingValueExpr::ListComprehension(lc) = lf_value_type {
                         build_iterable_context(lc)?
                     } else {
                         BTreeMap::new()
@@ -238,7 +238,7 @@ impl ConstraintBuilder {
                 let symbol = self.symbol_table.get_symbol(ident.name())?;
                 match symbol.symbol_type() {
                     SymbolType::Variable(variable_type) => match variable_type {
-                        VariableType::Vector(vector) => Ok(vector.len()),
+                        VariableValueExpr::Vector(vector) => Ok(vector.len()),
                         _ => Err(SemanticError::InvalidListComprehension(format!(
                             "Variable {} should be a vector for a valid list comprehension.",
                             symbol.name()
@@ -312,7 +312,7 @@ fn build_ident_expression(symbol: &Symbol, i: usize) -> Result<Expression, Seman
         }
         SymbolType::Variable(variable_type) => {
             match variable_type {
-                VariableType::Vector(vector) => {
+                VariableValueExpr::Vector(vector) => {
                     validate_access(i, vector.len())?;
                     Ok(vector[i].clone())
                 }
@@ -367,7 +367,7 @@ fn build_slice_ident_expression(
         }
         SymbolType::Variable(variable) => {
             match variable {
-                VariableType::Vector(vector) => {
+                VariableValueExpr::Vector(vector) => {
                     validate_access(i, vector.len())?;
                     Ok(vector[range_start + i].clone())
                 }

--- a/ir/src/constraint_builder/integrity_constraints/list_folding.rs
+++ b/ir/src/constraint_builder/integrity_constraints/list_folding.rs
@@ -1,6 +1,6 @@
 use super::{
-    ConstantType, ConstraintBuilder, Expression, ListFoldingValueType, SemanticError, SymbolType,
-    TraceAccess, VariableType, CURRENT_ROW,
+    ConstantValueExpr, ConstraintBuilder, Expression, ListFoldingValueExpr, SemanticError,
+    SymbolType, TraceAccess, VariableValueExpr, CURRENT_ROW,
 };
 
 // LIST FOLDING
@@ -16,17 +16,17 @@ impl ConstraintBuilder {
     /// - the list folding value is an identifier that does not refer to a vector
     pub fn build_list_from_list_folding_value(
         &self,
-        lf_value_type: &ListFoldingValueType,
+        lf_value_type: &ListFoldingValueExpr,
     ) -> Result<Vec<Expression>, SemanticError> {
         match lf_value_type {
-            ListFoldingValueType::Identifier(ident) => {
+            ListFoldingValueExpr::Identifier(ident) => {
                 let symbol = self.symbol_table.get_symbol(ident.name())?;
                 match symbol.symbol_type() {
-                    SymbolType::Constant(ConstantType::Vector(list)) => {
+                    SymbolType::Constant(ConstantValueExpr::Vector(list)) => {
                         Ok(list.iter().map(|value| Expression::Const(*value)).collect())
                     }
                     SymbolType::Variable(variable_type) => {
-                        if let VariableType::Vector(list) = variable_type {
+                        if let VariableValueExpr::Vector(list) = variable_type {
                             Ok(list.clone())
                         } else {
                             Err(SemanticError::invalid_list_folding(
@@ -61,8 +61,8 @@ impl ConstraintBuilder {
                     )),
                 }
             }
-            ListFoldingValueType::Vector(vector) => Ok(vector.clone()),
-            ListFoldingValueType::ListComprehension(lc) => Ok(self.unfold_lc(lc)?),
+            ListFoldingValueExpr::Vector(vector) => Ok(vector.clone()),
+            ListFoldingValueExpr::ListComprehension(lc) => Ok(self.unfold_lc(lc)?),
         }
     }
 }

--- a/ir/src/constraint_builder/integrity_constraints/mod.rs
+++ b/ir/src/constraint_builder/integrity_constraints/mod.rs
@@ -1,9 +1,9 @@
 use super::{
     ast::{ConstraintType, IntegrityStmt},
-    BTreeMap, ConstantType, ConstraintBuilder, ConstraintDomain, Expression, Identifier, Iterable,
-    ListComprehension, ListFolding, ListFoldingValueType, SemanticError, Symbol, SymbolType,
-    TraceAccess, TraceBindingAccess, TraceBindingAccessSize, VariableBinding, VariableType,
-    VectorAccess, CURRENT_ROW,
+    BTreeMap, ConstantValueExpr, ConstraintBuilder, ConstraintDomain, Expression, Identifier,
+    Iterable, ListComprehension, ListFolding, ListFoldingValueExpr, SemanticError, Symbol,
+    SymbolType, TraceAccess, TraceBindingAccess, TraceBindingAccessSize, VariableBinding,
+    VariableValueExpr, VectorAccess, CURRENT_ROW,
 };
 
 mod list_comprehension;
@@ -43,11 +43,11 @@ impl ConstraintBuilder {
                 self.insert_constraint(root, trace_segment.into(), domain)?;
             }
             IntegrityStmt::VariableBinding(variable) => {
-                if let VariableType::ListComprehension(list_comprehension) = variable.value() {
+                if let VariableValueExpr::ListComprehension(list_comprehension) = variable.value() {
                     let vector = self.unfold_lc(list_comprehension)?;
                     self.symbol_table.insert_variable(VariableBinding::new(
                         Identifier(variable.name().to_string()),
-                        VariableType::Vector(vector),
+                        VariableValueExpr::Vector(vector),
                     ))?
                 } else {
                     self.symbol_table.insert_variable(variable)?

--- a/ir/src/constraint_builder/integrity_constraints/mod.rs
+++ b/ir/src/constraint_builder/integrity_constraints/mod.rs
@@ -2,8 +2,8 @@ use super::{
     ast::{ConstraintType, IntegrityStmt},
     BTreeMap, ConstantType, ConstraintBuilder, ConstraintDomain, Expression, Identifier, Iterable,
     ListComprehension, ListFolding, ListFoldingValueType, SemanticError, Symbol, SymbolType,
-    TraceAccess, TraceBindingAccess, TraceBindingAccessSize, Variable, VariableType, VectorAccess,
-    CURRENT_ROW,
+    TraceAccess, TraceBindingAccess, TraceBindingAccessSize, VariableBinding, VariableType,
+    VectorAccess, CURRENT_ROW,
 };
 
 mod list_comprehension;
@@ -42,10 +42,10 @@ impl ConstraintBuilder {
                 // save the constraint information
                 self.insert_constraint(root, trace_segment.into(), domain)?;
             }
-            IntegrityStmt::Variable(variable) => {
+            IntegrityStmt::VariableBinding(variable) => {
                 if let VariableType::ListComprehension(list_comprehension) = variable.value() {
                     let vector = self.unfold_lc(list_comprehension)?;
-                    self.symbol_table.insert_variable(Variable::new(
+                    self.symbol_table.insert_variable(VariableBinding::new(
                         Identifier(variable.name().to_string()),
                         VariableType::Vector(vector),
                     ))?

--- a/ir/src/constraint_builder/mod.rs
+++ b/ir/src/constraint_builder/mod.rs
@@ -1,10 +1,10 @@
 use super::{
-    ast, AccessType, AlgebraicGraph, BTreeMap, BTreeSet, ConstantType, ConstantValue,
+    ast, AccessType, AlgebraicGraph, BTreeMap, BTreeSet, ConstantValue, ConstantValueExpr,
     ConstraintDomain, ConstraintRoot, Constraints, Declarations, Expression, Identifier, Iterable,
-    ListComprehension, ListFolding, ListFoldingValueType, MatrixAccess, NodeIndex, Operation,
+    ListComprehension, ListFolding, ListFoldingValueExpr, MatrixAccess, NodeIndex, Operation,
     SemanticError, Symbol, SymbolTable, SymbolType, TraceAccess, TraceBindingAccess,
-    TraceBindingAccessSize, TraceSegment, ValidateAccess, Value, VariableBinding, VariableType,
-    VectorAccess, CURRENT_ROW,
+    TraceBindingAccessSize, TraceSegment, ValidateAccess, Value, VariableBinding,
+    VariableValueExpr, VectorAccess, CURRENT_ROW,
 };
 
 mod boundary_constraints;

--- a/ir/src/constraint_builder/mod.rs
+++ b/ir/src/constraint_builder/mod.rs
@@ -3,7 +3,7 @@ use super::{
     ConstraintDomain, ConstraintRoot, Constraints, Declarations, Expression, Identifier, Iterable,
     ListComprehension, ListFolding, ListFoldingValueType, MatrixAccess, NodeIndex, Operation,
     SemanticError, Symbol, SymbolTable, SymbolType, TraceAccess, TraceBindingAccess,
-    TraceBindingAccessSize, TraceSegment, ValidateAccess, Value, Variable, VariableType,
+    TraceBindingAccessSize, TraceSegment, ValidateAccess, Value, VariableBinding, VariableType,
     VectorAccess, CURRENT_ROW,
 };
 

--- a/ir/src/declarations.rs
+++ b/ir/src/declarations.rs
@@ -1,4 +1,4 @@
-use super::{Constant, SemanticError};
+use super::{ConstantBinding, SemanticError};
 
 // TYPE ALIASES
 // ================================================================================================
@@ -13,7 +13,7 @@ pub type PeriodicColumn = Vec<u64>;
 #[derive(Default, Debug, Clone)]
 pub(super) struct Declarations {
     /// A vector of constants declared in the AirScript module.
-    constants: Vec<Constant>,
+    constants: Vec<ConstantBinding>,
 
     /// A map of the Air's periodic columns using the index of the column within the declared
     /// periodic columns as the key and the vector of periodic values as the value
@@ -35,7 +35,7 @@ pub(super) struct Declarations {
 impl Declarations {
     // --- ACCESSORS ------------------------------------------------------------------------------
 
-    pub(super) fn constants(&self) -> &[Constant] {
+    pub(super) fn constants(&self) -> &[ConstantBinding] {
         &self.constants
     }
 
@@ -74,7 +74,7 @@ impl Declarations {
 
     // --- MUTATORS -------------------------------------------------------------------------------
 
-    pub(super) fn add_constant(&mut self, constant: Constant) {
+    pub(super) fn add_constant(&mut self, constant: ConstantBinding) {
         self.constants.push(constant)
     }
 

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -1,7 +1,7 @@
 pub use air_script_core::{
-    Constant, ConstantType, Expression, Identifier, Iterable, ListComprehension, ListFolding,
-    ListFoldingValueType, MatrixAccess, TraceAccess, TraceBinding, TraceBindingAccess,
-    TraceBindingAccessSize, TraceSegment, Variable, VariableType, VectorAccess,
+    ConstantBinding, ConstantType, Expression, Identifier, Iterable, ListComprehension,
+    ListFolding, ListFoldingValueType, MatrixAccess, TraceAccess, TraceBinding, TraceBindingAccess,
+    TraceBindingAccessSize, TraceSegment, VariableBinding, VariableType, VectorAccess,
 };
 pub use parser::ast;
 use std::collections::{BTreeMap, BTreeSet};
@@ -138,7 +138,7 @@ impl AirIR {
         &self.air_name
     }
 
-    pub fn constants(&self) -> &[Constant] {
+    pub fn constants(&self) -> &[ConstantBinding] {
         self.declarations.constants()
     }
 

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -1,7 +1,7 @@
 pub use air_script_core::{
-    ConstantBinding, ConstantType, Expression, Identifier, Iterable, ListComprehension,
-    ListFolding, ListFoldingValueType, MatrixAccess, TraceAccess, TraceBinding, TraceBindingAccess,
-    TraceBindingAccessSize, TraceSegment, VariableBinding, VariableType, VectorAccess,
+    ConstantBinding, ConstantValueExpr, Expression, Identifier, Iterable, ListComprehension,
+    ListFolding, ListFoldingValueExpr, MatrixAccess, TraceAccess, TraceBinding, TraceBindingAccess,
+    TraceBindingAccessSize, TraceSegment, VariableBinding, VariableValueExpr, VectorAccess,
 };
 pub use parser::ast;
 use std::collections::{BTreeMap, BTreeSet};

--- a/ir/src/symbol_table/mod.rs
+++ b/ir/src/symbol_table/mod.rs
@@ -1,7 +1,7 @@
 use super::{
-    ast, BTreeMap, ConstantBinding, ConstantType, Declarations, Identifier, MatrixAccess,
-    SemanticError, TraceAccess, TraceBinding, TraceBindingAccess, VariableBinding, VariableType,
-    VectorAccess, CURRENT_ROW, MIN_CYCLE_LENGTH,
+    ast, BTreeMap, ConstantBinding, ConstantValueExpr, Declarations, Identifier, MatrixAccess,
+    SemanticError, TraceAccess, TraceBinding, TraceBindingAccess, VariableBinding,
+    VariableValueExpr, VectorAccess, CURRENT_ROW, MIN_CYCLE_LENGTH,
 };
 
 mod symbol;
@@ -60,7 +60,7 @@ impl SymbolTable {
         let (name, constant_type) = constant.into_parts();
 
         // check the number of elements in each row are same for a matrix
-        if let ConstantType::Matrix(matrix) = &constant_type {
+        if let ConstantValueExpr::Matrix(matrix) = &constant_type {
             let row_len = matrix[0].len();
             if matrix.iter().skip(1).any(|row| row.len() != row_len) {
                 return Err(SemanticError::invalid_matrix_constant(&name));

--- a/ir/src/symbol_table/mod.rs
+++ b/ir/src/symbol_table/mod.rs
@@ -1,7 +1,7 @@
 use super::{
-    ast, BTreeMap, Constant, ConstantType, Declarations, Identifier, MatrixAccess, SemanticError,
-    TraceAccess, TraceBinding, TraceBindingAccess, Variable, VariableType, VectorAccess,
-    CURRENT_ROW, MIN_CYCLE_LENGTH,
+    ast, BTreeMap, ConstantBinding, ConstantType, Declarations, Identifier, MatrixAccess,
+    SemanticError, TraceAccess, TraceBinding, TraceBindingAccess, VariableBinding, VariableType,
+    VectorAccess, CURRENT_ROW, MIN_CYCLE_LENGTH,
 };
 
 mod symbol;
@@ -52,7 +52,10 @@ impl SymbolTable {
     }
 
     /// Add a constant by its identifier and value.
-    pub(super) fn insert_constant(&mut self, constant: Constant) -> Result<(), SemanticError> {
+    pub(super) fn insert_constant(
+        &mut self,
+        constant: ConstantBinding,
+    ) -> Result<(), SemanticError> {
         self.declarations.add_constant(constant.clone());
         let (name, constant_type) = constant.into_parts();
 
@@ -159,7 +162,10 @@ impl SymbolTable {
     }
 
     /// Inserts a variable into the symbol table.
-    pub(super) fn insert_variable(&mut self, variable: Variable) -> Result<(), SemanticError> {
+    pub(super) fn insert_variable(
+        &mut self,
+        variable: VariableBinding,
+    ) -> Result<(), SemanticError> {
         let (name, value) = variable.into_parts();
         self.insert_symbol(name, SymbolType::Variable(value))?;
         Ok(())

--- a/ir/src/symbol_table/symbol.rs
+++ b/ir/src/symbol_table/symbol.rs
@@ -1,5 +1,5 @@
 use super::{
-    symbol_access::ValidateAccess, AccessType, ConstantType, ConstantValue, Identifier,
+    symbol_access::ValidateAccess, AccessType, ConstantValue, ConstantValueExpr, Identifier,
     MatrixAccess, SemanticError, SymbolType, TraceAccess, TraceBinding, Value, VectorAccess,
     CURRENT_ROW,
 };
@@ -49,7 +49,7 @@ impl Symbol {
 
     fn get_constant_value(
         &self,
-        constant_type: &ConstantType,
+        constant_type: &ConstantValueExpr,
         access_type: &AccessType,
     ) -> Result<Value, SemanticError> {
         constant_type.validate(self.name(), access_type)?;

--- a/ir/src/symbol_table/symbol_access.rs
+++ b/ir/src/symbol_table/symbol_access.rs
@@ -1,4 +1,6 @@
-use super::{ConstantType, SemanticError, Symbol, SymbolType, TraceBindingAccess, VariableType};
+use super::{
+    ConstantValueExpr, SemanticError, Symbol, SymbolType, TraceBindingAccess, VariableValueExpr,
+};
 use std::fmt::Display;
 
 /// TODO: docs
@@ -23,7 +25,7 @@ impl Display for AccessType {
 /// Checks that the specified access into an identifier is valid and returns an error otherwise.
 /// # Errors:
 /// - Returns an error if the type of the identifier does not allow the access type. For example,
-///   VariableType::Vector does not allow a MatrixAccess.
+///   VariableValueExpr::Vector does not allow a MatrixAccess.
 /// - Returns an error if any indices specified for the access are out of bounds fo the specified
 ///   identifier.
 pub(super) trait ValidateIdentifierAccess {
@@ -57,18 +59,18 @@ pub(crate) trait ValidateAccess {
     fn validate(&self, name: &str, access_type: &AccessType) -> Result<(), SemanticError>;
 }
 
-impl ValidateAccess for ConstantType {
+impl ValidateAccess for ConstantValueExpr {
     fn validate(&self, name: &str, access_type: &AccessType) -> Result<(), SemanticError> {
         match access_type {
             AccessType::Default => return Ok(()),
             AccessType::Vector(idx) => match self {
-                ConstantType::Scalar(_) => {
+                ConstantValueExpr::Scalar(_) => {
                     return Err(SemanticError::invalid_constant_access_type(
                         name,
                         access_type,
                     ))
                 }
-                ConstantType::Vector(vector) => {
+                ConstantValueExpr::Vector(vector) => {
                     if *idx >= vector.len() {
                         return Err(SemanticError::vector_access_out_of_bounds(
                             name,
@@ -77,7 +79,7 @@ impl ValidateAccess for ConstantType {
                         ));
                     }
                 }
-                ConstantType::Matrix(matrix) => {
+                ConstantValueExpr::Matrix(matrix) => {
                     if *idx >= matrix.len() {
                         return Err(SemanticError::vector_access_out_of_bounds(
                             name,
@@ -88,13 +90,13 @@ impl ValidateAccess for ConstantType {
                 }
             },
             AccessType::Matrix(row_idx, col_idx) => match self {
-                ConstantType::Scalar(_) | ConstantType::Vector(_) => {
+                ConstantValueExpr::Scalar(_) | ConstantValueExpr::Vector(_) => {
                     return Err(SemanticError::invalid_constant_access_type(
                         name,
                         access_type,
                     ))
                 }
-                ConstantType::Matrix(matrix) => {
+                ConstantValueExpr::Matrix(matrix) => {
                     if *row_idx >= matrix.len() || *col_idx >= matrix[0].len() {
                         return Err(SemanticError::matrix_access_out_of_bounds(
                             name,
@@ -112,14 +114,14 @@ impl ValidateAccess for ConstantType {
     }
 }
 
-impl ValidateAccess for VariableType {
+impl ValidateAccess for VariableValueExpr {
     fn validate(&self, name: &str, access_type: &AccessType) -> Result<(), SemanticError> {
         match access_type {
             AccessType::Default => return Ok(()),
             AccessType::Vector(idx) => match self {
                 // TODO: scalar can be ok; check this symbol in the future
-                VariableType::Scalar(_) => return Ok(()),
-                VariableType::Vector(vector) => {
+                VariableValueExpr::Scalar(_) => return Ok(()),
+                VariableValueExpr::Vector(vector) => {
                     if *idx >= vector.len() {
                         return Err(SemanticError::vector_access_out_of_bounds(
                             name,
@@ -137,8 +139,8 @@ impl ValidateAccess for VariableType {
             },
             AccessType::Matrix(row_idx, col_idx) => match self {
                 // TODO: scalar & vector can be ok; check this symbol in the future
-                VariableType::Scalar(_) | VariableType::Vector(_) => return Ok(()),
-                VariableType::Matrix(matrix) => {
+                VariableValueExpr::Scalar(_) | VariableValueExpr::Vector(_) => return Ok(()),
+                VariableValueExpr::Matrix(matrix) => {
                     if *row_idx >= matrix.len() || *col_idx >= matrix[0].len() {
                         return Err(SemanticError::matrix_access_out_of_bounds(
                             name,

--- a/ir/src/symbol_table/symbol_type.rs
+++ b/ir/src/symbol_table/symbol_type.rs
@@ -1,10 +1,10 @@
-use super::{ConstantType, TraceBinding, VariableType};
+use super::{ConstantValueExpr, TraceBinding, VariableValueExpr};
 use std::fmt::Display;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub(crate) enum SymbolType {
     /// an identifier for a constant, containing its type and value
-    Constant(ConstantType),
+    Constant(ConstantValueExpr),
     /// an identifier for a binding to one or more trace columns, containing the trace binding
     /// information with its identifier, trace segment, size, and offset.
     TraceBinding(TraceBinding),
@@ -14,7 +14,7 @@ pub(crate) enum SymbolType {
     /// its cycle length in that order.
     PeriodicColumn(usize, usize),
     /// an expression or set of expressions associated with a variable
-    Variable(VariableType),
+    Variable(VariableValueExpr),
     /// an identifier for random value, containing its index in the random values array and its
     /// length if this value is an array. For non-array random values second parameter is always 1.
     RandomValuesBinding(usize, usize),

--- a/ir/src/validation/error.rs
+++ b/ir/src/validation/error.rs
@@ -228,7 +228,7 @@ impl SemanticError {
     }
 
     pub(crate) fn invalid_list_folding(
-        lf_value_type: &air_script_core::ListFoldingValueType,
+        lf_value_type: &air_script_core::ListFoldingValueExpr,
         symbol_type: &SymbolType,
     ) -> SemanticError {
         SemanticError::InvalidListFolding(format!(
@@ -237,7 +237,7 @@ impl SemanticError {
     }
 
     pub(crate) fn list_folding_empty_list(
-        lf_value_type: &air_script_core::ListFoldingValueType,
+        lf_value_type: &air_script_core::ListFoldingValueExpr,
     ) -> SemanticError {
         SemanticError::InvalidListFolding(format!(
             "List folding value cannot be an empty list. {lf_value_type:?} represents an empty list.",

--- a/parser/src/ast/boundary_constraints.rs
+++ b/parser/src/ast/boundary_constraints.rs
@@ -1,4 +1,6 @@
-use super::{ComprehensionContext, Expression, Identifier, Iterable, TraceBindingAccess, Variable};
+use super::{
+    ComprehensionContext, Expression, Identifier, Iterable, TraceBindingAccess, VariableBinding,
+};
 use std::fmt::Display;
 
 // BOUNDARY STATEMENTS
@@ -8,7 +10,7 @@ use std::fmt::Display;
 pub enum BoundaryStmt {
     Constraint(BoundaryConstraint),
     ConstraintComprehension(BoundaryConstraint, ComprehensionContext),
-    Variable(Variable),
+    VariableBinding(VariableBinding),
 }
 
 /// Stores the expression corresponding to the boundary constraint.

--- a/parser/src/ast/integrity_constraints.rs
+++ b/parser/src/ast/integrity_constraints.rs
@@ -1,6 +1,6 @@
 use air_script_core::ComprehensionContext;
 
-use super::{EvaluatorFunctionCall, Expression, Variable};
+use super::{EvaluatorFunctionCall, Expression, VariableBinding};
 
 // INTEGRITY STATEMENTS
 // ================================================================================================
@@ -9,7 +9,7 @@ use super::{EvaluatorFunctionCall, Expression, Variable};
 pub enum IntegrityStmt {
     Constraint(ConstraintType, Option<Expression>),
     ConstraintComprehension(ConstraintType, Option<Expression>, ComprehensionContext),
-    Variable(Variable),
+    VariableBinding(VariableBinding),
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -1,8 +1,8 @@
 pub(crate) use air_script_core::{
-    ComprehensionContext, ConstantBinding, ConstantType, Expression, Identifier, Iterable,
-    ListComprehension, ListFolding, ListFoldingValueType, MatrixAccess, Range, TraceAccess,
+    ComprehensionContext, ConstantBinding, ConstantValueExpr, Expression, Identifier, Iterable,
+    ListComprehension, ListFolding, ListFoldingValueExpr, MatrixAccess, Range, TraceAccess,
     TraceBinding, TraceBindingAccess, TraceBindingAccessSize, TraceSegment, VariableBinding,
-    VariableType, VectorAccess,
+    VariableValueExpr, VectorAccess,
 };
 
 // declaration modules

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -1,8 +1,8 @@
 pub(crate) use air_script_core::{
-    ComprehensionContext, Constant, ConstantType, Expression, Identifier, Iterable,
+    ComprehensionContext, ConstantBinding, ConstantType, Expression, Identifier, Iterable,
     ListComprehension, ListFolding, ListFoldingValueType, MatrixAccess, Range, TraceAccess,
-    TraceBinding, TraceBindingAccess, TraceBindingAccessSize, TraceSegment, Variable, VariableType,
-    VectorAccess,
+    TraceBinding, TraceBindingAccess, TraceBindingAccessSize, TraceSegment, VariableBinding,
+    VariableType, VectorAccess,
 };
 
 // declaration modules
@@ -37,7 +37,7 @@ pub struct Source(pub Vec<SourceSection>);
 /// - AirDef: Name of the air constraints module.
 ///
 /// The type declaration sections are:
-/// - Constant: A constant is represented by a name and a value. Each [Constant] source section
+/// - ConstantBinding: A constant is represented by a name and a value. Each [ConstantBinding] source section
 ///   declares a single constant.
 /// - EvaluatorFunction: Evaluator functions take descriptions of the main and auxiliary traces as
 ///   input, and enforce integrity constraints on those trace columns. Each [EvaluatorFunction]
@@ -63,7 +63,7 @@ pub enum SourceSection {
     AirDef(Identifier),
 
     // type declarations
-    Constant(Constant),
+    Constant(ConstantBinding),
     EvaluatorFunction(EvaluatorFunction),
     PeriodicColumns(Vec<PeriodicColumn>),
     PublicInputs(Vec<PublicInput>),

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -2,11 +2,11 @@ use crate::{
     ast::{
         boundary_constraints::{Boundary, BoundaryConstraint, BoundaryStmt},
         integrity_constraints::{ConstraintType, IntegrityConstraint, IntegrityStmt},
-        build_trace_bindings, ConstantBinding, ConstantType, ComprehensionContext,
+        build_trace_bindings, ConstantBinding, ConstantValueExpr, ComprehensionContext,
         Expression, EvaluatorFunction, EvaluatorFunctionCall, Identifier, TraceAccess, Iterable,
-        ListComprehension, ListFolding, ListFoldingValueType, MatrixAccess, PeriodicColumn,
+        ListComprehension, ListFolding, ListFoldingValueExpr, MatrixAccess, PeriodicColumn,
         PublicInput, RandBinding, RandomValues, Range, Source, SourceSection, TraceBinding,
-        TraceBindingAccess, TraceBindingAccessSize, VariableBinding, VariableType, VectorAccess
+        TraceBindingAccess, TraceBindingAccessSize, VariableBinding, VariableValueExpr, VectorAccess
     }, error::{Error, ParseError::*}, lexer::Token
 };
 use std::str::FromStr;
@@ -77,11 +77,11 @@ TraceBinding: (Identifier, u64) = {
 
 Constant: ConstantBinding = {
     "const" <name: ConstName> "=" <scalar_value: Num_u64> => 
-        ConstantBinding::new(name, ConstantType::Scalar(scalar_value)),
+        ConstantBinding::new(name, ConstantValueExpr::Scalar(scalar_value)),
     "const" <name: ConstName> "=" <vector_value: Vector<Num_u64>> =>
-        ConstantBinding::new(name, ConstantType::Vector(vector_value)),
+        ConstantBinding::new(name, ConstantValueExpr::Vector(vector_value)),
     "const" <name: ConstName> "=" <matrix_value: Matrix<Num_u64>> =>
-        ConstantBinding::new(name, ConstantType::Matrix(matrix_value)),
+        ConstantBinding::new(name, ConstantValueExpr::Matrix(matrix_value)),
 }
 
 ConstName: Identifier = {
@@ -220,15 +220,15 @@ BoundaryConstraintExpr: BoundaryConstraint = {
         BoundaryConstraint::new(column, boundary, value),
 }
 
-BoundaryVariableType: VariableType = {
+BoundaryVariableType: VariableValueExpr = {
     <scalar_value: BoundaryExpr> => 
-        VariableType::Scalar(scalar_value),
+        VariableValueExpr::Scalar(scalar_value),
     <vector_value: Vector<BoundaryExpr>> => 
-        VariableType::Vector(vector_value),
+        VariableValueExpr::Vector(vector_value),
     <matrix_value: Matrix<BoundaryExpr>> =>
-        VariableType::Matrix(matrix_value),
+        VariableValueExpr::Matrix(matrix_value),
     "[" <list_comprehension: ListComprehension<BoundaryExpr>> "]" =>
-        VariableType::ListComprehension(list_comprehension),
+        VariableValueExpr::ListComprehension(list_comprehension),
 }
 
 Boundary: Boundary = {
@@ -327,15 +327,15 @@ IntegrityConstraintWithSelector: IntegrityStmt = {
         IntegrityStmt::Constraint(ConstraintType::Evaluator(evaluator_fn_call), Some(selectors)),
 }
 
-IntegrityVariableType: VariableType = {
+IntegrityVariableType: VariableValueExpr = {
     <scalar_value: IntegrityExpr> =>
-        VariableType::Scalar(scalar_value),
+        VariableValueExpr::Scalar(scalar_value),
     <vector_value: Vector<IntegrityExpr>> => 
-        VariableType::Vector(vector_value),
+        VariableValueExpr::Vector(vector_value),
     <matrix_value: Matrix<IntegrityExpr>> =>
-        VariableType::Matrix(matrix_value),
+        VariableValueExpr::Matrix(matrix_value),
     "[" <list_comprehension: ListComprehension<IntegrityExpr>> "]" =>
-        VariableType::ListComprehension(list_comprehension),
+        VariableValueExpr::ListComprehension(list_comprehension),
 }
 
 EvaluatorFunctionCall: EvaluatorFunctionCall = {
@@ -497,17 +497,17 @@ ListComprehension<T>: ListComprehension = {
 }
 
 ListFolding<T>: ListFolding = {
-    "sum" "(" <list_folding_value_type: ListFoldingValueType<T>> ")" =>
+    "sum" "(" <list_folding_value_type: ListFoldingValueExpr<T>> ")" =>
         ListFolding::Sum(list_folding_value_type),
-    "prod" "(" <list_folding_value_type: ListFoldingValueType<T>> ")" =>
+    "prod" "(" <list_folding_value_type: ListFoldingValueExpr<T>> ")" =>
         ListFolding::Prod(list_folding_value_type),
 }
 
-ListFoldingValueType<T>: ListFoldingValueType = {
-    <name: Identifier> => ListFoldingValueType::Identifier(name),
-    <vector: Vector<T>> => ListFoldingValueType::Vector(vector),
+ListFoldingValueExpr<T>: ListFoldingValueExpr = {
+    <name: Identifier> => ListFoldingValueExpr::Identifier(name),
+    <vector: Vector<T>> => ListFoldingValueExpr::Vector(vector),
     "[" <list_comprehension: ListComprehension<T>> "]" =>
-        ListFoldingValueType::ListComprehension(list_comprehension)
+        ListFoldingValueExpr::ListComprehension(list_comprehension)
 }
 
 Members: Vec<Identifier> = {

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -2,11 +2,11 @@ use crate::{
     ast::{
         boundary_constraints::{Boundary, BoundaryConstraint, BoundaryStmt},
         integrity_constraints::{ConstraintType, IntegrityConstraint, IntegrityStmt},
-        build_trace_bindings, Constant, ConstantType, ComprehensionContext,
+        build_trace_bindings, ConstantBinding, ConstantType, ComprehensionContext,
         Expression, EvaluatorFunction, EvaluatorFunctionCall, Identifier, TraceAccess, Iterable,
         ListComprehension, ListFolding, ListFoldingValueType, MatrixAccess, PeriodicColumn,
         PublicInput, RandBinding, RandomValues, Range, Source, SourceSection, TraceBinding,
-        TraceBindingAccess, TraceBindingAccessSize, Variable, VariableType, VectorAccess
+        TraceBindingAccess, TraceBindingAccessSize, VariableBinding, VariableType, VectorAccess
     }, error::{Error, ParseError::*}, lexer::Token
 };
 use std::str::FromStr;
@@ -75,13 +75,13 @@ TraceBinding: (Identifier, u64) = {
 // CONSTANTS
 // ================================================================================================
 
-Constant: Constant = {
+Constant: ConstantBinding = {
     "const" <name: ConstName> "=" <scalar_value: Num_u64> => 
-        Constant::new(name, ConstantType::Scalar(scalar_value)),
+        ConstantBinding::new(name, ConstantType::Scalar(scalar_value)),
     "const" <name: ConstName> "=" <vector_value: Vector<Num_u64>> =>
-        Constant::new(name, ConstantType::Vector(vector_value)),
+        ConstantBinding::new(name, ConstantType::Vector(vector_value)),
     "const" <name: ConstName> "=" <matrix_value: Matrix<Num_u64>> =>
-        Constant::new(name, ConstantType::Matrix(matrix_value)),
+        ConstantBinding::new(name, ConstantType::Matrix(matrix_value)),
 }
 
 ConstName: Identifier = {
@@ -207,7 +207,7 @@ BoundaryConstraints: Vec<BoundaryStmt> = {
 
 BoundaryStmt: BoundaryStmt = {
     "let" <name: Identifier> "=" <boundary_variable_type: BoundaryVariableType> =>
-        BoundaryStmt::Variable(Variable::new(name, boundary_variable_type)),
+        BoundaryStmt::VariableBinding(VariableBinding::new(name, boundary_variable_type)),
     "enf" <boundary_constraint: BoundaryConstraintExpr> =>
         BoundaryStmt::Constraint(boundary_constraint),
     "enf" <boundary_constraint: BoundaryConstraintExpr>
@@ -299,7 +299,7 @@ IntegrityStmts: Vec<IntegrityStmt> = {
 
 IntegrityStmtGroup: Vec<IntegrityStmt> = {
     "let" <name: Identifier> "=" <integrity_variable_type: IntegrityVariableType> =>
-        vec![IntegrityStmt::Variable(Variable::new(name, integrity_variable_type))],
+        vec![IntegrityStmt::VariableBinding(VariableBinding::new(name, integrity_variable_type))],
     "enf" <integrity_constraint: IntegrityConstraintExpr> => vec![integrity_constraint],
     "match" "enf" ":" <integrity_stmts: IntegrityConstraintExpr+> => integrity_stmts,
     "enf" <integrity_constraint: IntegrityConstraintExpr>

--- a/parser/src/parser/tests/boundary_constraints.rs
+++ b/parser/src/parser/tests/boundary_constraints.rs
@@ -4,9 +4,9 @@ use super::{
 };
 use crate::{
     ast::{
-        BoundaryStmt::*, ConstantBinding, ConstantType::*, Expression::*, MatrixAccess,
-        PublicInput, TraceBindingAccess, TraceBindingAccessSize, VariableBinding, VariableType,
-        VectorAccess,
+        BoundaryStmt::*, ConstantBinding, ConstantValueExpr::*, Expression::*, MatrixAccess,
+        PublicInput, TraceBindingAccess, TraceBindingAccessSize, VariableBinding,
+        VariableValueExpr, VectorAccess,
     },
     error::{Error, ParseError},
 };
@@ -201,11 +201,11 @@ fn boundary_constraint_with_variables() {
     let expected = Source(vec![SourceSection::BoundaryConstraints(vec![
         VariableBinding(VariableBinding::new(
             Identifier("a".to_string()),
-            VariableType::Scalar(Exp(Box::new(Const(2)), Box::new(Const(2)))),
+            VariableValueExpr::Scalar(Exp(Box::new(Const(2)), Box::new(Const(2)))),
         )),
         VariableBinding(VariableBinding::new(
             Identifier("b".to_string()),
-            VariableType::Vector(vec![
+            VariableValueExpr::Vector(vec![
                 Elem(Identifier("a".to_string())),
                 Mul(
                     Box::new(Const(2)),
@@ -215,7 +215,7 @@ fn boundary_constraint_with_variables() {
         )),
         VariableBinding(VariableBinding::new(
             Identifier("c".to_string()),
-            VariableType::Matrix(vec![
+            VariableValueExpr::Matrix(vec![
                 vec![
                     Sub(
                         Box::new(Elem(Identifier("a".to_string()))),

--- a/parser/src/parser/tests/boundary_constraints.rs
+++ b/parser/src/parser/tests/boundary_constraints.rs
@@ -4,8 +4,9 @@ use super::{
 };
 use crate::{
     ast::{
-        BoundaryStmt::*, Constant, ConstantType::*, Expression::*, MatrixAccess, PublicInput,
-        TraceBindingAccess, TraceBindingAccessSize, Variable, VariableType, VectorAccess,
+        BoundaryStmt::*, ConstantBinding, ConstantType::*, Expression::*, MatrixAccess,
+        PublicInput, TraceBindingAccess, TraceBindingAccessSize, VariableBinding, VariableType,
+        VectorAccess,
     },
     error::{Error, ParseError},
 };
@@ -153,12 +154,12 @@ fn boundary_constraint_with_const() {
     boundary_constraints:
         enf clk.first = A + B[1] - C[0][1]";
     let expected = Source(vec![
-        SourceSection::Constant(Constant::new(Identifier("A".to_string()), Scalar(1))),
-        SourceSection::Constant(Constant::new(
+        SourceSection::Constant(ConstantBinding::new(Identifier("A".to_string()), Scalar(1))),
+        SourceSection::Constant(ConstantBinding::new(
             Identifier("B".to_string()),
             Vector(vec![0, 1]),
         )),
-        SourceSection::Constant(Constant::new(
+        SourceSection::Constant(ConstantBinding::new(
             Identifier("C".to_string()),
             Matrix(vec![vec![0, 1], vec![1, 0]]),
         )),
@@ -198,11 +199,11 @@ fn boundary_constraint_with_variables() {
         let c = [[a - 1, a^2], [b[0], b[1]]]
         enf clk.first = 5 + a[3] + 6";
     let expected = Source(vec![SourceSection::BoundaryConstraints(vec![
-        Variable(Variable::new(
+        VariableBinding(VariableBinding::new(
             Identifier("a".to_string()),
             VariableType::Scalar(Exp(Box::new(Const(2)), Box::new(Const(2)))),
         )),
-        Variable(Variable::new(
+        VariableBinding(VariableBinding::new(
             Identifier("b".to_string()),
             VariableType::Vector(vec![
                 Elem(Identifier("a".to_string())),
@@ -212,7 +213,7 @@ fn boundary_constraint_with_variables() {
                 ),
             ]),
         )),
-        Variable(Variable::new(
+        VariableBinding(VariableBinding::new(
             Identifier("c".to_string()),
             VariableType::Matrix(vec![
                 vec![

--- a/parser/src/parser/tests/constants.rs
+++ b/parser/src/parser/tests/constants.rs
@@ -1,6 +1,6 @@
 use super::{build_parse_test, Identifier, Source, SourceSection};
 use crate::{
-    ast::{ConstantBinding, ConstantType},
+    ast::{ConstantBinding, ConstantValueExpr},
     error::{Error, ParseError},
 };
 
@@ -15,11 +15,11 @@ fn constants_scalars() {
     let expected = Source(vec![
         SourceSection::Constant(ConstantBinding::new(
             Identifier("A".to_string()),
-            ConstantType::Scalar(1),
+            ConstantValueExpr::Scalar(1),
         )),
         SourceSection::Constant(ConstantBinding::new(
             Identifier("B".to_string()),
-            ConstantType::Scalar(2),
+            ConstantValueExpr::Scalar(2),
         )),
     ]);
     build_parse_test!(source).expect_ast(expected);
@@ -33,11 +33,11 @@ fn constants_vectors() {
     let expected = Source(vec![
         SourceSection::Constant(ConstantBinding::new(
             Identifier("A".to_string()),
-            ConstantType::Vector(vec![1, 2, 3, 4]),
+            ConstantValueExpr::Vector(vec![1, 2, 3, 4]),
         )),
         SourceSection::Constant(ConstantBinding::new(
             Identifier("B".to_string()),
-            ConstantType::Vector(vec![5, 6, 7, 8]),
+            ConstantValueExpr::Vector(vec![5, 6, 7, 8]),
         )),
     ]);
     build_parse_test!(source).expect_ast(expected);
@@ -51,11 +51,11 @@ fn constants_matrices() {
     let expected = Source(vec![
         SourceSection::Constant(ConstantBinding::new(
             Identifier("ABC".to_string()),
-            ConstantType::Matrix(vec![vec![1, 2], vec![3, 4]]),
+            ConstantValueExpr::Matrix(vec![vec![1, 2], vec![3, 4]]),
         )),
         SourceSection::Constant(ConstantBinding::new(
             Identifier("XYZ".to_string()),
-            ConstantType::Matrix(vec![vec![5, 6], vec![7, 8]]),
+            ConstantValueExpr::Matrix(vec![vec![5, 6], vec![7, 8]]),
         )),
     ]);
     build_parse_test!(source).expect_ast(expected);
@@ -69,7 +69,7 @@ fn const_matrix_unequal_number_of_cols() {
     const A = [[1, 2], [3, 4, 5]]";
     let expected = Source(vec![SourceSection::Constant(ConstantBinding::new(
         Identifier("A".to_string()),
-        ConstantType::Matrix(vec![vec![1, 2], vec![3, 4, 5]]),
+        ConstantValueExpr::Matrix(vec![vec![1, 2], vec![3, 4, 5]]),
     ))]);
     build_parse_test!(source).expect_ast(expected);
 }

--- a/parser/src/parser/tests/constants.rs
+++ b/parser/src/parser/tests/constants.rs
@@ -1,6 +1,6 @@
 use super::{build_parse_test, Identifier, Source, SourceSection};
 use crate::{
-    ast::{Constant, ConstantType},
+    ast::{ConstantBinding, ConstantType},
     error::{Error, ParseError},
 };
 
@@ -13,11 +13,11 @@ fn constants_scalars() {
     const A = 1
     const B = 2";
     let expected = Source(vec![
-        SourceSection::Constant(Constant::new(
+        SourceSection::Constant(ConstantBinding::new(
             Identifier("A".to_string()),
             ConstantType::Scalar(1),
         )),
-        SourceSection::Constant(Constant::new(
+        SourceSection::Constant(ConstantBinding::new(
             Identifier("B".to_string()),
             ConstantType::Scalar(2),
         )),
@@ -31,11 +31,11 @@ fn constants_vectors() {
     const A = [1, 2, 3, 4]
     const B = [5, 6, 7, 8]";
     let expected = Source(vec![
-        SourceSection::Constant(Constant::new(
+        SourceSection::Constant(ConstantBinding::new(
             Identifier("A".to_string()),
             ConstantType::Vector(vec![1, 2, 3, 4]),
         )),
-        SourceSection::Constant(Constant::new(
+        SourceSection::Constant(ConstantBinding::new(
             Identifier("B".to_string()),
             ConstantType::Vector(vec![5, 6, 7, 8]),
         )),
@@ -49,11 +49,11 @@ fn constants_matrices() {
     const ABC = [[1, 2], [3, 4]]
     const XYZ = [[5, 6], [7, 8]]";
     let expected = Source(vec![
-        SourceSection::Constant(Constant::new(
+        SourceSection::Constant(ConstantBinding::new(
             Identifier("ABC".to_string()),
             ConstantType::Matrix(vec![vec![1, 2], vec![3, 4]]),
         )),
-        SourceSection::Constant(Constant::new(
+        SourceSection::Constant(ConstantBinding::new(
             Identifier("XYZ".to_string()),
             ConstantType::Matrix(vec![vec![5, 6], vec![7, 8]]),
         )),
@@ -67,7 +67,7 @@ fn const_matrix_unequal_number_of_cols() {
     // validation happens at the IR level.
     let source = "
     const A = [[1, 2], [3, 4, 5]]";
-    let expected = Source(vec![SourceSection::Constant(Constant::new(
+    let expected = Source(vec![SourceSection::Constant(ConstantBinding::new(
         Identifier("A".to_string()),
         ConstantType::Matrix(vec![vec![1, 2], vec![3, 4, 5]]),
     ))]);

--- a/parser/src/parser/tests/evaluator_functions.rs
+++ b/parser/src/parser/tests/evaluator_functions.rs
@@ -3,7 +3,7 @@ use crate::{
     ast::{
         ConstraintType, EvaluatorFunction, EvaluatorFunctionCall, Expression::*, IntegrityStmt::*,
         Range, TraceBinding, TraceBindingAccess, TraceBindingAccessSize, VariableBinding,
-        VariableType,
+        VariableValueExpr,
     },
     error::{Error, ParseError},
 };
@@ -59,7 +59,7 @@ fn ev_fn_main_and_aux_cols() {
             vec![
                 VariableBinding(VariableBinding::new(
                     Identifier("z".to_string()),
-                    VariableType::Scalar(Add(
+                    VariableValueExpr::Scalar(Add(
                         Box::new(Elem(Identifier("a".to_string()))),
                         Box::new(Elem(Identifier("b".to_string()))),
                     )),

--- a/parser/src/parser/tests/evaluator_functions.rs
+++ b/parser/src/parser/tests/evaluator_functions.rs
@@ -2,7 +2,8 @@ use super::{build_parse_test, Identifier, IntegrityConstraint, Source, SourceSec
 use crate::{
     ast::{
         ConstraintType, EvaluatorFunction, EvaluatorFunctionCall, Expression::*, IntegrityStmt::*,
-        Range, TraceBinding, TraceBindingAccess, TraceBindingAccessSize, Variable, VariableType,
+        Range, TraceBinding, TraceBindingAccess, TraceBindingAccessSize, VariableBinding,
+        VariableType,
     },
     error::{Error, ParseError},
 };
@@ -56,7 +57,7 @@ fn ev_fn_main_and_aux_cols() {
                 TraceBinding::new(Identifier("b".to_string()), 1, 1, 1),
             ],
             vec![
-                Variable(Variable::new(
+                VariableBinding(VariableBinding::new(
                     Identifier("z".to_string()),
                     VariableType::Scalar(Add(
                         Box::new(Elem(Identifier("a".to_string()))),

--- a/parser/src/parser/tests/integrity_constraints.rs
+++ b/parser/src/parser/tests/integrity_constraints.rs
@@ -4,9 +4,9 @@ use super::{
 };
 use crate::{
     ast::{
-        Constant, ConstantType::*, ConstraintType, EvaluatorFunction, EvaluatorFunctionCall,
+        ConstantBinding, ConstantType::*, ConstraintType, EvaluatorFunction, EvaluatorFunctionCall,
         Expression::*, IntegrityStmt::*, MatrixAccess, TraceAccess, TraceBindingAccess,
-        TraceBindingAccessSize, Variable, VariableType, VectorAccess,
+        TraceBindingAccessSize, VariableBinding, VariableType, VectorAccess,
     },
     error::{Error, ParseError},
 };
@@ -130,12 +130,12 @@ fn integrity_constraint_with_constants() {
     integrity_constraints:
         enf clk + A = B[1] + C[1][1]";
     let expected = Source(vec![
-        SourceSection::Constant(Constant::new(Identifier("A".to_string()), Scalar(0))),
-        SourceSection::Constant(Constant::new(
+        SourceSection::Constant(ConstantBinding::new(Identifier("A".to_string()), Scalar(0))),
+        SourceSection::Constant(ConstantBinding::new(
             Identifier("B".to_string()),
             Vector(vec![0, 1]),
         )),
-        SourceSection::Constant(Constant::new(
+        SourceSection::Constant(ConstantBinding::new(
             Identifier("C".to_string()),
             Matrix(vec![vec![0, 1], vec![1, 0]]),
         )),
@@ -172,11 +172,11 @@ fn integrity_constraint_with_variables() {
         let c = [[a - 1, a^2], [b[0], b[1]]]
         enf clk + a = b[1] + c[1][1]";
     let expected = Source(vec![SourceSection::IntegrityConstraints(vec![
-        Variable(Variable::new(
+        VariableBinding(VariableBinding::new(
             Identifier("a".to_string()),
             VariableType::Scalar(Exp(Box::new(Const(2)), Box::new(Const(2)))),
         )),
-        Variable(Variable::new(
+        VariableBinding(VariableBinding::new(
             Identifier("b".to_string()),
             VariableType::Vector(vec![
                 Elem(Identifier("a".to_string())),
@@ -186,7 +186,7 @@ fn integrity_constraint_with_variables() {
                 ),
             ]),
         )),
-        Variable(Variable::new(
+        VariableBinding(VariableBinding::new(
             Identifier("c".to_string()),
             VariableType::Matrix(vec![
                 vec![

--- a/parser/src/parser/tests/integrity_constraints.rs
+++ b/parser/src/parser/tests/integrity_constraints.rs
@@ -4,9 +4,10 @@ use super::{
 };
 use crate::{
     ast::{
-        ConstantBinding, ConstantType::*, ConstraintType, EvaluatorFunction, EvaluatorFunctionCall,
-        Expression::*, IntegrityStmt::*, MatrixAccess, TraceAccess, TraceBindingAccess,
-        TraceBindingAccessSize, VariableBinding, VariableType, VectorAccess,
+        ConstantBinding, ConstantValueExpr::*, ConstraintType, EvaluatorFunction,
+        EvaluatorFunctionCall, Expression::*, IntegrityStmt::*, MatrixAccess, TraceAccess,
+        TraceBindingAccess, TraceBindingAccessSize, VariableBinding, VariableValueExpr,
+        VectorAccess,
     },
     error::{Error, ParseError},
 };
@@ -174,11 +175,11 @@ fn integrity_constraint_with_variables() {
     let expected = Source(vec![SourceSection::IntegrityConstraints(vec![
         VariableBinding(VariableBinding::new(
             Identifier("a".to_string()),
-            VariableType::Scalar(Exp(Box::new(Const(2)), Box::new(Const(2)))),
+            VariableValueExpr::Scalar(Exp(Box::new(Const(2)), Box::new(Const(2)))),
         )),
         VariableBinding(VariableBinding::new(
             Identifier("b".to_string()),
-            VariableType::Vector(vec![
+            VariableValueExpr::Vector(vec![
                 Elem(Identifier("a".to_string())),
                 Mul(
                     Box::new(Const(2)),
@@ -188,7 +189,7 @@ fn integrity_constraint_with_variables() {
         )),
         VariableBinding(VariableBinding::new(
             Identifier("c".to_string()),
-            VariableType::Matrix(vec![
+            VariableValueExpr::Matrix(vec![
                 vec![
                     Sub(
                         Box::new(Elem(Identifier("a".to_string()))),

--- a/parser/src/parser/tests/list_comprehension.rs
+++ b/parser/src/parser/tests/list_comprehension.rs
@@ -4,8 +4,8 @@ use super::{build_parse_test, Identifier, IntegrityConstraint, Source};
 use crate::{
     ast::{
         Boundary, BoundaryConstraint, BoundaryStmt, ConstraintType, Expression::*, IntegrityStmt,
-        SourceSection::*, TraceBinding, TraceBindingAccess, TraceBindingAccessSize, Variable,
-        VariableType, VectorAccess,
+        SourceSection::*, TraceBinding, TraceBindingAccess, TraceBindingAccessSize,
+        VariableBinding, VariableType, VectorAccess,
     },
     error::{Error, ParseError},
 };
@@ -32,7 +32,7 @@ fn bc_one_iterable_identifier_lc() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
         ]]),
         BoundaryConstraints(vec![
-            BoundaryStmt::Variable(Variable::new(
+            BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableType::ListComprehension(ListComprehension::new(
                     Exp(
@@ -99,7 +99,7 @@ fn bc_identifier_and_range_lc() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
         ]]),
         BoundaryConstraints(vec![
-            BoundaryStmt::Variable(Variable::new(
+            BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableType::ListComprehension(ListComprehension::new(
                     Mul(
@@ -175,7 +175,7 @@ fn bc_iterable_slice_lc() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
         ]]),
         BoundaryConstraints(vec![
-            BoundaryStmt::Variable(Variable::new(
+            BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableType::ListComprehension(ListComprehension::new(
                     Elem(Identifier("c".to_string())),
@@ -240,7 +240,7 @@ fn bc_two_iterable_identifier_lc() {
             TraceBinding::new(Identifier("d".to_string()), 0, 6, 4),
         ]]),
         BoundaryConstraints(vec![
-            BoundaryStmt::Variable(Variable::new(
+            BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("diff".to_string()),
                 VariableType::ListComprehension(ListComprehension::new(
                     Sub(
@@ -314,7 +314,7 @@ fn bc_multiple_iterables_lc() {
             TraceBinding::new(Identifier("d".to_string()), 0, 8, 4),
         ]]),
         BoundaryConstraints(vec![
-            BoundaryStmt::Variable(Variable::new(
+            BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("diff".to_string()),
                 VariableType::ListComprehension(ListComprehension::new(
                     Sub(
@@ -405,7 +405,7 @@ fn ic_one_iterable_identifier_lc() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
         ]]),
         IntegrityConstraints(vec![
-            IntegrityStmt::Variable(Variable::new(
+            IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableType::ListComprehension(ListComprehension::new(
                     Exp(
@@ -418,7 +418,7 @@ fn ic_one_iterable_identifier_lc() {
                     )],
                 )),
             )),
-            IntegrityStmt::Variable(Variable::new(
+            IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
                 VariableType::ListComprehension(ListComprehension::new(
                     Exp(
@@ -487,7 +487,7 @@ fn ic_iterable_identifier_range_lc() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
         ]]),
         IntegrityConstraints(vec![
-            IntegrityStmt::Variable(Variable::new(
+            IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableType::ListComprehension(ListComprehension::new(
                     Mul(
@@ -560,7 +560,7 @@ fn ic_iterable_slice_lc() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
         ]]),
         IntegrityConstraints(vec![
-            IntegrityStmt::Variable(Variable::new(
+            IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableType::ListComprehension(ListComprehension::new(
                     Elem(Identifier("c".to_string())),
@@ -622,7 +622,7 @@ fn ic_two_iterable_identifier_lc() {
             TraceBinding::new(Identifier("d".to_string()), 0, 6, 4),
         ]]),
         IntegrityConstraints(vec![
-            IntegrityStmt::Variable(Variable::new(
+            IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("diff".to_string()),
                 VariableType::ListComprehension(ListComprehension::new(
                     Sub(
@@ -693,7 +693,7 @@ fn ic_multiple_iterables_lc() {
             TraceBinding::new(Identifier("d".to_string()), 0, 8, 4),
         ]]),
         IntegrityConstraints(vec![
-            IntegrityStmt::Variable(Variable::new(
+            IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("diff".to_string()),
                 VariableType::ListComprehension(ListComprehension::new(
                     Sub(

--- a/parser/src/parser/tests/list_comprehension.rs
+++ b/parser/src/parser/tests/list_comprehension.rs
@@ -5,7 +5,7 @@ use crate::{
     ast::{
         Boundary, BoundaryConstraint, BoundaryStmt, ConstraintType, Expression::*, IntegrityStmt,
         SourceSection::*, TraceBinding, TraceBindingAccess, TraceBindingAccessSize,
-        VariableBinding, VariableType, VectorAccess,
+        VariableBinding, VariableValueExpr, VectorAccess,
     },
     error::{Error, ParseError},
 };
@@ -34,7 +34,7 @@ fn bc_one_iterable_identifier_lc() {
         BoundaryConstraints(vec![
             BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
-                VariableType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::ListComprehension(ListComprehension::new(
                     Exp(
                         Box::new(Elem(Identifier("col".to_string()))),
                         Box::new(Const(7)),
@@ -101,7 +101,7 @@ fn bc_identifier_and_range_lc() {
         BoundaryConstraints(vec![
             BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
-                VariableType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::ListComprehension(ListComprehension::new(
                     Mul(
                         Box::new(Exp(
                             Box::new(Const(2)),
@@ -177,7 +177,7 @@ fn bc_iterable_slice_lc() {
         BoundaryConstraints(vec![
             BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
-                VariableType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::ListComprehension(ListComprehension::new(
                     Elem(Identifier("c".to_string())),
                     vec![(
                         Identifier("c".to_string()),
@@ -242,7 +242,7 @@ fn bc_two_iterable_identifier_lc() {
         BoundaryConstraints(vec![
             BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("diff".to_string()),
-                VariableType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::ListComprehension(ListComprehension::new(
                     Sub(
                         Box::new(Elem(Identifier("x".to_string()))),
                         Box::new(Elem(Identifier("y".to_string()))),
@@ -316,7 +316,7 @@ fn bc_multiple_iterables_lc() {
         BoundaryConstraints(vec![
             BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("diff".to_string()),
-                VariableType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::ListComprehension(ListComprehension::new(
                     Sub(
                         Box::new(Sub(
                             Box::new(Add(
@@ -407,7 +407,7 @@ fn ic_one_iterable_identifier_lc() {
         IntegrityConstraints(vec![
             IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
-                VariableType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::ListComprehension(ListComprehension::new(
                     Exp(
                         Box::new(Elem(Identifier("col".to_string()))),
                         Box::new(Const(7)),
@@ -420,7 +420,7 @@ fn ic_one_iterable_identifier_lc() {
             )),
             IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
-                VariableType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::ListComprehension(ListComprehension::new(
                     Exp(
                         Box::new(TraceBindingAccess(TraceBindingAccess::new(
                             Identifier("col".to_string()),
@@ -489,7 +489,7 @@ fn ic_iterable_identifier_range_lc() {
         IntegrityConstraints(vec![
             IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
-                VariableType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::ListComprehension(ListComprehension::new(
                     Mul(
                         Box::new(Exp(
                             Box::new(Const(2)),
@@ -562,7 +562,7 @@ fn ic_iterable_slice_lc() {
         IntegrityConstraints(vec![
             IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
-                VariableType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::ListComprehension(ListComprehension::new(
                     Elem(Identifier("c".to_string())),
                     vec![(
                         Identifier("c".to_string()),
@@ -624,7 +624,7 @@ fn ic_two_iterable_identifier_lc() {
         IntegrityConstraints(vec![
             IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("diff".to_string()),
-                VariableType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::ListComprehension(ListComprehension::new(
                     Sub(
                         Box::new(Elem(Identifier("x".to_string()))),
                         Box::new(Elem(Identifier("y".to_string()))),
@@ -695,7 +695,7 @@ fn ic_multiple_iterables_lc() {
         IntegrityConstraints(vec![
             IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("diff".to_string()),
-                VariableType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::ListComprehension(ListComprehension::new(
                     Sub(
                         Box::new(Sub(
                             Box::new(Add(

--- a/parser/src/parser/tests/list_folding.rs
+++ b/parser/src/parser/tests/list_folding.rs
@@ -1,11 +1,11 @@
-use air_script_core::{Iterable, ListComprehension, ListFolding, ListFoldingValueType, Range};
+use air_script_core::{Iterable, ListComprehension, ListFolding, ListFoldingValueExpr, Range};
 
 use super::{build_parse_test, Identifier, IntegrityConstraint, Source};
 use crate::{
     ast::{
         Boundary, BoundaryConstraint, BoundaryStmt, ConstraintType, Expression::*, IntegrityStmt,
         SourceSection::*, TraceBinding, TraceBindingAccess, TraceBindingAccessSize,
-        VariableBinding, VariableType, VectorAccess,
+        VariableBinding, VariableValueExpr, VectorAccess,
     },
     error::{Error, ParseError},
 };
@@ -32,14 +32,14 @@ fn identifier_lf() {
         BoundaryConstraints(vec![
             BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Sum(
-                    ListFoldingValueType::Identifier(Identifier("c".to_string())),
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
+                    ListFoldingValueExpr::Identifier(Identifier("c".to_string())),
                 ))),
             )),
             BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Prod(
-                    ListFoldingValueType::Identifier(Identifier("c".to_string())),
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
+                    ListFoldingValueExpr::Identifier(Identifier("c".to_string())),
                 ))),
             )),
             BoundaryStmt::Constraint(BoundaryConstraint::new(
@@ -79,18 +79,18 @@ fn vector_lf() {
         BoundaryConstraints(vec![
             BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Sum(ListFoldingValueType::Vector(
-                    vec![
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
+                    ListFoldingValueExpr::Vector(vec![
                         Elem(Identifier("a".to_string())),
                         Elem(Identifier("b".to_string())),
                         VectorAccess(VectorAccess::new(Identifier("c".to_string()), 0)),
-                    ],
-                )))),
+                    ]),
+                ))),
             )),
             BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Prod(
-                    ListFoldingValueType::Vector(vec![
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
+                    ListFoldingValueExpr::Vector(vec![
                         Elem(Identifier("a".to_string())),
                         Elem(Identifier("b".to_string())),
                         VectorAccess(VectorAccess::new(Identifier("c".to_string()), 0)),
@@ -135,8 +135,8 @@ fn bc_one_iterable_identifier_lf() {
         BoundaryConstraints(vec![
             BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Sum(
-                    ListFoldingValueType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
+                    ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Exp(
                             Box::new(Elem(Identifier("col".to_string()))),
                             Box::new(Const(7)),
@@ -150,8 +150,8 @@ fn bc_one_iterable_identifier_lf() {
             )),
             BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Prod(
-                    ListFoldingValueType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
+                    ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Exp(
                             Box::new(Elem(Identifier("col".to_string()))),
                             Box::new(Const(7)),
@@ -202,8 +202,8 @@ fn bc_two_iterable_identifier_lf() {
         BoundaryConstraints(vec![
             BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Sum(
-                    ListFoldingValueType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
+                    ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
                             Box::new(Elem(Identifier("c".to_string()))),
                             Box::new(Elem(Identifier("d".to_string()))),
@@ -223,8 +223,8 @@ fn bc_two_iterable_identifier_lf() {
             )),
             BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Prod(
-                    ListFoldingValueType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
+                    ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Add(
                             Box::new(Elem(Identifier("c".to_string()))),
                             Box::new(Elem(Identifier("d".to_string()))),
@@ -280,8 +280,8 @@ fn bc_two_iterables_identifier_range_lf() {
         BoundaryConstraints(vec![
             BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Sum(
-                    ListFoldingValueType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
+                    ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
                             Box::new(Elem(Identifier("i".to_string()))),
                             Box::new(Elem(Identifier("c".to_string()))),
@@ -301,8 +301,8 @@ fn bc_two_iterables_identifier_range_lf() {
             )),
             BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Prod(
-                    ListFoldingValueType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
+                    ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Add(
                             Box::new(Elem(Identifier("i".to_string()))),
                             Box::new(Elem(Identifier("c".to_string()))),
@@ -358,8 +358,8 @@ fn ic_one_iterable_identifier_lf() {
         IntegrityConstraints(vec![
             IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Sum(
-                    ListFoldingValueType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
+                    ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Exp(
                             Box::new(Elem(Identifier("col".to_string()))),
                             Box::new(Const(7)),
@@ -373,8 +373,8 @@ fn ic_one_iterable_identifier_lf() {
             )),
             IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Prod(
-                    ListFoldingValueType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
+                    ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Exp(
                             Box::new(Elem(Identifier("col".to_string()))),
                             Box::new(Const(7)),
@@ -422,8 +422,8 @@ fn ic_two_iterable_identifier_lf() {
         IntegrityConstraints(vec![
             IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Sum(
-                    ListFoldingValueType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
+                    ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
                             Box::new(Elem(Identifier("c".to_string()))),
                             Box::new(Elem(Identifier("d".to_string()))),
@@ -443,8 +443,8 @@ fn ic_two_iterable_identifier_lf() {
             )),
             IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Prod(
-                    ListFoldingValueType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
+                    ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Add(
                             Box::new(Elem(Identifier("c".to_string()))),
                             Box::new(Elem(Identifier("d".to_string()))),
@@ -497,8 +497,8 @@ fn ic_two_iterables_identifier_range_lf() {
         IntegrityConstraints(vec![
             IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Sum(
-                    ListFoldingValueType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
+                    ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
                             Box::new(Elem(Identifier("i".to_string()))),
                             Box::new(Elem(Identifier("c".to_string()))),
@@ -518,8 +518,8 @@ fn ic_two_iterables_identifier_range_lf() {
             )),
             IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Prod(
-                    ListFoldingValueType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
+                    ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Add(
                             Box::new(Elem(Identifier("i".to_string()))),
                             Box::new(Elem(Identifier("c".to_string()))),
@@ -572,8 +572,8 @@ fn ic_three_iterables_slice_identifier_range_lf() {
         IntegrityConstraints(vec![
             IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Sum(
-                    ListFoldingValueType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
+                    ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
                             Box::new(Mul(
                                 Box::new(Elem(Identifier("m".to_string()))),
@@ -600,8 +600,8 @@ fn ic_three_iterables_slice_identifier_range_lf() {
             )),
             IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
-                VariableType::Scalar(ListFolding(ListFolding::Sum(
-                    ListFoldingValueType::ListComprehension(ListComprehension::new(
+                VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
+                    ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
                             Box::new(Mul(
                                 Box::new(Elem(Identifier("m".to_string()))),

--- a/parser/src/parser/tests/list_folding.rs
+++ b/parser/src/parser/tests/list_folding.rs
@@ -4,8 +4,8 @@ use super::{build_parse_test, Identifier, IntegrityConstraint, Source};
 use crate::{
     ast::{
         Boundary, BoundaryConstraint, BoundaryStmt, ConstraintType, Expression::*, IntegrityStmt,
-        SourceSection::*, TraceBinding, TraceBindingAccess, TraceBindingAccessSize, Variable,
-        VariableType, VectorAccess,
+        SourceSection::*, TraceBinding, TraceBindingAccess, TraceBindingAccessSize,
+        VariableBinding, VariableType, VectorAccess,
     },
     error::{Error, ParseError},
 };
@@ -30,13 +30,13 @@ fn identifier_lf() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
         ]]),
         BoundaryConstraints(vec![
-            BoundaryStmt::Variable(Variable::new(
+            BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueType::Identifier(Identifier("c".to_string())),
                 ))),
             )),
-            BoundaryStmt::Variable(Variable::new(
+            BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueType::Identifier(Identifier("c".to_string())),
@@ -77,7 +77,7 @@ fn vector_lf() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
         ]]),
         BoundaryConstraints(vec![
-            BoundaryStmt::Variable(Variable::new(
+            BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Sum(ListFoldingValueType::Vector(
                     vec![
@@ -87,7 +87,7 @@ fn vector_lf() {
                     ],
                 )))),
             )),
-            BoundaryStmt::Variable(Variable::new(
+            BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueType::Vector(vec![
@@ -133,7 +133,7 @@ fn bc_one_iterable_identifier_lf() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
         ]]),
         BoundaryConstraints(vec![
-            BoundaryStmt::Variable(Variable::new(
+            BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueType::ListComprehension(ListComprehension::new(
@@ -148,7 +148,7 @@ fn bc_one_iterable_identifier_lf() {
                     )),
                 ))),
             )),
-            BoundaryStmt::Variable(Variable::new(
+            BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueType::ListComprehension(ListComprehension::new(
@@ -200,7 +200,7 @@ fn bc_two_iterable_identifier_lf() {
             TraceBinding::new(Identifier("d".to_string()), 0, 6, 4),
         ]]),
         BoundaryConstraints(vec![
-            BoundaryStmt::Variable(Variable::new(
+            BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueType::ListComprehension(ListComprehension::new(
@@ -221,7 +221,7 @@ fn bc_two_iterable_identifier_lf() {
                     )),
                 ))),
             )),
-            BoundaryStmt::Variable(Variable::new(
+            BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueType::ListComprehension(ListComprehension::new(
@@ -278,7 +278,7 @@ fn bc_two_iterables_identifier_range_lf() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
         ]]),
         BoundaryConstraints(vec![
-            BoundaryStmt::Variable(Variable::new(
+            BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueType::ListComprehension(ListComprehension::new(
@@ -299,7 +299,7 @@ fn bc_two_iterables_identifier_range_lf() {
                     )),
                 ))),
             )),
-            BoundaryStmt::Variable(Variable::new(
+            BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueType::ListComprehension(ListComprehension::new(
@@ -356,7 +356,7 @@ fn ic_one_iterable_identifier_lf() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
         ]]),
         IntegrityConstraints(vec![
-            IntegrityStmt::Variable(Variable::new(
+            IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueType::ListComprehension(ListComprehension::new(
@@ -371,7 +371,7 @@ fn ic_one_iterable_identifier_lf() {
                     )),
                 ))),
             )),
-            IntegrityStmt::Variable(Variable::new(
+            IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueType::ListComprehension(ListComprehension::new(
@@ -420,7 +420,7 @@ fn ic_two_iterable_identifier_lf() {
             TraceBinding::new(Identifier("d".to_string()), 0, 6, 4),
         ]]),
         IntegrityConstraints(vec![
-            IntegrityStmt::Variable(Variable::new(
+            IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueType::ListComprehension(ListComprehension::new(
@@ -441,7 +441,7 @@ fn ic_two_iterable_identifier_lf() {
                     )),
                 ))),
             )),
-            IntegrityStmt::Variable(Variable::new(
+            IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueType::ListComprehension(ListComprehension::new(
@@ -495,7 +495,7 @@ fn ic_two_iterables_identifier_range_lf() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
         ]]),
         IntegrityConstraints(vec![
-            IntegrityStmt::Variable(Variable::new(
+            IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueType::ListComprehension(ListComprehension::new(
@@ -516,7 +516,7 @@ fn ic_two_iterables_identifier_range_lf() {
                     )),
                 ))),
             )),
-            IntegrityStmt::Variable(Variable::new(
+            IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueType::ListComprehension(ListComprehension::new(
@@ -570,7 +570,7 @@ fn ic_three_iterables_slice_identifier_range_lf() {
             TraceBinding::new(Identifier("c".to_string()), 0, 7, 4),
         ]]),
         IntegrityConstraints(vec![
-            IntegrityStmt::Variable(Variable::new(
+            IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueType::ListComprehension(ListComprehension::new(
@@ -598,7 +598,7 @@ fn ic_three_iterables_slice_identifier_range_lf() {
                     )),
                 ))),
             )),
-            IntegrityStmt::Variable(Variable::new(
+            IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("y".to_string()),
                 VariableType::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueType::ListComprehension(ListComprehension::new(

--- a/parser/src/parser/tests/variables.rs
+++ b/parser/src/parser/tests/variables.rs
@@ -1,7 +1,7 @@
 use super::{build_parse_test, Identifier, IntegrityConstraint, Source, SourceSection};
 use crate::ast::{
     ConstraintType, Expression::*, IntegrityStmt::*, TraceBindingAccess, TraceBindingAccessSize,
-    Variable, VariableType, VectorAccess,
+    VariableBinding, VariableType, VectorAccess,
 };
 
 // VARIABLES
@@ -13,7 +13,7 @@ fn variables_with_and_operators() {
         let flag = n1 & !n2
         enf clk' = clk + 1 when flag";
     let expected = Source(vec![SourceSection::IntegrityConstraints(vec![
-        Variable(Variable::new(
+        VariableBinding(VariableBinding::new(
             Identifier("flag".to_string()),
             VariableType::Scalar(Mul(
                 Box::new(Elem(Identifier("n1".to_string()))),
@@ -49,7 +49,7 @@ fn variables_with_or_operators() {
         let flag = s[0] | !s[1]'
         enf clk' = clk + 1 when flag";
     let expected = Source(vec![SourceSection::IntegrityConstraints(vec![
-        Variable(Variable::new(
+        VariableBinding(VariableBinding::new(
             Identifier("flag".to_string()),
             VariableType::Scalar(Sub(
                 Box::new(Add(

--- a/parser/src/parser/tests/variables.rs
+++ b/parser/src/parser/tests/variables.rs
@@ -1,7 +1,7 @@
 use super::{build_parse_test, Identifier, IntegrityConstraint, Source, SourceSection};
 use crate::ast::{
     ConstraintType, Expression::*, IntegrityStmt::*, TraceBindingAccess, TraceBindingAccessSize,
-    VariableBinding, VariableType, VectorAccess,
+    VariableBinding, VariableValueExpr, VectorAccess,
 };
 
 // VARIABLES
@@ -15,7 +15,7 @@ fn variables_with_and_operators() {
     let expected = Source(vec![SourceSection::IntegrityConstraints(vec![
         VariableBinding(VariableBinding::new(
             Identifier("flag".to_string()),
-            VariableType::Scalar(Mul(
+            VariableValueExpr::Scalar(Mul(
                 Box::new(Elem(Identifier("n1".to_string()))),
                 Box::new(Sub(
                     Box::new(Const(1)),
@@ -51,7 +51,7 @@ fn variables_with_or_operators() {
     let expected = Source(vec![SourceSection::IntegrityConstraints(vec![
         VariableBinding(VariableBinding::new(
             Identifier("flag".to_string()),
-            VariableType::Scalar(Sub(
+            VariableValueExpr::Scalar(Sub(
                 Box::new(Add(
                     Box::new(VectorAccess(VectorAccess::new(
                         Identifier("s".to_string()),


### PR DESCRIPTION
This PR addresses the following issues that have come up while working towards support for functions and evaluator functions:

1. lack of distinction between a binding and accessing a binding (e.g. in a function declaration, we need to parse bindings, but in a function call we want to parse accesses of bindings)
2. many structs are named in a format like _Type (e.g. VariableType), but actually they do not identify types in the language. Instead, they identify different expression variations for bindings (e.g. the value of a variable binding can be a single expression, a vector of expressions, a matrix of expressions, etc). This became confusing when implementing functions, as functions actually have types.

The first point is addressed by renaming `Constant` to `ConstantBinding` and `Variable` to `VariableBinding`.
The second point is addressed by replacing "Type" with "ValueExpr" (e.g. VariableType --> VariableValueExpr), although I'm open to other names. for this