### PR TITLE
refactor: change access types to BindingAccess

### DIFF
--- a/air-script-core/src/access.rs
+++ b/air-script-core/src/access.rs
@@ -1,61 +1,64 @@
 use super::Identifier;
+use std::fmt::Display;
 
-/// [VectorAccess] is used to represent an element inside vector at the specified index.
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
-pub struct VectorAccess {
-    name: Identifier,
-    idx: usize,
+/// Defines the type of an access into a binding such as a [ConstantBinding] or a [VariableBinding].
+///
+/// - Default: accesses the entire bound value, which could be a scalar, vector, or matrix.
+/// - Vector: indexes into the bound value at the specified index. The result could be either a
+///   single value or a vector, depending on the type of the original binding. This is not allowed
+///   for bindings to scalar values and will result in an error.
+/// - Matrix: indexes into the bound value at the specified row and column. The result is a single
+///   value. This [AccessType] is not allowed for bindings to scalar or vector values and will
+///   result in an error.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub enum AccessType {
+    Default,
+    Vector(usize),
+    /// Access into a matrix, with the values referring to the row and column indices respectively.
+    Matrix(usize, usize),
 }
 
-impl VectorAccess {
-    /// Creates a new [VectorAccess] instance with the specified identifier name and index.
-    pub fn new(name: Identifier, idx: usize) -> Self {
-        Self { name, idx }
-    }
-
-    /// Returns the name of the vector.
-    pub fn name(&self) -> &str {
-        self.name.name()
-    }
-
-    /// Returns the index of the vector access.
-    pub fn idx(&self) -> usize {
-        self.idx
-    }
-}
-
-/// [MatrixAccess] is used to represent an element inside a matrix at the specified row and column
-/// indices.
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
-pub struct MatrixAccess {
-    name: Identifier,
-    row_idx: usize,
-    col_idx: usize,
-}
-
-impl MatrixAccess {
-    /// Creates a new [MatrixAccess] instance with the specified identifier name and indices.
-    pub fn new(name: Identifier, row_idx: usize, col_idx: usize) -> Self {
-        Self {
-            name,
-            row_idx,
-            col_idx,
+impl Display for AccessType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Default => write!(f, "direct reference by name"),
+            Self::Vector(_) => write!(f, "vector"),
+            Self::Matrix(_, _) => write!(f, "matrix"),
         }
     }
+}
 
-    /// Returns the name of the matrix.
+/// [BindingAccess] is used to indicate referencing all or part of an identifier that is bound to a
+/// value, such as a [ConstantBinding] or a [VariableBinding].
+///
+/// - `name`: is the identifier of the [ConstantBinding] or [VariableBinding] being accessed.
+/// - `access_type`: specifies the [AccessType] by which the identifier is being accessed.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BindingAccess {
+    name: Identifier,
+    access_type: AccessType,
+}
+
+impl BindingAccess {
+    pub fn new(name: Identifier, access_type: AccessType) -> Self {
+        Self { name, access_type }
+    }
+
+    pub fn ident(&self) -> &Identifier {
+        &self.name
+    }
+
     pub fn name(&self) -> &str {
         self.name.name()
     }
 
-    /// Returns the row index of the matrix access.
-    pub fn row_idx(&self) -> usize {
-        self.row_idx
+    /// Gets the access type of this [BindingAccess].
+    pub fn access_type(&self) -> &AccessType {
+        &self.access_type
     }
 
-    /// Returns the column index of the matrix access.
-    pub fn col_idx(&self) -> usize {
-        self.col_idx
+    pub fn into_parts(self) -> (Identifier, AccessType) {
+        (self.name, self.access_type)
     }
 }
 

--- a/air-script-core/src/expression.rs
+++ b/air-script-core/src/expression.rs
@@ -1,17 +1,11 @@
-use super::{Identifier, ListFolding, MatrixAccess, TraceAccess, TraceBindingAccess, VectorAccess};
+use super::{BindingAccess, Identifier, ListFolding, TraceAccess, TraceBindingAccess};
 
 /// Arithmetic expressions for evaluation of constraints.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Expression {
     Const(u64),
-    /// Represents any named constant or variable.
-    Elem(Identifier),
-    /// Represents an element inside a constant or variable vector. [VectorAccess] contains the
-    /// name of the vector and the index of the element to access.
-    VectorAccess(VectorAccess),
-    /// Represents an element inside a constant or variable matrix. [MatrixAccess] contains the
-    /// name of the matrix and indices of the element to access.
-    MatrixAccess(MatrixAccess),
+    /// Represents a reference to all or part of a constant, variable, or trace binding.
+    BindingAccess(BindingAccess),
     TraceAccess(TraceAccess),
     TraceBindingAccess(TraceBindingAccess),
     /// Represents a random value provided by the verifier. The first inner value is the name of

--- a/air-script-core/src/lib.rs
+++ b/air-script-core/src/lib.rs
@@ -1,5 +1,5 @@
 mod access;
-pub use access::{Iterable, MatrixAccess, Range, VectorAccess};
+pub use access::{AccessType, BindingAccess, Iterable, Range};
 
 mod constant;
 pub use constant::{ConstantBinding, ConstantValueExpr};

--- a/air-script-core/src/trace.rs
+++ b/air-script-core/src/trace.rs
@@ -4,55 +4,17 @@ use super::{Identifier, Range};
 // ================================================================================================
 pub type TraceSegment = u8;
 
-/// [TraceBinding] is used to represent one or more columns in the execution trace that are bound to
-/// a name. For single columns, the size is 1. For groups, the size is the number of columns in the
-/// group. The offset is the column index in the trace where the first column of the binding starts.
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
-pub struct TraceBinding {
-    binding: Identifier,
-    trace_segment: TraceSegment,
-    offset: usize,
-    size: usize,
-}
-
-impl TraceBinding {
-    /// Creates a new trace binding.
-    pub fn new(binding: Identifier, trace_segment: usize, offset: usize, size: u64) -> Self {
-        Self {
-            binding,
-            trace_segment: trace_segment as TraceSegment,
-            offset,
-            size: size as usize,
-        }
-    }
-
-    /// Returns the name of the trace binding.
-    pub fn name(&self) -> &str {
-        self.binding.name()
-    }
-
-    /// Returns the trace segment of the trace binding.
-    pub fn trace_segment(&self) -> TraceSegment {
-        self.trace_segment
-    }
-
-    /// Returns the offset of the trace binding.
-    pub fn offset(&self) -> usize {
-        self.offset
-    }
-
-    /// Returns the size of the trace binding.
-    pub fn size(&self) -> usize {
-        self.size
-    }
-}
-
-/// [TraceAccess] is used to represent accessing an element in the execution trace during
-/// constraint evaluation. The trace_segment specifies
-/// how many trace commitments have preceded the specified segment. `col_idx` specifies the index
-/// of the column within that trace segment, and `row_offset` specifies the offset from the current
-/// row. For example, an element in the "next" row of the "main" trace would be specified by
-/// a trace_segment of 0 and a row_offset of 1.
+/// [TraceAccess] is used to represent accessing one or more elements in the execution trace during
+/// constraint evaluation.
+///
+/// - `trace_segment`: specifies how many trace commitments have preceded the specified segment.
+/// - `col_idx`: specifies the index of the column within that trace segment at which the access
+///   starts.
+/// - `size`: refers to how many columns are being accessed.
+/// - `row_offset`: specifies the offset from the current row.
+///
+/// For example, a single element in the "next" row of
+/// the "main" trace would be specified by a trace_segment of 0, a size of 1, and a row_offset of 1.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TraceAccess {
     trace_segment: TraceSegment,
@@ -98,22 +60,77 @@ impl TraceAccess {
     }
 }
 
-/// [TraceBindingAccess] is used to indicate a column in the trace by specifying its offset within
-/// a set of trace columns with the given identifier. If the identifier refers to a single column
-/// then the index is always zero.
+/// [TraceBinding] is used to represent one or more columns in the execution trace that are bound to
+/// a name. For single columns, the size is 1. For groups, the size is the number of columns in the
+/// group. The offset is the column index in the trace where the first column of the binding starts.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct TraceBinding {
+    binding: Identifier,
+    trace_segment: TraceSegment,
+    offset: usize,
+    size: usize,
+}
+
+impl TraceBinding {
+    /// Creates a new trace binding.
+    pub fn new(binding: Identifier, trace_segment: usize, offset: usize, size: u64) -> Self {
+        Self {
+            binding,
+            trace_segment: trace_segment as TraceSegment,
+            offset,
+            size: size as usize,
+        }
+    }
+
+    /// Returns the name of the trace binding.
+    pub fn name(&self) -> &str {
+        self.binding.name()
+    }
+
+    /// Returns the trace segment of the trace binding.
+    pub fn trace_segment(&self) -> TraceSegment {
+        self.trace_segment
+    }
+
+    /// Returns the offset of the trace binding.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Returns the size of the trace binding.
+    pub fn size(&self) -> usize {
+        self.size
+    }
+}
+
+/// Indicates how much of a [TraceBinding] is being accessed.
+///
+/// TODO: check that this is correct for `Single`.
+/// - `Single`: only a single element from the [TraceBinding] is being referenced.
+/// - `Slice`: the specified range of the [TraceBinding] is being referenced.
+/// - `Full`: the entire [TraceBinding] is being referenced.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TraceBindingAccessSize {
+    Single,
+    Slice(Range),
+    Full,
+}
+
+/// [TraceBindingAccess] is used to indicate accessing a [TraceBinding].
+///
+/// - `binding`: is the identifier of the [TraceBinding] being accessed.
+/// - `col_offset`: specifies the column within the [TraceBinding] where the access starts. For
+///   example, if a [TraceBinding] has `offset` = 2 and the [TraceBindingAccess] has
+///   `col_offset` = 2, then the offset of the access within the trace segment will be 4. If the
+///   [TraceBinding] refers to a single column, then this value will be zero.
+/// - `size`: specifies how much of the [TraceBinding] is being accessed.
+/// - `row_offset`: specifies the offset from the current row.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TraceBindingAccess {
     binding: Identifier,
     col_offset: usize,
     size: TraceBindingAccessSize,
     row_offset: usize,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum TraceBindingAccessSize {
-    Single,
-    Slice(Range),
-    Full,
 }
 
 impl TraceBindingAccess {

--- a/codegen/winterfell/src/air/mod.rs
+++ b/codegen/winterfell/src/air/mod.rs
@@ -1,8 +1,8 @@
 use super::{AirIR, Impl, Scope};
-use air_script_core::{ConstantBinding, ConstantValueExpr, TraceAccess};
+use air_script_core::{AccessType, ConstantBinding, ConstantValueExpr, TraceAccess};
 use ir::{
     constraints::{AlgebraicGraph, ConstraintDomain, Operation},
-    ConstantValue, IntegrityConstraintDegree, NodeIndex, PeriodicColumn, Value,
+    IntegrityConstraintDegree, NodeIndex, PeriodicColumn, Value,
 };
 
 mod constants;

--- a/ir/src/constraint_builder/integrity_constraints/list_folding.rs
+++ b/ir/src/constraint_builder/integrity_constraints/list_folding.rs
@@ -22,10 +22,10 @@ impl ConstraintBuilder {
             ListFoldingValueExpr::Identifier(ident) => {
                 let symbol = self.symbol_table.get_symbol(ident.name())?;
                 match symbol.symbol_type() {
-                    SymbolType::Constant(ConstantValueExpr::Vector(list)) => {
+                    SymbolType::ConstantBinding(ConstantValueExpr::Vector(list)) => {
                         Ok(list.iter().map(|value| Expression::Const(*value)).collect())
                     }
-                    SymbolType::Variable(variable_type) => {
+                    SymbolType::VariableBinding(variable_type) => {
                         if let VariableValueExpr::Vector(list) = variable_type {
                             Ok(list.clone())
                         } else {

--- a/ir/src/constraint_builder/integrity_constraints/mod.rs
+++ b/ir/src/constraint_builder/integrity_constraints/mod.rs
@@ -1,9 +1,9 @@
 use super::{
     ast::{ConstraintType, IntegrityStmt},
-    BTreeMap, ConstantValueExpr, ConstraintBuilder, ConstraintDomain, Expression, Identifier,
-    Iterable, ListComprehension, ListFolding, ListFoldingValueExpr, SemanticError, Symbol,
-    SymbolType, TraceAccess, TraceBindingAccess, TraceBindingAccessSize, VariableBinding,
-    VariableValueExpr, VectorAccess, CURRENT_ROW,
+    AccessType, BTreeMap, BindingAccess, ConstantValueExpr, ConstraintBuilder, ConstraintDomain,
+    Expression, Identifier, Iterable, ListComprehension, ListFolding, ListFoldingValueExpr,
+    SemanticError, Symbol, SymbolType, TraceAccess, TraceBindingAccess, TraceBindingAccessSize,
+    VariableBinding, VariableValueExpr, CURRENT_ROW,
 };
 
 mod list_comprehension;

--- a/ir/src/constraint_builder/mod.rs
+++ b/ir/src/constraint_builder/mod.rs
@@ -1,10 +1,9 @@
 use super::{
-    ast, AccessType, AlgebraicGraph, BTreeMap, BTreeSet, ConstantValue, ConstantValueExpr,
+    ast, AccessType, AlgebraicGraph, BTreeMap, BTreeSet, BindingAccess, ConstantValueExpr,
     ConstraintDomain, ConstraintRoot, Constraints, Declarations, Expression, Identifier, Iterable,
-    ListComprehension, ListFolding, ListFoldingValueExpr, MatrixAccess, NodeIndex, Operation,
-    SemanticError, Symbol, SymbolTable, SymbolType, TraceAccess, TraceBindingAccess,
-    TraceBindingAccessSize, TraceSegment, ValidateAccess, Value, VariableBinding,
-    VariableValueExpr, VectorAccess, CURRENT_ROW,
+    ListComprehension, ListFolding, ListFoldingValueExpr, NodeIndex, Operation, SemanticError,
+    Symbol, SymbolTable, SymbolType, TraceAccess, TraceBindingAccess, TraceBindingAccessSize,
+    TraceSegment, Value, VariableBinding, VariableValueExpr, CURRENT_ROW,
 };
 
 mod boundary_constraints;

--- a/ir/src/constraint_builder/variables.rs
+++ b/ir/src/constraint_builder/variables.rs
@@ -1,73 +1,174 @@
-use super::{
-    AccessType, Expression, Identifier, MatrixAccess, SemanticError, ValidateAccess,
-    VariableValueExpr, VectorAccess,
-};
+use super::{AccessType, BindingAccess, Expression, SemanticError, VariableValueExpr};
 
-/// TODO: add doc comment and add comments in the code to explain the logic
+/// Returns an expression representing a single element, based on the name and value of a variable
+/// binding and the type of access into that variable which is being attempted.
+///
+/// # Errors
+/// Returns an error if the access would result in a vector or matrix of expressions instead of a
+/// single expression.
 pub(crate) fn get_variable_expr(
-    variable_name: &str,
-    variable_type: &VariableValueExpr,
-    access_type: &AccessType,
+    bound_value: &VariableValueExpr,
+    binding_access: BindingAccess,
 ) -> Result<Expression, SemanticError> {
-    variable_type.validate(variable_name, access_type)?;
+    let (ident, access_type) = binding_access.into_parts();
 
-    let expr = match (variable_type, access_type) {
-        (VariableValueExpr::Scalar(expr), AccessType::Default) => expr.clone(),
-        (VariableValueExpr::Scalar(expr), AccessType::Vector(idx)) => match expr {
-            Expression::Elem(elem) => {
-                Expression::VectorAccess(VectorAccess::new(elem.clone(), *idx))
-            }
-            Expression::VectorAccess(matrix_row_access) => {
-                Expression::MatrixAccess(MatrixAccess::new(
-                    Identifier(matrix_row_access.name().to_string()),
-                    matrix_row_access.idx(),
-                    *idx,
-                ))
-            }
-            _ => {
-                return Err(SemanticError::invalid_variable_access_type(
-                    variable_name,
-                    access_type,
-                ))
-            }
-        },
-        (
-            VariableValueExpr::Scalar(Expression::Elem(elem)),
-            AccessType::Matrix(row_idx, col_idx),
-        ) => Expression::MatrixAccess(MatrixAccess::new(elem.clone(), *row_idx, *col_idx)),
-        (VariableValueExpr::Vector(expr_vector), AccessType::Vector(idx)) => {
-            expr_vector[*idx].clone()
-        }
-        (VariableValueExpr::Vector(expr_vector), AccessType::Matrix(row_idx, col_idx)) => {
-            match &expr_vector[*row_idx] {
-                Expression::Elem(elem) => {
-                    Expression::VectorAccess(VectorAccess::new(elem.clone(), *col_idx))
-                }
-                Expression::VectorAccess(matrix_row_access) => {
-                    Expression::MatrixAccess(MatrixAccess::new(
-                        Identifier(matrix_row_access.name().to_string()),
-                        matrix_row_access.idx(),
-                        *col_idx,
-                    ))
+    // access the expression in the bound value that is specified by the binding_access.
+    let (inner_expr, inner_access_type) = match bound_value {
+        // return the expression. the access type does not change.
+        VariableValueExpr::Scalar(expr) => (expr, access_type),
+        VariableValueExpr::Vector(expr_vector) => {
+            // get the specified expression from the expression vector.
+            let inner_expr = match &access_type {
+                AccessType::Vector(idx) | AccessType::Matrix(idx, _) => {
+                    if *idx < expr_vector.len() {
+                        &expr_vector[*idx]
+                    } else {
+                        return Err(SemanticError::vector_access_out_of_bounds(
+                            ident.name(),
+                            *idx,
+                            expr_vector.len(),
+                        ));
+                    }
                 }
                 _ => {
                     return Err(SemanticError::invalid_variable_access_type(
-                        variable_name,
-                        access_type,
-                    ))
+                        ident.name(),
+                        &access_type,
+                    ));
                 }
-            }
+            };
+            // reduce the dimension of the access by 1, since we indexed the bound value once.
+            let inner_access_type = reduce_access_dim(ident.name(), access_type)?;
+            (inner_expr, inner_access_type)
         }
-        (VariableValueExpr::Matrix(expr_matrix), AccessType::Matrix(row_idx, col_idx)) => {
-            expr_matrix[*row_idx][*col_idx].clone()
+        VariableValueExpr::Matrix(expr_matrix) => {
+            // get the specified expression from the expression matrix.
+            let inner_expr = match &access_type {
+                AccessType::Matrix(row_idx, col_idx) => {
+                    if *row_idx < expr_matrix.len() && *col_idx < expr_matrix[0].len() {
+                        &expr_matrix[*row_idx][*col_idx]
+                    } else {
+                        return Err(SemanticError::matrix_access_out_of_bounds(
+                            ident.name(),
+                            *row_idx,
+                            *col_idx,
+                            expr_matrix.len(),
+                            expr_matrix[0].len(),
+                        ));
+                    }
+                }
+                _ => {
+                    return Err(SemanticError::invalid_variable_access_type(
+                        ident.name(),
+                        &access_type,
+                    ));
+                }
+            };
+            // reduce the dimension of the access by 2, since we indexed the bound value twice.
+            let inner_access_type = reduce_access_dim(ident.name(), access_type)?;
+            let inner_access_type = reduce_access_dim(ident.name(), inner_access_type)?;
+            (inner_expr, inner_access_type)
         }
         _ => {
             return Err(SemanticError::invalid_variable_access_type(
-                variable_name,
-                access_type,
-            ))
+                ident.name(),
+                &access_type,
+            ));
         }
     };
 
-    Ok(expr)
+    // access the inner expression with the specified access type to get the expression
+    access_inner_expr(ident.name(), inner_expr, inner_access_type)
+}
+
+// HELPERS
+// ================================================================================================
+
+/// Returns a new [AccessType] with the dimension reduced by one. For example, a Matrix access
+/// becomes a Vector access.
+fn reduce_access_dim(var_name: &str, access_type: AccessType) -> Result<AccessType, SemanticError> {
+    match access_type {
+        AccessType::Default => Err(SemanticError::invalid_variable_access_type(
+            var_name,
+            &access_type,
+        )),
+        AccessType::Vector(_) => Ok(AccessType::Default),
+        AccessType::Matrix(_, idx) => Ok(AccessType::Vector(idx)),
+    }
+}
+
+/// Accesses into a `BindingAccess` expression and returns a new `BindingAccess` of a higher
+/// dimension.
+///
+/// For example:
+/// Suppose the `expr` is a [BindingAccess] specifying that a binding `A` is being accessed as a
+/// vector at index 0 (i.e. the access_type is [AccessType::Vector(0)], representing `A[0]`).
+/// Suppose also the specified `access_type` is [AccessType::Vector(i)]. Then the resulting
+/// expression would be A[i][0], represented by a new [BindingAccess] with identifier `A` and
+/// [AccessType::Matrix(0, i)].
+///
+/// # Errors
+/// Returns an error if the expression is one that can't be accessed
+fn access_inner_expr(
+    var_name: &str,
+    expr: &Expression,
+    access_type: AccessType,
+) -> Result<Expression, SemanticError> {
+    match access_type {
+        // access the entire expression
+        AccessType::Default => Ok(expr.clone()),
+        // access into the expression at the specified index
+        AccessType::Vector(new_idx) => match expr {
+            Expression::BindingAccess(inner_binding) => match inner_binding.access_type() {
+                AccessType::Default => {
+                    let new_binding_access = BindingAccess::new(
+                        inner_binding.ident().clone(),
+                        AccessType::Vector(new_idx),
+                    );
+                    Ok(Expression::BindingAccess(new_binding_access))
+                }
+                AccessType::Vector(old_idx) => {
+                    let new_binding_access = BindingAccess::new(
+                        inner_binding.ident().clone(),
+                        AccessType::Matrix(*old_idx, new_idx),
+                    );
+                    Ok(Expression::BindingAccess(new_binding_access))
+                }
+                _ => Err(SemanticError::invalid_variable_access_type(
+                    inner_binding.name(),
+                    &access_type,
+                )),
+            },
+            _ => {
+                // other variable value expressions cannot be accessed directly.
+                Err(SemanticError::invalid_variable_access_type(
+                    var_name,
+                    &access_type,
+                ))
+            }
+        },
+        // access into the expression at the specified row and column indices
+        AccessType::Matrix(row_idx, col_idx) => match expr {
+            Expression::BindingAccess(inner_binding) => match inner_binding.access_type() {
+                AccessType::Default => {
+                    let new_binding_access = BindingAccess::new(
+                        inner_binding.ident().clone(),
+                        AccessType::Matrix(row_idx, col_idx),
+                    );
+                    Ok(Expression::BindingAccess(new_binding_access))
+                }
+                _ => Err(SemanticError::invalid_variable_access_type(
+                    inner_binding.name(),
+                    &access_type,
+                )),
+            },
+            _ => {
+                // other variable value expressions cannot be accessed directly.
+                Err(SemanticError::invalid_variable_access_type(
+                    var_name,
+                    &access_type,
+                ))
+            }
+        },
+    }
 }

--- a/ir/src/constraints/graph.rs
+++ b/ir/src/constraints/graph.rs
@@ -53,7 +53,9 @@ impl AlgebraicGraph {
         // recursively walk the subgraph and infer the trace segment and domain
         match self.node(index).op() {
             Operation::Value(value) => match value {
-                Value::Constant(_) => Ok((DEFAULT_SEGMENT, default_domain)),
+                Value::InlineConstant(_) | Value::BoundConstant(_) => {
+                    Ok((DEFAULT_SEGMENT, default_domain))
+                }
                 Value::PeriodicColumn(_, _) => {
                     if default_domain.is_boundary() {
                         return Err(SemanticError::invalid_periodic_column_access_in_bc());
@@ -120,7 +122,10 @@ impl AlgebraicGraph {
         // recursively walk the subgraph and compute the degree from the operation and child nodes
         match self.node(index).op() {
             Operation::Value(value) => match value {
-                Value::Constant(_) | Value::RandomValue(_) | Value::PublicInput(_, _) => 0,
+                Value::InlineConstant(_)
+                | Value::BoundConstant(_)
+                | Value::RandomValue(_)
+                | Value::PublicInput(_, _) => 0,
                 Value::TraceElement(_) => 1,
                 Value::PeriodicColumn(index, cycle_len) => {
                     cycles.insert(*index, *cycle_len);

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -1,7 +1,7 @@
 pub use air_script_core::{
-    ConstantBinding, ConstantValueExpr, Expression, Identifier, Iterable, ListComprehension,
-    ListFolding, ListFoldingValueExpr, MatrixAccess, TraceAccess, TraceBinding, TraceBindingAccess,
-    TraceBindingAccessSize, TraceSegment, VariableBinding, VariableValueExpr, VectorAccess,
+    AccessType, BindingAccess, ConstantBinding, ConstantValueExpr, Expression, Identifier,
+    Iterable, ListComprehension, ListFolding, ListFoldingValueExpr, TraceAccess, TraceBinding,
+    TraceBindingAccess, TraceBindingAccessSize, TraceSegment, VariableBinding, VariableValueExpr,
 };
 pub use parser::ast;
 use std::collections::{BTreeMap, BTreeSet};
@@ -21,8 +21,8 @@ use declarations::Declarations;
 pub use declarations::{PeriodicColumn, PublicInput};
 
 mod symbol_table;
-use symbol_table::{AccessType, Symbol, SymbolTable, SymbolType, ValidateAccess};
-pub use symbol_table::{ConstantValue, Value};
+pub use symbol_table::Value;
+use symbol_table::{Symbol, SymbolTable, SymbolType};
 
 mod validation;
 use validation::{SemanticError, SourceValidator};

--- a/ir/src/symbol_table/mod.rs
+++ b/ir/src/symbol_table/mod.rs
@@ -1,7 +1,7 @@
 use super::{
-    ast, BTreeMap, ConstantBinding, ConstantValueExpr, Declarations, Identifier, MatrixAccess,
-    SemanticError, TraceAccess, TraceBinding, TraceBindingAccess, VariableBinding,
-    VariableValueExpr, VectorAccess, CURRENT_ROW, MIN_CYCLE_LENGTH,
+    ast, AccessType, BTreeMap, BindingAccess, ConstantBinding, ConstantValueExpr, Declarations,
+    Identifier, SemanticError, TraceAccess, TraceBinding, TraceBindingAccess, VariableBinding,
+    VariableValueExpr, CURRENT_ROW, MIN_CYCLE_LENGTH,
 };
 
 mod symbol;
@@ -9,13 +9,12 @@ pub(crate) use symbol::Symbol;
 
 mod symbol_access;
 use symbol_access::ValidateIdentifierAccess;
-pub(crate) use symbol_access::{AccessType, ValidateAccess};
 
 mod symbol_type;
 pub(crate) use symbol_type::SymbolType;
 
 mod value;
-pub use value::{ConstantValue, Value};
+pub use value::Value;
 
 // SYMBOL TABLE
 // ================================================================================================
@@ -67,7 +66,7 @@ impl SymbolTable {
             }
         }
 
-        self.insert_symbol(name, SymbolType::Constant(constant_type))?;
+        self.insert_symbol(name, SymbolType::ConstantBinding(constant_type))?;
 
         Ok(())
     }
@@ -167,7 +166,7 @@ impl SymbolTable {
         variable: VariableBinding,
     ) -> Result<(), SemanticError> {
         let (name, value) = variable.into_parts();
-        self.insert_symbol(name, SymbolType::Variable(value))?;
+        self.insert_symbol(name, SymbolType::VariableBinding(value))?;
         Ok(())
     }
 
@@ -191,7 +190,7 @@ impl SymbolTable {
                 &symbol_type,
                 symbol.symbol_type(),
             ));
-        } else if matches!(symbol_type, SymbolType::Variable(_)) {
+        } else if matches!(symbol_type, SymbolType::VariableBinding(_)) {
             // track variables so we can clear them out when we are done with them
             self.variables.push(name);
         }

--- a/ir/src/symbol_table/symbol_access.rs
+++ b/ir/src/symbol_table/symbol_access.rs
@@ -1,26 +1,4 @@
-use super::{
-    ConstantValueExpr, SemanticError, Symbol, SymbolType, TraceBindingAccess, VariableValueExpr,
-};
-use std::fmt::Display;
-
-/// TODO: docs
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
-pub(crate) enum AccessType {
-    Default,
-    Vector(usize),
-    /// TODO: docs (row, then column)
-    Matrix(usize, usize),
-}
-
-impl Display for AccessType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Default => write!(f, "direct reference by name"),
-            Self::Vector(_) => write!(f, "vector"),
-            Self::Matrix(_, _) => write!(f, "matrix"),
-        }
-    }
-}
+use super::{AccessType, ConstantValueExpr, SemanticError, Symbol, SymbolType, TraceBindingAccess};
 
 /// Checks that the specified access into an identifier is valid and returns an error otherwise.
 /// # Errors:
@@ -106,56 +84,6 @@ impl ValidateAccess for ConstantValueExpr {
                             matrix[0].len(),
                         ));
                     }
-                }
-            },
-        }
-
-        Ok(())
-    }
-}
-
-impl ValidateAccess for VariableValueExpr {
-    fn validate(&self, name: &str, access_type: &AccessType) -> Result<(), SemanticError> {
-        match access_type {
-            AccessType::Default => return Ok(()),
-            AccessType::Vector(idx) => match self {
-                // TODO: scalar can be ok; check this symbol in the future
-                VariableValueExpr::Scalar(_) => return Ok(()),
-                VariableValueExpr::Vector(vector) => {
-                    if *idx >= vector.len() {
-                        return Err(SemanticError::vector_access_out_of_bounds(
-                            name,
-                            *idx,
-                            vector.len(),
-                        ));
-                    }
-                }
-                _ => {
-                    return Err(SemanticError::invalid_variable_access_type(
-                        name,
-                        access_type,
-                    ))
-                }
-            },
-            AccessType::Matrix(row_idx, col_idx) => match self {
-                // TODO: scalar & vector can be ok; check this symbol in the future
-                VariableValueExpr::Scalar(_) | VariableValueExpr::Vector(_) => return Ok(()),
-                VariableValueExpr::Matrix(matrix) => {
-                    if *row_idx >= matrix.len() || *col_idx >= matrix[0].len() {
-                        return Err(SemanticError::matrix_access_out_of_bounds(
-                            name,
-                            *row_idx,
-                            *col_idx,
-                            matrix.len(),
-                            matrix[0].len(),
-                        ));
-                    }
-                }
-                _ => {
-                    return Err(SemanticError::invalid_variable_access_type(
-                        name,
-                        access_type,
-                    ))
                 }
             },
         }

--- a/ir/src/symbol_table/symbol_type.rs
+++ b/ir/src/symbol_table/symbol_type.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub(crate) enum SymbolType {
     /// an identifier for a constant, containing its type and value
-    Constant(ConstantValueExpr),
+    ConstantBinding(ConstantValueExpr),
     /// an identifier for a binding to one or more trace columns, containing the trace binding
     /// information with its identifier, trace segment, size, and offset.
     TraceBinding(TraceBinding),
@@ -14,7 +14,7 @@ pub(crate) enum SymbolType {
     /// its cycle length in that order.
     PeriodicColumn(usize, usize),
     /// an expression or set of expressions associated with a variable
-    Variable(VariableValueExpr),
+    VariableBinding(VariableValueExpr),
     /// an identifier for random value, containing its index in the random values array and its
     /// length if this value is an array. For non-array random values second parameter is always 1.
     RandomValuesBinding(usize, usize),
@@ -23,13 +23,13 @@ pub(crate) enum SymbolType {
 impl Display for SymbolType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Constant(_) => write!(f, "Constant"),
+            Self::ConstantBinding(_) => write!(f, "ConstantBinding"),
             Self::TraceBinding(binding) => {
                 write!(f, "TraceBinding in segment {}", binding.trace_segment())
             }
             Self::PublicInput(_) => write!(f, "PublicInput"),
             Self::PeriodicColumn(_, _) => write!(f, "PeriodicColumn"),
-            Self::Variable(_) => write!(f, "Variable"),
+            Self::VariableBinding(_) => write!(f, "VariableBinding"),
             Self::RandomValuesBinding(_, _) => write!(f, "RandomValuesBinding"),
         }
     }

--- a/ir/src/symbol_table/value.rs
+++ b/ir/src/symbol_table/value.rs
@@ -1,9 +1,11 @@
-use super::{MatrixAccess, TraceAccess, VectorAccess};
+use super::{BindingAccess, TraceAccess};
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Value {
-    /// An inlined or named constant with identifier and access indices.
-    Constant(ConstantValue),
+    /// A named constant with identifier and access indices.
+    BoundConstant(BindingAccess),
+    /// An inlined constant value.
+    InlineConstant(u64),
     /// An identifier for an element in the trace segment, column, and row offset specified by the
     /// [TraceAccess]
     TraceElement(TraceAccess),
@@ -18,12 +20,4 @@ pub enum Value {
     /// A random value provided by the verifier. The inner value is the index of this random value
     /// in the array of all random values.
     RandomValue(usize),
-}
-
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub enum ConstantValue {
-    Inline(u64),
-    Scalar(String),
-    Vector(VectorAccess),
-    Matrix(MatrixAccess),
 }

--- a/ir/src/validation/error.rs
+++ b/ir/src/validation/error.rs
@@ -96,7 +96,7 @@ impl SemanticError {
 
     pub(crate) fn invalid_constant_access_type(name: &str, access_type: &AccessType) -> Self {
         Self::InvalidUsage(format!(
-            "Constant '{name}' cannot be accessed by a {access_type}.",
+            "ConstantBinding '{name}' cannot be accessed by a {access_type}.",
         ))
     }
 
@@ -126,7 +126,7 @@ impl SemanticError {
 
     pub(crate) fn invalid_variable_access_type(name: &str, access_type: &AccessType) -> Self {
         Self::InvalidUsage(format!(
-            "Variable '{name}' cannot be accessed as a {access_type}.",
+            "VariableBinding '{name}' cannot be accessed as a {access_type}.",
         ))
     }
 

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -1,8 +1,8 @@
 pub(crate) use air_script_core::{
-    ComprehensionContext, ConstantBinding, ConstantValueExpr, Expression, Identifier, Iterable,
-    ListComprehension, ListFolding, ListFoldingValueExpr, MatrixAccess, Range, TraceAccess,
-    TraceBinding, TraceBindingAccess, TraceBindingAccessSize, TraceSegment, VariableBinding,
-    VariableValueExpr, VectorAccess,
+    AccessType, BindingAccess, ComprehensionContext, ConstantBinding, ConstantValueExpr,
+    Expression, Identifier, Iterable, ListComprehension, ListFolding, ListFoldingValueExpr, Range,
+    TraceAccess, TraceBinding, TraceBindingAccess, TraceBindingAccessSize, TraceSegment,
+    VariableBinding, VariableValueExpr,
 };
 
 // declaration modules
@@ -37,8 +37,8 @@ pub struct Source(pub Vec<SourceSection>);
 /// - AirDef: Name of the air constraints module.
 ///
 /// The type declaration sections are:
-/// - ConstantBinding: A constant is represented by a name and a value. Each [ConstantBinding] source section
-///   declares a single constant.
+/// - Constant: A constant is represented by a name and a value. Each [ConstantBinding] source
+///   section declares a single constant.
 /// - EvaluatorFunction: Evaluator functions take descriptions of the main and auxiliary traces as
 ///   input, and enforce integrity constraints on those trace columns. Each [EvaluatorFunction]
 ///   source section declares a single evaluator function

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -2,11 +2,11 @@ use crate::{
     ast::{
         boundary_constraints::{Boundary, BoundaryConstraint, BoundaryStmt},
         integrity_constraints::{ConstraintType, IntegrityConstraint, IntegrityStmt},
-        build_trace_bindings, ConstantBinding, ConstantValueExpr, ComprehensionContext,
-        Expression, EvaluatorFunction, EvaluatorFunctionCall, Identifier, TraceAccess, Iterable,
-        ListComprehension, ListFolding, ListFoldingValueExpr, MatrixAccess, PeriodicColumn,
-        PublicInput, RandBinding, RandomValues, Range, Source, SourceSection, TraceBinding,
-        TraceBindingAccess, TraceBindingAccessSize, VariableBinding, VariableValueExpr, VectorAccess
+        build_trace_bindings, AccessType, BindingAccess, ConstantBinding, ConstantValueExpr, 
+        ComprehensionContext, Expression, EvaluatorFunction, EvaluatorFunctionCall, Identifier, 
+        TraceAccess, Iterable, ListComprehension, ListFolding, ListFoldingValueExpr,
+        PeriodicColumn, PublicInput, RandBinding, RandomValues, Range, Source, SourceSection, 
+        TraceBinding, TraceBindingAccess, TraceBindingAccessSize, VariableBinding, VariableValueExpr, 
     }, error::{Error, ParseError::*}, lexer::Token
 };
 use std::str::FromStr;
@@ -262,9 +262,7 @@ BoundaryAtom: Expression = {
     "(" <BoundaryExpr> ")",
     "$" <ident: Identifier> <idx: Index> => Expression::Rand(ident, idx),
     <n: Num_u64> => Expression::Const(n),
-    <ident: Identifier> => Expression::Elem(ident),
-    <vector_access: VectorAccess> => Expression::VectorAccess(vector_access),
-    <matrix_access: MatrixAccess> => Expression::MatrixAccess(matrix_access),
+    <binding_access: BindingAccess> => Expression::BindingAccess(binding_access),
     <list_folding_type: ListFolding<BoundaryExpr>> => Expression::ListFolding(list_folding_type),
 }
 
@@ -330,7 +328,7 @@ IntegrityConstraintWithSelector: IntegrityStmt = {
 IntegrityVariableType: VariableValueExpr = {
     <scalar_value: IntegrityExpr> =>
         VariableValueExpr::Scalar(scalar_value),
-    <vector_value: Vector<IntegrityExpr>> => 
+    <vector_value: Vector<IntegrityExpr>> =>
         VariableValueExpr::Vector(vector_value),
     <matrix_value: Matrix<IntegrityExpr>> =>
         VariableValueExpr::Matrix(matrix_value),
@@ -395,11 +393,9 @@ IntegrityAtom: Expression = {
     <col_access: TraceAccess> => Expression::TraceAccess(col_access),
     "$" <ident: Identifier> <idx: Index> => Expression::Rand(ident, idx),
     <n: Num_u64> => Expression::Const(n),
-    <ident: Identifier> => Expression::Elem(ident),
     "!" <expr: IntegrityAtom> =>
         Expression::Sub(Box::new(Expression::Const(1)), Box::new(expr)),
-    <vector_access: VectorAccess> => Expression::VectorAccess(vector_access),
-    <matrix_access: MatrixAccess> => Expression::MatrixAccess(matrix_access),
+    <binding_access: BindingAccess> => Expression::BindingAccess(binding_access),
     <trace_access: TraceBindingAccessWithOffset> => Expression::TraceBindingAccess(trace_access),
     <list_folding_type: ListFolding<IntegrityExpr>> =>
         Expression::ListFolding(list_folding_type),
@@ -440,13 +436,13 @@ Index: usize = {
     "[" <idx: Num_u64> "]" => idx as usize
 }
 
-VectorAccess: VectorAccess = {
-    <ident: Identifier> <idx: Index> => VectorAccess::new(ident, idx)
-}
-
-MatrixAccess: MatrixAccess = {
+BindingAccess: BindingAccess = {
+    <ident: Identifier> => 
+        BindingAccess::new(ident, AccessType::Default),
+    <ident: Identifier> <idx: Index> => 
+        BindingAccess::new(ident, AccessType::Vector(idx)),
     <ident: Identifier> <row: Index> <col: Index> =>
-        MatrixAccess::new(ident, row, col)
+        BindingAccess::new(ident, AccessType::Matrix(row, col))
 }
 
 TraceBindingAccess: TraceBindingAccess = {

--- a/parser/src/parser/tests/arithmetic_ops.rs
+++ b/parser/src/parser/tests/arithmetic_ops.rs
@@ -1,6 +1,6 @@
 use super::{
-    build_parse_test, Expression::*, Identifier, IntegrityConstraint, IntegrityStmt::*, Source,
-    SourceSection::*,
+    build_parse_test, AccessType, BindingAccess, Expression::*, Identifier, IntegrityConstraint,
+    IntegrityStmt::*, Source, SourceSection::*,
 };
 use crate::ast::{ConstraintType, TraceBindingAccess, TraceBindingAccessSize};
 
@@ -22,7 +22,10 @@ fn single_addition() {
                     TraceBindingAccessSize::Full,
                     1,
                 ))),
-                Box::new(Elem(Identifier("clk".to_string()))),
+                Box::new(BindingAccess(BindingAccess::new(
+                    Identifier("clk".to_string()),
+                    AccessType::Default,
+                ))),
             ),
             Const(0),
         )),
@@ -47,7 +50,10 @@ fn multi_addition() {
                         TraceBindingAccessSize::Full,
                         1,
                     ))),
-                    Box::new(Elem(Identifier("clk".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("clk".to_string()),
+                        AccessType::Default,
+                    ))),
                 )),
                 Box::new(Const(2)),
             ),
@@ -73,7 +79,10 @@ fn single_subtraction() {
                     TraceBindingAccessSize::Full,
                     1,
                 ))),
-                Box::new(Elem(Identifier("clk".to_string()))),
+                Box::new(BindingAccess(BindingAccess::new(
+                    Identifier("clk".to_string()),
+                    AccessType::Default,
+                ))),
             ),
             Const(0),
         )),
@@ -98,7 +107,10 @@ fn multi_subtraction() {
                         TraceBindingAccessSize::Full,
                         1,
                     ))),
-                    Box::new(Elem(Identifier("clk".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("clk".to_string()),
+                        AccessType::Default,
+                    ))),
                 )),
                 Box::new(Const(1)),
             ),
@@ -124,7 +136,10 @@ fn single_multiplication() {
                     TraceBindingAccessSize::Full,
                     1,
                 ))),
-                Box::new(Elem(Identifier("clk".to_string()))),
+                Box::new(BindingAccess(BindingAccess::new(
+                    Identifier("clk".to_string()),
+                    AccessType::Default,
+                ))),
             ),
             Const(0),
         )),
@@ -149,7 +164,10 @@ fn multi_multiplication() {
                         TraceBindingAccessSize::Full,
                         1,
                     ))),
-                    Box::new(Elem(Identifier("clk".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("clk".to_string()),
+                        AccessType::Default,
+                    ))),
                 )),
                 Box::new(Const(2)),
             ),
@@ -192,7 +210,10 @@ fn ops_with_parens() {
                         TraceBindingAccessSize::Full,
                         1,
                     ))),
-                    Box::new(Elem(Identifier("clk".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("clk".to_string()),
+                        AccessType::Default,
+                    ))),
                 )),
                 Box::new(Const(2)),
             ),
@@ -243,7 +264,10 @@ fn non_const_exponentiation() {
                     1,
                 ))),
                 Box::new(Add(
-                    Box::new(Elem(Identifier("clk".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("clk".to_string()),
+                        AccessType::Default,
+                    ))),
                     Box::new(Const(2)),
                 )),
             ),
@@ -289,7 +313,10 @@ fn multi_arithmetic_ops_same_precedence() {
                             TraceBindingAccessSize::Full,
                             1,
                         ))),
-                        Box::new(Elem(Identifier("clk".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("clk".to_string()),
+                            AccessType::Default,
+                        ))),
                     )),
                     Box::new(Const(2)),
                 )),
@@ -327,7 +354,10 @@ fn multi_arithmetic_ops_different_precedence() {
                         Box::new(Const(2)),
                     )),
                     Box::new(Mul(
-                        Box::new(Elem(Identifier("clk".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("clk".to_string()),
+                            AccessType::Default,
+                        ))),
                         Box::new(Const(2)),
                     )),
                 )),
@@ -363,7 +393,10 @@ fn multi_arithmetic_ops_different_precedence_w_parens() {
                 ))),
                 Box::new(Mul(
                     Box::new(Exp(
-                        Box::new(Elem(Identifier("clk".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("clk".to_string()),
+                            AccessType::Default,
+                        ))),
                         Box::new(Const(2)),
                     )),
                     Box::new(Sub(Box::new(Const(2)), Box::new(Const(1)))),

--- a/parser/src/parser/tests/boundary_constraints.rs
+++ b/parser/src/parser/tests/boundary_constraints.rs
@@ -1,12 +1,11 @@
 use super::{
-    build_parse_test, Boundary, BoundaryConstraint, Identifier, Iterable, Range, Source,
-    SourceSection, TraceBinding,
+    build_parse_test, AccessType, BindingAccess, Boundary, BoundaryConstraint, Identifier,
+    Iterable, Range, Source, SourceSection, TraceBinding,
 };
 use crate::{
     ast::{
-        BoundaryStmt::*, ConstantBinding, ConstantValueExpr::*, Expression::*, MatrixAccess,
-        PublicInput, TraceBindingAccess, TraceBindingAccessSize, VariableBinding,
-        VariableValueExpr, VectorAccess,
+        BoundaryStmt::*, ConstantBinding, ConstantValueExpr::*, Expression::*, PublicInput,
+        TraceBindingAccess, TraceBindingAccessSize, VariableBinding, VariableValueExpr,
     },
     error::{Error, ParseError},
 };
@@ -110,7 +109,10 @@ fn boundary_constraint_with_pub_input() {
                 0,
             ),
             Boundary::First,
-            VectorAccess(VectorAccess::new(Identifier("a".to_string()), 0)),
+            BindingAccess(BindingAccess::new(
+                Identifier("a".to_string()),
+                AccessType::Vector(0),
+            )),
         ))]),
     ]);
     build_parse_test!(source).expect_ast(expected);
@@ -133,9 +135,9 @@ fn boundary_constraint_with_expr() {
             Add(
                 Box::new(Add(
                     Box::new(Const(5)),
-                    Box::new(VectorAccess(VectorAccess::new(
+                    Box::new(BindingAccess(BindingAccess::new(
                         Identifier("a".to_string()),
-                        3,
+                        AccessType::Vector(3),
                     ))),
                 )),
                 Box::new(Const(6)),
@@ -173,16 +175,18 @@ fn boundary_constraint_with_const() {
             Boundary::First,
             Sub(
                 Box::new(Add(
-                    Box::new(Elem(Identifier("A".to_string()))),
-                    Box::new(VectorAccess(VectorAccess::new(
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("A".to_string()),
+                        AccessType::Default,
+                    ))),
+                    Box::new(BindingAccess(BindingAccess::new(
                         Identifier("B".to_string()),
-                        1,
+                        AccessType::Vector(1),
                     ))),
                 )),
-                Box::new(MatrixAccess(MatrixAccess::new(
+                Box::new(BindingAccess(BindingAccess::new(
                     Identifier("C".to_string()),
-                    0,
-                    1,
+                    AccessType::Matrix(0, 1),
                 ))),
             ),
         ))]),
@@ -206,10 +210,16 @@ fn boundary_constraint_with_variables() {
         VariableBinding(VariableBinding::new(
             Identifier("b".to_string()),
             VariableValueExpr::Vector(vec![
-                Elem(Identifier("a".to_string())),
+                BindingAccess(BindingAccess::new(
+                    Identifier("a".to_string()),
+                    AccessType::Default,
+                )),
                 Mul(
                     Box::new(Const(2)),
-                    Box::new(Elem(Identifier("a".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("a".to_string()),
+                        AccessType::Default,
+                    ))),
                 ),
             ]),
         )),
@@ -218,17 +228,29 @@ fn boundary_constraint_with_variables() {
             VariableValueExpr::Matrix(vec![
                 vec![
                     Sub(
-                        Box::new(Elem(Identifier("a".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("a".to_string()),
+                            AccessType::Default,
+                        ))),
                         Box::new(Const(1)),
                     ),
                     Exp(
-                        Box::new(Elem(Identifier("a".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("a".to_string()),
+                            AccessType::Default,
+                        ))),
                         Box::new(Const(2)),
                     ),
                 ],
                 vec![
-                    VectorAccess(VectorAccess::new(Identifier("b".to_string()), 0)),
-                    VectorAccess(VectorAccess::new(Identifier("b".to_string()), 1)),
+                    BindingAccess(BindingAccess::new(
+                        Identifier("b".to_string()),
+                        AccessType::Vector(0),
+                    )),
+                    BindingAccess(BindingAccess::new(
+                        Identifier("b".to_string()),
+                        AccessType::Vector(1),
+                    )),
                 ],
             ]),
         )),
@@ -243,9 +265,9 @@ fn boundary_constraint_with_variables() {
             Add(
                 Box::new(Add(
                     Box::new(Const(5)),
-                    Box::new(VectorAccess(VectorAccess::new(
+                    Box::new(BindingAccess(BindingAccess::new(
                         Identifier("a".to_string()),
-                        3,
+                        AccessType::Vector(3),
                     ))),
                 )),
                 Box::new(Const(6)),
@@ -390,7 +412,10 @@ fn bc_comprehension_two_iterable_identifiers() {
                     0,
                 ),
                 Boundary::First,
-                Elem(Identifier("y".to_string())),
+                BindingAccess(BindingAccess::new(
+                    Identifier("y".to_string()),
+                    AccessType::Default,
+                )),
             ),
             vec![
                 (

--- a/parser/src/parser/tests/evaluator_functions.rs
+++ b/parser/src/parser/tests/evaluator_functions.rs
@@ -1,9 +1,9 @@
 use super::{build_parse_test, Identifier, IntegrityConstraint, Source, SourceSection};
 use crate::{
     ast::{
-        ConstraintType, EvaluatorFunction, EvaluatorFunctionCall, Expression::*, IntegrityStmt::*,
-        Range, TraceBinding, TraceBindingAccess, TraceBindingAccessSize, VariableBinding,
-        VariableValueExpr,
+        AccessType, BindingAccess, ConstraintType, EvaluatorFunction, EvaluatorFunctionCall,
+        Expression::*, IntegrityStmt::*, Range, TraceBinding, TraceBindingAccess,
+        TraceBindingAccessSize, VariableBinding, VariableValueExpr,
     },
     error::{Error, ParseError},
 };
@@ -29,7 +29,10 @@ fn ev_fn_main_cols() {
                         1,
                     )),
                     Add(
-                        Box::new(Elem(Identifier("clk".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("clk".to_string()),
+                            AccessType::Default,
+                        ))),
                         Box::new(Const(1)),
                     ),
                 )),
@@ -60,8 +63,14 @@ fn ev_fn_main_and_aux_cols() {
                 VariableBinding(VariableBinding::new(
                     Identifier("z".to_string()),
                     VariableValueExpr::Scalar(Add(
-                        Box::new(Elem(Identifier("a".to_string()))),
-                        Box::new(Elem(Identifier("b".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("a".to_string()),
+                            AccessType::Default,
+                        ))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("b".to_string()),
+                            AccessType::Default,
+                        ))),
                     )),
                 )),
                 Constraint(
@@ -73,7 +82,10 @@ fn ev_fn_main_and_aux_cols() {
                             1,
                         )),
                         Add(
-                            Box::new(Elem(Identifier("clk".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("clk".to_string()),
+                                AccessType::Default,
+                            ))),
                             Box::new(Const(1)),
                         ),
                     )),
@@ -88,8 +100,14 @@ fn ev_fn_main_and_aux_cols() {
                             1,
                         )),
                         Add(
-                            Box::new(Elem(Identifier("a".to_string()))),
-                            Box::new(Elem(Identifier("z".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("a".to_string()),
+                                AccessType::Default,
+                            ))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("z".to_string()),
+                                AccessType::Default,
+                            ))),
                         ),
                     )),
                     None,

--- a/parser/src/parser/tests/list_comprehension.rs
+++ b/parser/src/parser/tests/list_comprehension.rs
@@ -3,9 +3,9 @@ use air_script_core::{Iterable, ListComprehension, Range};
 use super::{build_parse_test, Identifier, IntegrityConstraint, Source};
 use crate::{
     ast::{
-        Boundary, BoundaryConstraint, BoundaryStmt, ConstraintType, Expression::*, IntegrityStmt,
-        SourceSection::*, TraceBinding, TraceBindingAccess, TraceBindingAccessSize,
-        VariableBinding, VariableValueExpr, VectorAccess,
+        AccessType, BindingAccess, Boundary, BoundaryConstraint, BoundaryStmt, ConstraintType,
+        Expression::*, IntegrityStmt, SourceSection::*, TraceBinding, TraceBindingAccess,
+        TraceBindingAccessSize, VariableBinding, VariableValueExpr,
     },
     error::{Error, ParseError},
 };
@@ -36,7 +36,10 @@ fn bc_one_iterable_identifier_lc() {
                 Identifier("x".to_string()),
                 VariableValueExpr::ListComprehension(ListComprehension::new(
                     Exp(
-                        Box::new(Elem(Identifier("col".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("col".to_string()),
+                            AccessType::Default,
+                        ))),
                         Box::new(Const(7)),
                     ),
                     vec![(
@@ -56,23 +59,23 @@ fn bc_one_iterable_identifier_lc() {
                 Add(
                     Box::new(Add(
                         Box::new(Add(
-                            Box::new(VectorAccess(VectorAccess::new(
+                            Box::new(BindingAccess(BindingAccess::new(
                                 Identifier("x".to_string()),
-                                0,
+                                AccessType::Vector(0),
                             ))),
-                            Box::new(VectorAccess(VectorAccess::new(
+                            Box::new(BindingAccess(BindingAccess::new(
                                 Identifier("x".to_string()),
-                                1,
+                                AccessType::Vector(1),
                             ))),
                         )),
-                        Box::new(VectorAccess(VectorAccess::new(
+                        Box::new(BindingAccess(BindingAccess::new(
                             Identifier("x".to_string()),
-                            2,
+                            AccessType::Vector(2),
                         ))),
                     )),
-                    Box::new(VectorAccess(VectorAccess::new(
+                    Box::new(BindingAccess(BindingAccess::new(
                         Identifier("x".to_string()),
-                        3,
+                        AccessType::Vector(3),
                     ))),
                 ),
             )),
@@ -105,9 +108,15 @@ fn bc_identifier_and_range_lc() {
                     Mul(
                         Box::new(Exp(
                             Box::new(Const(2)),
-                            Box::new(Elem(Identifier("i".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("i".to_string()),
+                                AccessType::Default,
+                            ))),
                         )),
-                        Box::new(Elem(Identifier("c".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("c".to_string()),
+                            AccessType::Default,
+                        ))),
                     ),
                     vec![
                         (
@@ -132,23 +141,23 @@ fn bc_identifier_and_range_lc() {
                 Add(
                     Box::new(Add(
                         Box::new(Add(
-                            Box::new(VectorAccess(VectorAccess::new(
+                            Box::new(BindingAccess(BindingAccess::new(
                                 Identifier("x".to_string()),
-                                0,
+                                AccessType::Vector(0),
                             ))),
-                            Box::new(VectorAccess(VectorAccess::new(
+                            Box::new(BindingAccess(BindingAccess::new(
                                 Identifier("x".to_string()),
-                                1,
+                                AccessType::Vector(1),
                             ))),
                         )),
-                        Box::new(VectorAccess(VectorAccess::new(
+                        Box::new(BindingAccess(BindingAccess::new(
                             Identifier("x".to_string()),
-                            2,
+                            AccessType::Vector(2),
                         ))),
                     )),
-                    Box::new(VectorAccess(VectorAccess::new(
+                    Box::new(BindingAccess(BindingAccess::new(
                         Identifier("x".to_string()),
-                        3,
+                        AccessType::Vector(3),
                     ))),
                 ),
             )),
@@ -178,7 +187,10 @@ fn bc_iterable_slice_lc() {
             BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableValueExpr::ListComprehension(ListComprehension::new(
-                    Elem(Identifier("c".to_string())),
+                    BindingAccess(BindingAccess::new(
+                        Identifier("c".to_string()),
+                        AccessType::Default,
+                    )),
                     vec![(
                         Identifier("c".to_string()),
                         Iterable::Slice(Identifier("c".to_string()), Range::new(0, 3)),
@@ -196,23 +208,23 @@ fn bc_iterable_slice_lc() {
                 Add(
                     Box::new(Add(
                         Box::new(Add(
-                            Box::new(VectorAccess(VectorAccess::new(
+                            Box::new(BindingAccess(BindingAccess::new(
                                 Identifier("x".to_string()),
-                                0,
+                                AccessType::Vector(0),
                             ))),
-                            Box::new(VectorAccess(VectorAccess::new(
+                            Box::new(BindingAccess(BindingAccess::new(
                                 Identifier("x".to_string()),
-                                1,
+                                AccessType::Vector(1),
                             ))),
                         )),
-                        Box::new(VectorAccess(VectorAccess::new(
+                        Box::new(BindingAccess(BindingAccess::new(
                             Identifier("x".to_string()),
-                            2,
+                            AccessType::Vector(2),
                         ))),
                     )),
-                    Box::new(VectorAccess(VectorAccess::new(
+                    Box::new(BindingAccess(BindingAccess::new(
                         Identifier("x".to_string()),
-                        3,
+                        AccessType::Vector(3),
                     ))),
                 ),
             )),
@@ -244,8 +256,14 @@ fn bc_two_iterable_identifier_lc() {
                 Identifier("diff".to_string()),
                 VariableValueExpr::ListComprehension(ListComprehension::new(
                     Sub(
-                        Box::new(Elem(Identifier("x".to_string()))),
-                        Box::new(Elem(Identifier("y".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("x".to_string()),
+                            AccessType::Default,
+                        ))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("y".to_string()),
+                            AccessType::Default,
+                        ))),
                     ),
                     vec![
                         (
@@ -270,23 +288,23 @@ fn bc_two_iterable_identifier_lc() {
                 Add(
                     Box::new(Add(
                         Box::new(Add(
-                            Box::new(VectorAccess(VectorAccess::new(
+                            Box::new(BindingAccess(BindingAccess::new(
                                 Identifier("x".to_string()),
-                                0,
+                                AccessType::Vector(0),
                             ))),
-                            Box::new(VectorAccess(VectorAccess::new(
+                            Box::new(BindingAccess(BindingAccess::new(
                                 Identifier("x".to_string()),
-                                1,
+                                AccessType::Vector(1),
                             ))),
                         )),
-                        Box::new(VectorAccess(VectorAccess::new(
+                        Box::new(BindingAccess(BindingAccess::new(
                             Identifier("x".to_string()),
-                            2,
+                            AccessType::Vector(2),
                         ))),
                     )),
-                    Box::new(VectorAccess(VectorAccess::new(
+                    Box::new(BindingAccess(BindingAccess::new(
                         Identifier("x".to_string()),
-                        3,
+                        AccessType::Vector(3),
                     ))),
                 ),
             )),
@@ -320,12 +338,24 @@ fn bc_multiple_iterables_lc() {
                     Sub(
                         Box::new(Sub(
                             Box::new(Add(
-                                Box::new(Elem(Identifier("w".to_string()))),
-                                Box::new(Elem(Identifier("x".to_string()))),
+                                Box::new(BindingAccess(BindingAccess::new(
+                                    Identifier("w".to_string()),
+                                    AccessType::Default,
+                                ))),
+                                Box::new(BindingAccess(BindingAccess::new(
+                                    Identifier("x".to_string()),
+                                    AccessType::Default,
+                                ))),
                             )),
-                            Box::new(Elem(Identifier("y".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("y".to_string()),
+                                AccessType::Default,
+                            ))),
                         )),
-                        Box::new(Elem(Identifier("z".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("z".to_string()),
+                            AccessType::Default,
+                        ))),
                     ),
                     vec![
                         (
@@ -358,23 +388,23 @@ fn bc_multiple_iterables_lc() {
                 Add(
                     Box::new(Add(
                         Box::new(Add(
-                            Box::new(VectorAccess(VectorAccess::new(
+                            Box::new(BindingAccess(BindingAccess::new(
                                 Identifier("x".to_string()),
-                                0,
+                                AccessType::Vector(0),
                             ))),
-                            Box::new(VectorAccess(VectorAccess::new(
+                            Box::new(BindingAccess(BindingAccess::new(
                                 Identifier("x".to_string()),
-                                1,
+                                AccessType::Vector(1),
                             ))),
                         )),
-                        Box::new(VectorAccess(VectorAccess::new(
+                        Box::new(BindingAccess(BindingAccess::new(
                             Identifier("x".to_string()),
-                            2,
+                            AccessType::Vector(2),
                         ))),
                     )),
-                    Box::new(VectorAccess(VectorAccess::new(
+                    Box::new(BindingAccess(BindingAccess::new(
                         Identifier("x".to_string()),
-                        3,
+                        AccessType::Vector(3),
                     ))),
                 ),
             )),
@@ -409,7 +439,10 @@ fn ic_one_iterable_identifier_lc() {
                 Identifier("x".to_string()),
                 VariableValueExpr::ListComprehension(ListComprehension::new(
                     Exp(
-                        Box::new(Elem(Identifier("col".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("col".to_string()),
+                            AccessType::Default,
+                        ))),
                         Box::new(Const(7)),
                     ),
                     vec![(
@@ -438,27 +471,30 @@ fn ic_one_iterable_identifier_lc() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    Elem(Identifier("a".to_string())),
+                    BindingAccess(BindingAccess::new(
+                        Identifier("a".to_string()),
+                        AccessType::Default,
+                    )),
                     Add(
                         Box::new(Add(
                             Box::new(Add(
-                                Box::new(VectorAccess(VectorAccess::new(
+                                Box::new(BindingAccess(BindingAccess::new(
                                     Identifier("x".to_string()),
-                                    0,
+                                    AccessType::Vector(0),
                                 ))),
-                                Box::new(VectorAccess(VectorAccess::new(
+                                Box::new(BindingAccess(BindingAccess::new(
                                     Identifier("x".to_string()),
-                                    1,
+                                    AccessType::Vector(1),
                                 ))),
                             )),
-                            Box::new(VectorAccess(VectorAccess::new(
+                            Box::new(BindingAccess(BindingAccess::new(
                                 Identifier("x".to_string()),
-                                2,
+                                AccessType::Vector(2),
                             ))),
                         )),
-                        Box::new(VectorAccess(VectorAccess::new(
+                        Box::new(BindingAccess(BindingAccess::new(
                             Identifier("x".to_string()),
-                            3,
+                            AccessType::Vector(3),
                         ))),
                     ),
                 )),
@@ -493,9 +529,15 @@ fn ic_iterable_identifier_range_lc() {
                     Mul(
                         Box::new(Exp(
                             Box::new(Const(2)),
-                            Box::new(Elem(Identifier("i".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("i".to_string()),
+                                AccessType::Default,
+                            ))),
                         )),
-                        Box::new(Elem(Identifier("c".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("c".to_string()),
+                            AccessType::Default,
+                        ))),
                     ),
                     vec![
                         (
@@ -511,27 +553,30 @@ fn ic_iterable_identifier_range_lc() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    Elem(Identifier("a".to_string())),
+                    BindingAccess(BindingAccess::new(
+                        Identifier("a".to_string()),
+                        AccessType::Default,
+                    )),
                     Add(
                         Box::new(Add(
                             Box::new(Add(
-                                Box::new(VectorAccess(VectorAccess::new(
+                                Box::new(BindingAccess(BindingAccess::new(
                                     Identifier("x".to_string()),
-                                    0,
+                                    AccessType::Vector(0),
                                 ))),
-                                Box::new(VectorAccess(VectorAccess::new(
+                                Box::new(BindingAccess(BindingAccess::new(
                                     Identifier("x".to_string()),
-                                    1,
+                                    AccessType::Vector(1),
                                 ))),
                             )),
-                            Box::new(VectorAccess(VectorAccess::new(
+                            Box::new(BindingAccess(BindingAccess::new(
                                 Identifier("x".to_string()),
-                                2,
+                                AccessType::Vector(2),
                             ))),
                         )),
-                        Box::new(VectorAccess(VectorAccess::new(
+                        Box::new(BindingAccess(BindingAccess::new(
                             Identifier("x".to_string()),
-                            3,
+                            AccessType::Vector(3),
                         ))),
                     ),
                 )),
@@ -563,7 +608,10 @@ fn ic_iterable_slice_lc() {
             IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableValueExpr::ListComprehension(ListComprehension::new(
-                    Elem(Identifier("c".to_string())),
+                    BindingAccess(BindingAccess::new(
+                        Identifier("c".to_string()),
+                        AccessType::Default,
+                    )),
                     vec![(
                         Identifier("c".to_string()),
                         Iterable::Slice(Identifier("c".to_string()), Range::new(0, 3)),
@@ -572,27 +620,30 @@ fn ic_iterable_slice_lc() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    Elem(Identifier("a".to_string())),
+                    BindingAccess(BindingAccess::new(
+                        Identifier("a".to_string()),
+                        AccessType::Default,
+                    )),
                     Add(
                         Box::new(Add(
                             Box::new(Add(
-                                Box::new(VectorAccess(VectorAccess::new(
+                                Box::new(BindingAccess(BindingAccess::new(
                                     Identifier("x".to_string()),
-                                    0,
+                                    AccessType::Vector(0),
                                 ))),
-                                Box::new(VectorAccess(VectorAccess::new(
+                                Box::new(BindingAccess(BindingAccess::new(
                                     Identifier("x".to_string()),
-                                    1,
+                                    AccessType::Vector(1),
                                 ))),
                             )),
-                            Box::new(VectorAccess(VectorAccess::new(
+                            Box::new(BindingAccess(BindingAccess::new(
                                 Identifier("x".to_string()),
-                                2,
+                                AccessType::Vector(2),
                             ))),
                         )),
-                        Box::new(VectorAccess(VectorAccess::new(
+                        Box::new(BindingAccess(BindingAccess::new(
                             Identifier("x".to_string()),
-                            3,
+                            AccessType::Vector(3),
                         ))),
                     ),
                 )),
@@ -626,8 +677,14 @@ fn ic_two_iterable_identifier_lc() {
                 Identifier("diff".to_string()),
                 VariableValueExpr::ListComprehension(ListComprehension::new(
                     Sub(
-                        Box::new(Elem(Identifier("x".to_string()))),
-                        Box::new(Elem(Identifier("y".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("x".to_string()),
+                            AccessType::Default,
+                        ))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("y".to_string()),
+                            AccessType::Default,
+                        ))),
                     ),
                     vec![
                         (
@@ -643,27 +700,30 @@ fn ic_two_iterable_identifier_lc() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    Elem(Identifier("a".to_string())),
+                    BindingAccess(BindingAccess::new(
+                        Identifier("a".to_string()),
+                        AccessType::Default,
+                    )),
                     Add(
                         Box::new(Add(
                             Box::new(Add(
-                                Box::new(VectorAccess(VectorAccess::new(
+                                Box::new(BindingAccess(BindingAccess::new(
                                     Identifier("x".to_string()),
-                                    0,
+                                    AccessType::Vector(0),
                                 ))),
-                                Box::new(VectorAccess(VectorAccess::new(
+                                Box::new(BindingAccess(BindingAccess::new(
                                     Identifier("x".to_string()),
-                                    1,
+                                    AccessType::Vector(1),
                                 ))),
                             )),
-                            Box::new(VectorAccess(VectorAccess::new(
+                            Box::new(BindingAccess(BindingAccess::new(
                                 Identifier("x".to_string()),
-                                2,
+                                AccessType::Vector(2),
                             ))),
                         )),
-                        Box::new(VectorAccess(VectorAccess::new(
+                        Box::new(BindingAccess(BindingAccess::new(
                             Identifier("x".to_string()),
-                            3,
+                            AccessType::Vector(3),
                         ))),
                     ),
                 )),
@@ -699,12 +759,24 @@ fn ic_multiple_iterables_lc() {
                     Sub(
                         Box::new(Sub(
                             Box::new(Add(
-                                Box::new(Elem(Identifier("w".to_string()))),
-                                Box::new(Elem(Identifier("x".to_string()))),
+                                Box::new(BindingAccess(BindingAccess::new(
+                                    Identifier("w".to_string()),
+                                    AccessType::Default,
+                                ))),
+                                Box::new(BindingAccess(BindingAccess::new(
+                                    Identifier("x".to_string()),
+                                    AccessType::Default,
+                                ))),
                             )),
-                            Box::new(Elem(Identifier("y".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("y".to_string()),
+                                AccessType::Default,
+                            ))),
                         )),
-                        Box::new(Elem(Identifier("z".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("z".to_string()),
+                            AccessType::Default,
+                        ))),
                     ),
                     vec![
                         (
@@ -728,27 +800,30 @@ fn ic_multiple_iterables_lc() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    Elem(Identifier("a".to_string())),
+                    BindingAccess(BindingAccess::new(
+                        Identifier("a".to_string()),
+                        AccessType::Default,
+                    )),
                     Add(
                         Box::new(Add(
                             Box::new(Add(
-                                Box::new(VectorAccess(VectorAccess::new(
+                                Box::new(BindingAccess(BindingAccess::new(
                                     Identifier("x".to_string()),
-                                    0,
+                                    AccessType::Vector(0),
                                 ))),
-                                Box::new(VectorAccess(VectorAccess::new(
+                                Box::new(BindingAccess(BindingAccess::new(
                                     Identifier("x".to_string()),
-                                    1,
+                                    AccessType::Vector(1),
                                 ))),
                             )),
-                            Box::new(VectorAccess(VectorAccess::new(
+                            Box::new(BindingAccess(BindingAccess::new(
                                 Identifier("x".to_string()),
-                                2,
+                                AccessType::Vector(2),
                             ))),
                         )),
-                        Box::new(VectorAccess(VectorAccess::new(
+                        Box::new(BindingAccess(BindingAccess::new(
                             Identifier("x".to_string()),
-                            3,
+                            AccessType::Vector(3),
                         ))),
                     ),
                 )),

--- a/parser/src/parser/tests/list_folding.rs
+++ b/parser/src/parser/tests/list_folding.rs
@@ -3,9 +3,9 @@ use air_script_core::{Iterable, ListComprehension, ListFolding, ListFoldingValue
 use super::{build_parse_test, Identifier, IntegrityConstraint, Source};
 use crate::{
     ast::{
-        Boundary, BoundaryConstraint, BoundaryStmt, ConstraintType, Expression::*, IntegrityStmt,
-        SourceSection::*, TraceBinding, TraceBindingAccess, TraceBindingAccessSize,
-        VariableBinding, VariableValueExpr, VectorAccess,
+        AccessType, BindingAccess, Boundary, BoundaryConstraint, BoundaryStmt, ConstraintType,
+        Expression::*, IntegrityStmt, SourceSection::*, TraceBinding, TraceBindingAccess,
+        TraceBindingAccessSize, VariableBinding, VariableValueExpr,
     },
     error::{Error, ParseError},
 };
@@ -51,8 +51,14 @@ fn identifier_lf() {
                 ),
                 Boundary::First,
                 Add(
-                    Box::new(Elem(Identifier("x".to_string()))),
-                    Box::new(Elem(Identifier("y".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("x".to_string()),
+                        AccessType::Default,
+                    ))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("y".to_string()),
+                        AccessType::Default,
+                    ))),
                 ),
             )),
         ]),
@@ -81,9 +87,18 @@ fn vector_lf() {
                 Identifier("x".to_string()),
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueExpr::Vector(vec![
-                        Elem(Identifier("a".to_string())),
-                        Elem(Identifier("b".to_string())),
-                        VectorAccess(VectorAccess::new(Identifier("c".to_string()), 0)),
+                        BindingAccess(BindingAccess::new(
+                            Identifier("a".to_string()),
+                            AccessType::Default,
+                        )),
+                        BindingAccess(BindingAccess::new(
+                            Identifier("b".to_string()),
+                            AccessType::Default,
+                        )),
+                        BindingAccess(BindingAccess::new(
+                            Identifier("c".to_string()),
+                            AccessType::Vector(0),
+                        )),
                     ]),
                 ))),
             )),
@@ -91,9 +106,18 @@ fn vector_lf() {
                 Identifier("y".to_string()),
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueExpr::Vector(vec![
-                        Elem(Identifier("a".to_string())),
-                        Elem(Identifier("b".to_string())),
-                        VectorAccess(VectorAccess::new(Identifier("c".to_string()), 0)),
+                        BindingAccess(BindingAccess::new(
+                            Identifier("a".to_string()),
+                            AccessType::Default,
+                        )),
+                        BindingAccess(BindingAccess::new(
+                            Identifier("b".to_string()),
+                            AccessType::Default,
+                        )),
+                        BindingAccess(BindingAccess::new(
+                            Identifier("c".to_string()),
+                            AccessType::Vector(0),
+                        )),
                     ]),
                 ))),
             )),
@@ -106,8 +130,14 @@ fn vector_lf() {
                 ),
                 Boundary::First,
                 Add(
-                    Box::new(Elem(Identifier("x".to_string()))),
-                    Box::new(Elem(Identifier("y".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("x".to_string()),
+                        AccessType::Default,
+                    ))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("y".to_string()),
+                        AccessType::Default,
+                    ))),
                 ),
             )),
         ]),
@@ -138,7 +168,10 @@ fn bc_one_iterable_identifier_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Exp(
-                            Box::new(Elem(Identifier("col".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("col".to_string()),
+                                AccessType::Default,
+                            ))),
                             Box::new(Const(7)),
                         ),
                         vec![(
@@ -153,7 +186,10 @@ fn bc_one_iterable_identifier_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Exp(
-                            Box::new(Elem(Identifier("col".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("col".to_string()),
+                                AccessType::Default,
+                            ))),
                             Box::new(Const(7)),
                         ),
                         vec![(
@@ -172,8 +208,14 @@ fn bc_one_iterable_identifier_lf() {
                 ),
                 Boundary::First,
                 Add(
-                    Box::new(Elem(Identifier("x".to_string()))),
-                    Box::new(Elem(Identifier("y".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("x".to_string()),
+                        AccessType::Default,
+                    ))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("y".to_string()),
+                        AccessType::Default,
+                    ))),
                 ),
             )),
         ]),
@@ -205,8 +247,14 @@ fn bc_two_iterable_identifier_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
-                            Box::new(Elem(Identifier("c".to_string()))),
-                            Box::new(Elem(Identifier("d".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("c".to_string()),
+                                AccessType::Default,
+                            ))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("d".to_string()),
+                                AccessType::Default,
+                            ))),
                         ),
                         vec![
                             (
@@ -226,8 +274,14 @@ fn bc_two_iterable_identifier_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Add(
-                            Box::new(Elem(Identifier("c".to_string()))),
-                            Box::new(Elem(Identifier("d".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("c".to_string()),
+                                AccessType::Default,
+                            ))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("d".to_string()),
+                                AccessType::Default,
+                            ))),
                         ),
                         vec![
                             (
@@ -251,8 +305,14 @@ fn bc_two_iterable_identifier_lf() {
                 ),
                 Boundary::First,
                 Add(
-                    Box::new(Elem(Identifier("x".to_string()))),
-                    Box::new(Elem(Identifier("y".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("x".to_string()),
+                        AccessType::Default,
+                    ))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("y".to_string()),
+                        AccessType::Default,
+                    ))),
                 ),
             )),
         ]),
@@ -283,8 +343,14 @@ fn bc_two_iterables_identifier_range_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
-                            Box::new(Elem(Identifier("i".to_string()))),
-                            Box::new(Elem(Identifier("c".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("i".to_string()),
+                                AccessType::Default,
+                            ))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("c".to_string()),
+                                AccessType::Default,
+                            ))),
                         ),
                         vec![
                             (
@@ -304,8 +370,14 @@ fn bc_two_iterables_identifier_range_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Add(
-                            Box::new(Elem(Identifier("i".to_string()))),
-                            Box::new(Elem(Identifier("c".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("i".to_string()),
+                                AccessType::Default,
+                            ))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("c".to_string()),
+                                AccessType::Default,
+                            ))),
                         ),
                         vec![
                             (
@@ -329,8 +401,14 @@ fn bc_two_iterables_identifier_range_lf() {
                 ),
                 Boundary::First,
                 Add(
-                    Box::new(Elem(Identifier("x".to_string()))),
-                    Box::new(Elem(Identifier("y".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("x".to_string()),
+                        AccessType::Default,
+                    ))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("y".to_string()),
+                        AccessType::Default,
+                    ))),
                 ),
             )),
         ]),
@@ -361,7 +439,10 @@ fn ic_one_iterable_identifier_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Exp(
-                            Box::new(Elem(Identifier("col".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("col".to_string()),
+                                AccessType::Default,
+                            ))),
                             Box::new(Const(7)),
                         ),
                         vec![(
@@ -376,7 +457,10 @@ fn ic_one_iterable_identifier_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Exp(
-                            Box::new(Elem(Identifier("col".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("col".to_string()),
+                                AccessType::Default,
+                            ))),
                             Box::new(Const(7)),
                         ),
                         vec![(
@@ -388,10 +472,19 @@ fn ic_one_iterable_identifier_lf() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    Elem(Identifier("a".to_string())),
+                    BindingAccess(BindingAccess::new(
+                        Identifier("a".to_string()),
+                        AccessType::Default,
+                    )),
                     Add(
-                        Box::new(Elem(Identifier("x".to_string()))),
-                        Box::new(Elem(Identifier("y".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("x".to_string()),
+                            AccessType::Default,
+                        ))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("y".to_string()),
+                            AccessType::Default,
+                        ))),
                     ),
                 )),
                 None,
@@ -425,8 +518,14 @@ fn ic_two_iterable_identifier_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
-                            Box::new(Elem(Identifier("c".to_string()))),
-                            Box::new(Elem(Identifier("d".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("c".to_string()),
+                                AccessType::Default,
+                            ))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("d".to_string()),
+                                AccessType::Default,
+                            ))),
                         ),
                         vec![
                             (
@@ -446,8 +545,14 @@ fn ic_two_iterable_identifier_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Add(
-                            Box::new(Elem(Identifier("c".to_string()))),
-                            Box::new(Elem(Identifier("d".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("c".to_string()),
+                                AccessType::Default,
+                            ))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("d".to_string()),
+                                AccessType::Default,
+                            ))),
                         ),
                         vec![
                             (
@@ -464,10 +569,19 @@ fn ic_two_iterable_identifier_lf() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    Elem(Identifier("a".to_string())),
+                    BindingAccess(BindingAccess::new(
+                        Identifier("a".to_string()),
+                        AccessType::Default,
+                    )),
                     Add(
-                        Box::new(Elem(Identifier("x".to_string()))),
-                        Box::new(Elem(Identifier("y".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("x".to_string()),
+                            AccessType::Default,
+                        ))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("y".to_string()),
+                            AccessType::Default,
+                        ))),
                     ),
                 )),
                 None,
@@ -500,8 +614,14 @@ fn ic_two_iterables_identifier_range_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
-                            Box::new(Elem(Identifier("i".to_string()))),
-                            Box::new(Elem(Identifier("c".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("i".to_string()),
+                                AccessType::Default,
+                            ))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("c".to_string()),
+                                AccessType::Default,
+                            ))),
                         ),
                         vec![
                             (
@@ -521,8 +641,14 @@ fn ic_two_iterables_identifier_range_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Add(
-                            Box::new(Elem(Identifier("i".to_string()))),
-                            Box::new(Elem(Identifier("c".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("i".to_string()),
+                                AccessType::Default,
+                            ))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("c".to_string()),
+                                AccessType::Default,
+                            ))),
                         ),
                         vec![
                             (
@@ -539,10 +665,19 @@ fn ic_two_iterables_identifier_range_lf() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    Elem(Identifier("a".to_string())),
+                    BindingAccess(BindingAccess::new(
+                        Identifier("a".to_string()),
+                        AccessType::Default,
+                    )),
                     Add(
-                        Box::new(Elem(Identifier("x".to_string()))),
-                        Box::new(Elem(Identifier("y".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("x".to_string()),
+                            AccessType::Default,
+                        ))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("y".to_string()),
+                            AccessType::Default,
+                        ))),
                     ),
                 )),
                 None,
@@ -576,10 +711,19 @@ fn ic_three_iterables_slice_identifier_range_lf() {
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
                             Box::new(Mul(
-                                Box::new(Elem(Identifier("m".to_string()))),
-                                Box::new(Elem(Identifier("n".to_string()))),
+                                Box::new(BindingAccess(BindingAccess::new(
+                                    Identifier("m".to_string()),
+                                    AccessType::Default,
+                                ))),
+                                Box::new(BindingAccess(BindingAccess::new(
+                                    Identifier("n".to_string()),
+                                    AccessType::Default,
+                                ))),
                             )),
-                            Box::new(Elem(Identifier("i".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("i".to_string()),
+                                AccessType::Default,
+                            ))),
                         ),
                         vec![
                             (
@@ -604,10 +748,19 @@ fn ic_three_iterables_slice_identifier_range_lf() {
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
                             Box::new(Mul(
-                                Box::new(Elem(Identifier("m".to_string()))),
-                                Box::new(Elem(Identifier("n".to_string()))),
+                                Box::new(BindingAccess(BindingAccess::new(
+                                    Identifier("m".to_string()),
+                                    AccessType::Default,
+                                ))),
+                                Box::new(BindingAccess(BindingAccess::new(
+                                    Identifier("n".to_string()),
+                                    AccessType::Default,
+                                ))),
                             )),
-                            Box::new(Elem(Identifier("i".to_string()))),
+                            Box::new(BindingAccess(BindingAccess::new(
+                                Identifier("i".to_string()),
+                                AccessType::Default,
+                            ))),
                         ),
                         vec![
                             (
@@ -628,10 +781,19 @@ fn ic_three_iterables_slice_identifier_range_lf() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    Elem(Identifier("a".to_string())),
+                    BindingAccess(BindingAccess::new(
+                        Identifier("a".to_string()),
+                        AccessType::Default,
+                    )),
                     Add(
-                        Box::new(Elem(Identifier("x".to_string()))),
-                        Box::new(Elem(Identifier("y".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("x".to_string()),
+                            AccessType::Default,
+                        ))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("y".to_string()),
+                            AccessType::Default,
+                        ))),
                     ),
                 )),
                 None,

--- a/parser/src/parser/tests/mod.rs
+++ b/parser/src/parser/tests/mod.rs
@@ -54,7 +54,10 @@ fn full_air_file() {
                     1,
                 )),
                 Expression::Add(
-                    Box::new(Expression::Elem(Identifier("clk".to_string()))),
+                    Box::new(Expression::BindingAccess(BindingAccess::new(
+                        Identifier("clk".to_string()),
+                        AccessType::Default,
+                    ))),
                     Box::new(Expression::Const(1)),
                 ),
             )),

--- a/parser/src/parser/tests/random_values.rs
+++ b/parser/src/parser/tests/random_values.rs
@@ -1,6 +1,7 @@
 use super::{
-    build_parse_test, Error, Expression::*, Identifier, IntegrityConstraint, IntegrityStmt::*,
-    ParseError, RandBinding, RandomValues, Source, SourceSection, SourceSection::*,
+    build_parse_test, AccessType, BindingAccess, Error, Expression::*, Identifier,
+    IntegrityConstraint, IntegrityStmt::*, ParseError, RandBinding, RandomValues, Source,
+    SourceSection, SourceSection::*,
 };
 use crate::ast::ConstraintType;
 
@@ -81,7 +82,10 @@ fn random_values_index_access() {
     let expected = Source(vec![SourceSection::IntegrityConstraints(vec![Constraint(
         ConstraintType::Inline(IntegrityConstraint::new(
             Add(
-                Box::new(Elem(Identifier("a".to_string()))),
+                Box::new(BindingAccess(BindingAccess::new(
+                    Identifier("a".to_string()),
+                    AccessType::Default,
+                ))),
                 Box::new(Rand(Identifier("alphas".to_string()), 1)),
             ),
             Const(0),

--- a/parser/src/parser/tests/selectors.rs
+++ b/parser/src/parser/tests/selectors.rs
@@ -1,6 +1,7 @@
 use super::{build_parse_test, Identifier, IntegrityConstraint, Source, SourceSection};
 use crate::ast::{
-    ConstraintType, Expression::*, IntegrityStmt::*, TraceBindingAccess, TraceBindingAccessSize,
+    AccessType, BindingAccess, ConstraintType, Expression::*, IntegrityStmt::*, TraceBindingAccess,
+    TraceBindingAccessSize,
 };
 
 // SELECTORS
@@ -20,10 +21,16 @@ fn single_selector() {
                 TraceBindingAccessSize::Full,
                 1,
             )),
-            Elem(Identifier("clk".to_string())),
+            BindingAccess(BindingAccess::new(
+                Identifier("clk".to_string()),
+                AccessType::Default,
+            )),
         )),
         // n1
-        Some(Elem(Identifier("n1".to_string()))),
+        Some(BindingAccess(BindingAccess::new(
+            Identifier("n1".to_string()),
+            AccessType::Default,
+        ))),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -42,34 +49,55 @@ fn chained_selectors() {
                 TraceBindingAccessSize::Full,
                 1,
             )),
-            Elem(Identifier("clk".to_string())),
+            BindingAccess(BindingAccess::new(
+                Identifier("clk".to_string()),
+                AccessType::Default,
+            )),
         )),
         // (n1 & !n2) | !n3
         Some(Sub(
             Box::new(Add(
                 Box::new(Mul(
-                    Box::new(Elem(Identifier("n1".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("n1".to_string()),
+                        AccessType::Default,
+                    ))),
                     Box::new(Sub(
                         Box::new(Const(1)),
-                        Box::new(Elem(Identifier("n2".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("n2".to_string()),
+                            AccessType::Default,
+                        ))),
                     )),
                 )),
                 Box::new(Sub(
                     Box::new(Const(1)),
-                    Box::new(Elem(Identifier("n3".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("n3".to_string()),
+                        AccessType::Default,
+                    ))),
                 )),
             )),
             Box::new(Mul(
                 Box::new(Mul(
-                    Box::new(Elem(Identifier("n1".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("n1".to_string()),
+                        AccessType::Default,
+                    ))),
                     Box::new(Sub(
                         Box::new(Const(1)),
-                        Box::new(Elem(Identifier("n2".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("n2".to_string()),
+                            AccessType::Default,
+                        ))),
                     )),
                 )),
                 Box::new(Sub(
                     Box::new(Const(1)),
-                    Box::new(Elem(Identifier("n3".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("n3".to_string()),
+                        AccessType::Default,
+                    ))),
                 )),
             )),
         )),
@@ -98,10 +126,16 @@ fn multiconstraint_selectors() {
                 Const(0),
             )),
             Some(Mul(
-                Box::new(Elem(Identifier("n1".to_string()))),
+                Box::new(BindingAccess(BindingAccess::new(
+                    Identifier("n1".to_string()),
+                    AccessType::Default,
+                ))),
                 Box::new(Sub(
                     Box::new(Const(1)),
-                    Box::new(Elem(Identifier("n2".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("n2".to_string()),
+                        AccessType::Default,
+                    ))),
                 )),
             )),
         ),
@@ -114,11 +148,20 @@ fn multiconstraint_selectors() {
                     TraceBindingAccessSize::Full,
                     1,
                 )),
-                Elem(Identifier("clk".to_string())),
+                BindingAccess(BindingAccess::new(
+                    Identifier("clk".to_string()),
+                    AccessType::Default,
+                )),
             )),
             Some(Mul(
-                Box::new(Elem(Identifier("n1".to_string()))),
-                Box::new(Elem(Identifier("n2".to_string()))),
+                Box::new(BindingAccess(BindingAccess::new(
+                    Identifier("n1".to_string()),
+                    AccessType::Default,
+                ))),
+                Box::new(BindingAccess(BindingAccess::new(
+                    Identifier("n2".to_string()),
+                    AccessType::Default,
+                ))),
             )),
         ),
         Constraint(
@@ -135,11 +178,17 @@ fn multiconstraint_selectors() {
             Some(Mul(
                 Box::new(Sub(
                     Box::new(Const(1)),
-                    Box::new(Elem(Identifier("n1".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("n1".to_string()),
+                        AccessType::Default,
+                    ))),
                 )),
                 Box::new(Sub(
                     Box::new(Const(1)),
-                    Box::new(Elem(Identifier("n2".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("n2".to_string()),
+                        AccessType::Default,
+                    ))),
                 )),
             )),
         ),

--- a/parser/src/parser/tests/trace_columns.rs
+++ b/parser/src/parser/tests/trace_columns.rs
@@ -1,6 +1,7 @@
 use super::{
-    build_parse_test, Error, Expression::*, Identifier, IntegrityConstraint, IntegrityStmt::*,
-    ParseError, Source, SourceSection::*, TraceBinding, TraceBindingAccess, TraceBindingAccessSize,
+    build_parse_test, AccessType, BindingAccess, Error, Expression::*, Identifier,
+    IntegrityConstraint, IntegrityStmt::*, ParseError, Source, SourceSection::*, TraceBinding,
+    TraceBindingAccess, TraceBindingAccessSize,
 };
 use crate::ast::ConstraintType;
 
@@ -85,7 +86,10 @@ fn trace_columns_groups() {
                         1,
                     )),
                     Sub(
-                        Box::new(Elem(Identifier("clk".to_string()))),
+                        Box::new(BindingAccess(BindingAccess::new(
+                            Identifier("clk".to_string()),
+                            AccessType::Default,
+                        ))),
                         Box::new(Const(1)),
                     ),
                 )),

--- a/parser/src/parser/tests/variables.rs
+++ b/parser/src/parser/tests/variables.rs
@@ -1,7 +1,7 @@
 use super::{build_parse_test, Identifier, IntegrityConstraint, Source, SourceSection};
 use crate::ast::{
-    ConstraintType, Expression::*, IntegrityStmt::*, TraceBindingAccess, TraceBindingAccessSize,
-    VariableBinding, VariableValueExpr, VectorAccess,
+    AccessType, BindingAccess, ConstraintType, Expression::*, IntegrityStmt::*, TraceBindingAccess,
+    TraceBindingAccessSize, VariableBinding, VariableValueExpr,
 };
 
 // VARIABLES
@@ -16,10 +16,16 @@ fn variables_with_and_operators() {
         VariableBinding(VariableBinding::new(
             Identifier("flag".to_string()),
             VariableValueExpr::Scalar(Mul(
-                Box::new(Elem(Identifier("n1".to_string()))),
+                Box::new(BindingAccess(BindingAccess::new(
+                    Identifier("n1".to_string()),
+                    AccessType::Default,
+                ))),
                 Box::new(Sub(
                     Box::new(Const(1)),
-                    Box::new(Elem(Identifier("n2".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("n2".to_string()),
+                        AccessType::Default,
+                    ))),
                 )),
             )),
         )),
@@ -32,11 +38,17 @@ fn variables_with_and_operators() {
                     1,
                 )),
                 Add(
-                    Box::new(Elem(Identifier("clk".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("clk".to_string()),
+                        AccessType::Default,
+                    ))),
                     Box::new(Const(1)),
                 ),
             )),
-            Some(Elem(Identifier("flag".to_string()))),
+            Some(BindingAccess(BindingAccess::new(
+                Identifier("flag".to_string()),
+                AccessType::Default,
+            ))),
         ),
     ])]);
     build_parse_test!(source).expect_ast(expected);
@@ -53,9 +65,9 @@ fn variables_with_or_operators() {
             Identifier("flag".to_string()),
             VariableValueExpr::Scalar(Sub(
                 Box::new(Add(
-                    Box::new(VectorAccess(VectorAccess::new(
+                    Box::new(BindingAccess(BindingAccess::new(
                         Identifier("s".to_string()),
-                        0,
+                        AccessType::Vector(0),
                     ))),
                     Box::new(Sub(
                         Box::new(Const(1)),
@@ -68,9 +80,9 @@ fn variables_with_or_operators() {
                     )),
                 )),
                 Box::new(Mul(
-                    Box::new(VectorAccess(VectorAccess::new(
+                    Box::new(BindingAccess(BindingAccess::new(
                         Identifier("s".to_string()),
-                        0,
+                        AccessType::Vector(0),
                     ))),
                     Box::new(Sub(
                         Box::new(Const(1)),
@@ -93,11 +105,17 @@ fn variables_with_or_operators() {
                     1,
                 )),
                 Add(
-                    Box::new(Elem(Identifier("clk".to_string()))),
+                    Box::new(BindingAccess(BindingAccess::new(
+                        Identifier("clk".to_string()),
+                        AccessType::Default,
+                    ))),
                     Box::new(Const(1)),
                 ),
             )),
-            Some(Elem(Identifier("flag".to_string()))),
+            Some(BindingAccess(BindingAccess::new(
+                Identifier("flag".to_string()),
+                AccessType::Default,
+            ))),
         ),
     ])]);
     build_parse_test!(source).expect_ast(expected);


### PR DESCRIPTION
Currently, there are 5 different variants of `Expression` into which references to bound identifiers within variables or constraints are parsed - `Elem`, `VectorAccess`, `MatrixAccess`, `Rand`, and `TraceBindingAccess`. These are all handled in essentially the same way within the IR, so consolidating these into a single type allows us to simplify handling in the IR, especially of variables.

This PR does the following. Because of the nature of the change, it's hard to split it into a smaller change without errors.

- introduce `BindingAccess`
- replace `Elem`, `VectorAccess`, and `MatrixAccess` with `BindingAccess`
- update codegen handling for new `Value` types

Future items for discussion:
- `Expression::Rand` should probably be similarly replaced. This would be fairly straightforward.
- Ideally, we would consolidate `TraceBindingAccess` into `BindingAccess` as well. This would improve the code clarity significantly, since all trace bindings for the "current" row are already parsed as `BindingAccess`, so `TraceBindingAccess` only represents references to trace bindings in the "next" row or being accessed as a `Range`. This means that the handling within the IR of accessing trace bindings is split into 2 places. The complication with this is that we access ranges of the trace, so `AccessType` would need to change, and I'm not sure of the best way to adjust this.