### PR TITLE
Renaming refactor

### DIFF
--- a/air-script-core/src/access.rs
+++ b/air-script-core/src/access.rs
@@ -28,18 +28,18 @@ impl Display for AccessType {
     }
 }
 
-/// [BindingAccess] is used to indicate referencing all or part of an identifier that is bound to a
+/// [SymbolAccess] is used to indicate referencing all or part of an identifier that is bound to a
 /// value, such as a [ConstantBinding] or a [VariableBinding].
 ///
 /// - `name`: is the identifier of the [ConstantBinding] or [VariableBinding] being accessed.
 /// - `access_type`: specifies the [AccessType] by which the identifier is being accessed.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct BindingAccess {
+pub struct SymbolAccess {
     name: Identifier,
     access_type: AccessType,
 }
 
-impl BindingAccess {
+impl SymbolAccess {
     pub fn new(name: Identifier, access_type: AccessType) -> Self {
         Self { name, access_type }
     }
@@ -52,7 +52,7 @@ impl BindingAccess {
         self.name.name()
     }
 
-    /// Gets the access type of this [BindingAccess].
+    /// Gets the access type of this [SymbolAccess].
     pub fn access_type(&self) -> &AccessType {
         &self.access_type
     }

--- a/air-script-core/src/expression.rs
+++ b/air-script-core/src/expression.rs
@@ -1,11 +1,11 @@
-use super::{BindingAccess, Identifier, ListFolding, TraceAccess, TraceBindingAccess};
+use super::{Identifier, ListFolding, SymbolAccess, TraceAccess, TraceBindingAccess};
 
 /// Arithmetic expressions for evaluation of constraints.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Expression {
     Const(u64),
     /// Represents a reference to all or part of a constant, variable, or trace binding.
-    BindingAccess(BindingAccess),
+    SymbolAccess(SymbolAccess),
     TraceAccess(TraceAccess),
     TraceBindingAccess(TraceBindingAccess),
     /// Represents a random value provided by the verifier. The first inner value is the name of

--- a/air-script-core/src/lib.rs
+++ b/air-script-core/src/lib.rs
@@ -1,5 +1,5 @@
 mod access;
-pub use access::{AccessType, BindingAccess, Iterable, Range};
+pub use access::{AccessType, Iterable, Range, SymbolAccess};
 
 mod constant;
 pub use constant::{ConstantBinding, ConstantValueExpr};

--- a/codegen/winterfell/src/air/graph.rs
+++ b/codegen/winterfell/src/air/graph.rs
@@ -113,9 +113,9 @@ impl Codegen for Value {
                 ElemType::Base => format!("Felt::new({value})"),
                 ElemType::Ext => format!("E::from({value}_u64)"),
             },
-            Value::BoundConstant(binding_access) => {
-                let name = binding_access.name().to_string();
-                let access_type = binding_access.access_type();
+            Value::BoundConstant(symbol_access) => {
+                let name = symbol_access.name().to_string();
+                let access_type = symbol_access.access_type();
                 let base_value = match access_type {
                     AccessType::Default => name,
                     AccessType::Vector(idx) => format!("{name}[{idx}]"),

--- a/ir/src/constraint_builder/integrity_constraints/mod.rs
+++ b/ir/src/constraint_builder/integrity_constraints/mod.rs
@@ -1,8 +1,8 @@
 use super::{
     ast::{ConstraintType, IntegrityStmt},
-    AccessType, BTreeMap, BindingAccess, ConstantValueExpr, ConstraintBuilder, ConstraintDomain,
-    Expression, Identifier, Iterable, ListComprehension, ListFolding, ListFoldingValueExpr,
-    SemanticError, Symbol, SymbolType, TraceAccess, TraceBindingAccess, TraceBindingAccessSize,
+    AccessType, BTreeMap, ConstantValueExpr, ConstraintBuilder, ConstraintDomain, Expression,
+    Identifier, Iterable, ListComprehension, ListFolding, ListFoldingValueExpr, SemanticError,
+    Symbol, SymbolAccess, SymbolBinding, TraceAccess, TraceBindingAccess, TraceBindingAccessSize,
     VariableBinding, VariableValueExpr, CURRENT_ROW,
 };
 

--- a/ir/src/constraint_builder/mod.rs
+++ b/ir/src/constraint_builder/mod.rs
@@ -1,8 +1,8 @@
 use super::{
-    ast, AccessType, AlgebraicGraph, BTreeMap, BTreeSet, BindingAccess, ConstantValueExpr,
-    ConstraintDomain, ConstraintRoot, Constraints, Declarations, Expression, Identifier, Iterable,
-    ListComprehension, ListFolding, ListFoldingValueExpr, NodeIndex, Operation, SemanticError,
-    Symbol, SymbolTable, SymbolType, TraceAccess, TraceBindingAccess, TraceBindingAccessSize,
+    ast, AccessType, AlgebraicGraph, BTreeMap, BTreeSet, ConstantValueExpr, ConstraintDomain,
+    ConstraintRoot, Constraints, Declarations, Expression, Identifier, Iterable, ListComprehension,
+    ListFolding, ListFoldingValueExpr, NodeIndex, Operation, SemanticError, Symbol, SymbolAccess,
+    SymbolBinding, SymbolTable, TraceAccess, TraceBindingAccess, TraceBindingAccessSize,
     TraceSegment, Value, VariableBinding, VariableValueExpr, CURRENT_ROW,
 };
 

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -1,6 +1,6 @@
 pub use air_script_core::{
-    AccessType, BindingAccess, ConstantBinding, ConstantValueExpr, Expression, Identifier,
-    Iterable, ListComprehension, ListFolding, ListFoldingValueExpr, TraceAccess, TraceBinding,
+    AccessType, ConstantBinding, ConstantValueExpr, Expression, Identifier, Iterable,
+    ListComprehension, ListFolding, ListFoldingValueExpr, SymbolAccess, TraceAccess, TraceBinding,
     TraceBindingAccess, TraceBindingAccessSize, TraceSegment, VariableBinding, VariableValueExpr,
 };
 pub use parser::ast;
@@ -22,7 +22,7 @@ pub use declarations::{PeriodicColumn, PublicInput};
 
 mod symbol_table;
 pub use symbol_table::Value;
-use symbol_table::{Symbol, SymbolTable, SymbolType};
+use symbol_table::{Symbol, SymbolBinding, SymbolTable};
 
 mod validation;
 use validation::{SemanticError, SourceValidator};

--- a/ir/src/symbol_table/symbol_access.rs
+++ b/ir/src/symbol_table/symbol_access.rs
@@ -1,4 +1,6 @@
-use super::{AccessType, ConstantValueExpr, SemanticError, Symbol, SymbolType, TraceBindingAccess};
+use super::{
+    AccessType, ConstantValueExpr, SemanticError, Symbol, SymbolBinding, TraceBindingAccess,
+};
 
 /// Checks that the specified access into an identifier is valid and returns an error otherwise.
 /// # Errors:
@@ -12,8 +14,8 @@ pub(super) trait ValidateIdentifierAccess {
 
 impl ValidateIdentifierAccess for TraceBindingAccess {
     fn validate(&self, symbol: &Symbol) -> Result<(), SemanticError> {
-        match symbol.symbol_type() {
-            SymbolType::TraceBinding(trace_binding) => {
+        match symbol.binding() {
+            SymbolBinding::Trace(trace_binding) => {
                 if self.col_offset() >= trace_binding.size() {
                     return Err(SemanticError::named_trace_column_access_out_of_bounds(
                         self,
@@ -24,7 +26,7 @@ impl ValidateIdentifierAccess for TraceBindingAccess {
             _ => {
                 return Err(SemanticError::not_a_trace_column_identifier(
                     symbol.name(),
-                    symbol.symbol_type(),
+                    symbol.binding(),
                 ))
             }
         }

--- a/ir/src/symbol_table/symbol_binding.rs
+++ b/ir/src/symbol_table/symbol_binding.rs
@@ -2,35 +2,35 @@ use super::{ConstantValueExpr, TraceBinding, VariableValueExpr};
 use std::fmt::Display;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
-pub(crate) enum SymbolType {
+pub(crate) enum SymbolBinding {
     /// an identifier for a constant, containing its type and value
-    ConstantBinding(ConstantValueExpr),
+    Constant(ConstantValueExpr),
     /// an identifier for a binding to one or more trace columns, containing the trace binding
     /// information with its identifier, trace segment, size, and offset.
-    TraceBinding(TraceBinding),
+    Trace(TraceBinding),
     /// an identifier for a public input, containing the size of the public input array
     PublicInput(usize),
     /// an identifier for a periodic column, containing its index out of all periodic columns and
     /// its cycle length in that order.
     PeriodicColumn(usize, usize),
     /// an expression or set of expressions associated with a variable
-    VariableBinding(VariableValueExpr),
+    Variable(VariableValueExpr),
     /// an identifier for random value, containing its index in the random values array and its
     /// length if this value is an array. For non-array random values second parameter is always 1.
-    RandomValuesBinding(usize, usize),
+    RandomValues(usize, usize),
 }
 
-impl Display for SymbolType {
+impl Display for SymbolBinding {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ConstantBinding(_) => write!(f, "ConstantBinding"),
-            Self::TraceBinding(binding) => {
-                write!(f, "TraceBinding in segment {}", binding.trace_segment())
+            Self::Constant(_) => write!(f, "Constant"),
+            Self::Trace(binding) => {
+                write!(f, "Trace in segment {}", binding.trace_segment())
             }
             Self::PublicInput(_) => write!(f, "PublicInput"),
             Self::PeriodicColumn(_, _) => write!(f, "PeriodicColumn"),
-            Self::VariableBinding(_) => write!(f, "VariableBinding"),
-            Self::RandomValuesBinding(_, _) => write!(f, "RandomValuesBinding"),
+            Self::Variable(_) => write!(f, "Variable"),
+            Self::RandomValues(_, _) => write!(f, "RandomValues"),
         }
     }
 }

--- a/ir/src/symbol_table/value.rs
+++ b/ir/src/symbol_table/value.rs
@@ -1,9 +1,9 @@
-use super::{BindingAccess, TraceAccess};
+use super::{SymbolAccess, TraceAccess};
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Value {
     /// A named constant with identifier and access indices.
-    BoundConstant(BindingAccess),
+    BoundConstant(SymbolAccess),
     /// An inlined constant value.
     InlineConstant(u64),
     /// An identifier for an element in the trace segment, column, and row offset specified by the

--- a/ir/src/validation/error.rs
+++ b/ir/src/validation/error.rs
@@ -1,6 +1,6 @@
 use super::{
-    AccessType, ConstrainedBoundary, ConstraintDomain, SymbolType, TraceAccess, TraceBindingAccess,
-    TraceSegment, MIN_CYCLE_LENGTH,
+    AccessType, ConstrainedBoundary, ConstraintDomain, SymbolBinding, TraceAccess,
+    TraceBindingAccess, TraceSegment, MIN_CYCLE_LENGTH,
 };
 
 #[derive(Debug)]
@@ -55,8 +55,8 @@ impl SemanticError {
 
     pub(crate) fn duplicate_identifer(
         ident_name: &str,
-        ident_type: &SymbolType,
-        prev_type: &SymbolType,
+        ident_type: &SymbolBinding,
+        prev_type: &SymbolBinding,
     ) -> Self {
         SemanticError::DuplicateIdentifier(format!(
             "Cannot declare {ident_name} as a {ident_type}, since it was already defined as a {prev_type}"))
@@ -86,7 +86,10 @@ impl SemanticError {
 
     // --- TYPE ERRORS ----------------------------------------------------------------------------
 
-    pub(crate) fn not_a_trace_column_identifier(ident_name: &str, ident_type: &SymbolType) -> Self {
+    pub(crate) fn not_a_trace_column_identifier(
+        ident_name: &str,
+        ident_type: &SymbolBinding,
+    ) -> Self {
         SemanticError::InvalidUsage(format!(
             "Identifier {ident_name} was declared as a {ident_type} not as a trace column"
         ))
@@ -229,10 +232,10 @@ impl SemanticError {
 
     pub(crate) fn invalid_list_folding(
         lf_value_type: &air_script_core::ListFoldingValueExpr,
-        symbol_type: &SymbolType,
+        symbol_binding: &SymbolBinding,
     ) -> SemanticError {
         SemanticError::InvalidListFolding(format!(
-            "Symbol type {symbol_type} is not supported for list folding value type {lf_value_type:?}",
+            "Symbol type {symbol_binding} is not supported for list folding value type {lf_value_type:?}",
         ))
     }
 

--- a/ir/src/validation/mod.rs
+++ b/ir/src/validation/mod.rs
@@ -1,5 +1,5 @@
 use super::{
-    constraints::ConstraintDomain, AccessType, ConstrainedBoundary, SymbolType, TraceAccess,
+    constraints::ConstraintDomain, AccessType, ConstrainedBoundary, SymbolBinding, TraceAccess,
     TraceBindingAccess, TraceSegment, MIN_CYCLE_LENGTH,
 };
 

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) use air_script_core::{
-    AccessType, BindingAccess, ComprehensionContext, ConstantBinding, ConstantValueExpr,
-    Expression, Identifier, Iterable, ListComprehension, ListFolding, ListFoldingValueExpr, Range,
+    AccessType, ComprehensionContext, ConstantBinding, ConstantValueExpr, Expression, Identifier,
+    Iterable, ListComprehension, ListFolding, ListFoldingValueExpr, Range, SymbolAccess,
     TraceAccess, TraceBinding, TraceBindingAccess, TraceBindingAccessSize, TraceSegment,
     VariableBinding, VariableValueExpr,
 };

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -2,7 +2,7 @@ use crate::{
     ast::{
         boundary_constraints::{Boundary, BoundaryConstraint, BoundaryStmt},
         integrity_constraints::{ConstraintType, IntegrityConstraint, IntegrityStmt},
-        build_trace_bindings, AccessType, BindingAccess, ConstantBinding, ConstantValueExpr, 
+        build_trace_bindings, AccessType, SymbolAccess, ConstantBinding, ConstantValueExpr, 
         ComprehensionContext, Expression, EvaluatorFunction, EvaluatorFunctionCall, Identifier, 
         TraceAccess, Iterable, ListComprehension, ListFolding, ListFoldingValueExpr,
         PeriodicColumn, PublicInput, RandBinding, RandomValues, Range, Source, SourceSection, 
@@ -262,7 +262,7 @@ BoundaryAtom: Expression = {
     "(" <BoundaryExpr> ")",
     "$" <ident: Identifier> <idx: Index> => Expression::Rand(ident, idx),
     <n: Num_u64> => Expression::Const(n),
-    <binding_access: BindingAccess> => Expression::BindingAccess(binding_access),
+    <symbol_access: SymbolAccess> => Expression::SymbolAccess(symbol_access),
     <list_folding_type: ListFolding<BoundaryExpr>> => Expression::ListFolding(list_folding_type),
 }
 
@@ -395,7 +395,7 @@ IntegrityAtom: Expression = {
     <n: Num_u64> => Expression::Const(n),
     "!" <expr: IntegrityAtom> =>
         Expression::Sub(Box::new(Expression::Const(1)), Box::new(expr)),
-    <binding_access: BindingAccess> => Expression::BindingAccess(binding_access),
+    <symbol_access: SymbolAccess> => Expression::SymbolAccess(symbol_access),
     <trace_access: TraceBindingAccessWithOffset> => Expression::TraceBindingAccess(trace_access),
     <list_folding_type: ListFolding<IntegrityExpr>> =>
         Expression::ListFolding(list_folding_type),
@@ -436,13 +436,13 @@ Index: usize = {
     "[" <idx: Num_u64> "]" => idx as usize
 }
 
-BindingAccess: BindingAccess = {
+SymbolAccess: SymbolAccess = {
     <ident: Identifier> => 
-        BindingAccess::new(ident, AccessType::Default),
+        SymbolAccess::new(ident, AccessType::Default),
     <ident: Identifier> <idx: Index> => 
-        BindingAccess::new(ident, AccessType::Vector(idx)),
+        SymbolAccess::new(ident, AccessType::Vector(idx)),
     <ident: Identifier> <row: Index> <col: Index> =>
-        BindingAccess::new(ident, AccessType::Matrix(row, col))
+        SymbolAccess::new(ident, AccessType::Matrix(row, col))
 }
 
 TraceBindingAccess: TraceBindingAccess = {

--- a/parser/src/parser/tests/arithmetic_ops.rs
+++ b/parser/src/parser/tests/arithmetic_ops.rs
@@ -1,6 +1,6 @@
 use super::{
-    build_parse_test, AccessType, BindingAccess, Expression::*, Identifier, IntegrityConstraint,
-    IntegrityStmt::*, Source, SourceSection::*,
+    build_parse_test, AccessType, Expression::*, Identifier, IntegrityConstraint, IntegrityStmt::*,
+    Source, SourceSection::*, SymbolAccess,
 };
 use crate::ast::{ConstraintType, TraceBindingAccess, TraceBindingAccessSize};
 
@@ -22,7 +22,7 @@ fn single_addition() {
                     TraceBindingAccessSize::Full,
                     1,
                 ))),
-                Box::new(BindingAccess(BindingAccess::new(
+                Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("clk".to_string()),
                     AccessType::Default,
                 ))),
@@ -50,7 +50,7 @@ fn multi_addition() {
                         TraceBindingAccessSize::Full,
                         1,
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
                         AccessType::Default,
                     ))),
@@ -79,7 +79,7 @@ fn single_subtraction() {
                     TraceBindingAccessSize::Full,
                     1,
                 ))),
-                Box::new(BindingAccess(BindingAccess::new(
+                Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("clk".to_string()),
                     AccessType::Default,
                 ))),
@@ -107,7 +107,7 @@ fn multi_subtraction() {
                         TraceBindingAccessSize::Full,
                         1,
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
                         AccessType::Default,
                     ))),
@@ -136,7 +136,7 @@ fn single_multiplication() {
                     TraceBindingAccessSize::Full,
                     1,
                 ))),
-                Box::new(BindingAccess(BindingAccess::new(
+                Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("clk".to_string()),
                     AccessType::Default,
                 ))),
@@ -164,7 +164,7 @@ fn multi_multiplication() {
                         TraceBindingAccessSize::Full,
                         1,
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
                         AccessType::Default,
                     ))),
@@ -210,7 +210,7 @@ fn ops_with_parens() {
                         TraceBindingAccessSize::Full,
                         1,
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
                         AccessType::Default,
                     ))),
@@ -264,7 +264,7 @@ fn non_const_exponentiation() {
                     1,
                 ))),
                 Box::new(Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
                         AccessType::Default,
                     ))),
@@ -313,7 +313,7 @@ fn multi_arithmetic_ops_same_precedence() {
                             TraceBindingAccessSize::Full,
                             1,
                         ))),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("clk".to_string()),
                             AccessType::Default,
                         ))),
@@ -354,7 +354,7 @@ fn multi_arithmetic_ops_different_precedence() {
                         Box::new(Const(2)),
                     )),
                     Box::new(Mul(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("clk".to_string()),
                             AccessType::Default,
                         ))),
@@ -393,7 +393,7 @@ fn multi_arithmetic_ops_different_precedence_w_parens() {
                 ))),
                 Box::new(Mul(
                     Box::new(Exp(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("clk".to_string()),
                             AccessType::Default,
                         ))),

--- a/parser/src/parser/tests/boundary_constraints.rs
+++ b/parser/src/parser/tests/boundary_constraints.rs
@@ -1,6 +1,6 @@
 use super::{
-    build_parse_test, AccessType, BindingAccess, Boundary, BoundaryConstraint, Identifier,
-    Iterable, Range, Source, SourceSection, TraceBinding,
+    build_parse_test, AccessType, Boundary, BoundaryConstraint, Identifier, Iterable, Range,
+    Source, SourceSection, SymbolAccess, TraceBinding,
 };
 use crate::{
     ast::{
@@ -109,7 +109,7 @@ fn boundary_constraint_with_pub_input() {
                 0,
             ),
             Boundary::First,
-            BindingAccess(BindingAccess::new(
+            SymbolAccess(SymbolAccess::new(
                 Identifier("a".to_string()),
                 AccessType::Vector(0),
             )),
@@ -135,7 +135,7 @@ fn boundary_constraint_with_expr() {
             Add(
                 Box::new(Add(
                     Box::new(Const(5)),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Vector(3),
                     ))),
@@ -175,16 +175,16 @@ fn boundary_constraint_with_const() {
             Boundary::First,
             Sub(
                 Box::new(Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("A".to_string()),
                         AccessType::Default,
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("B".to_string()),
                         AccessType::Vector(1),
                     ))),
                 )),
-                Box::new(BindingAccess(BindingAccess::new(
+                Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("C".to_string()),
                     AccessType::Matrix(0, 1),
                 ))),
@@ -210,13 +210,13 @@ fn boundary_constraint_with_variables() {
         VariableBinding(VariableBinding::new(
             Identifier("b".to_string()),
             VariableValueExpr::Vector(vec![
-                BindingAccess(BindingAccess::new(
+                SymbolAccess(SymbolAccess::new(
                     Identifier("a".to_string()),
                     AccessType::Default,
                 )),
                 Mul(
                     Box::new(Const(2)),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
                     ))),
@@ -228,14 +228,14 @@ fn boundary_constraint_with_variables() {
             VariableValueExpr::Matrix(vec![
                 vec![
                     Sub(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("a".to_string()),
                             AccessType::Default,
                         ))),
                         Box::new(Const(1)),
                     ),
                     Exp(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("a".to_string()),
                             AccessType::Default,
                         ))),
@@ -243,11 +243,11 @@ fn boundary_constraint_with_variables() {
                     ),
                 ],
                 vec![
-                    BindingAccess(BindingAccess::new(
+                    SymbolAccess(SymbolAccess::new(
                         Identifier("b".to_string()),
                         AccessType::Vector(0),
                     )),
-                    BindingAccess(BindingAccess::new(
+                    SymbolAccess(SymbolAccess::new(
                         Identifier("b".to_string()),
                         AccessType::Vector(1),
                     )),
@@ -265,7 +265,7 @@ fn boundary_constraint_with_variables() {
             Add(
                 Box::new(Add(
                     Box::new(Const(5)),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Vector(3),
                     ))),
@@ -412,7 +412,7 @@ fn bc_comprehension_two_iterable_identifiers() {
                     0,
                 ),
                 Boundary::First,
-                BindingAccess(BindingAccess::new(
+                SymbolAccess(SymbolAccess::new(
                     Identifier("y".to_string()),
                     AccessType::Default,
                 )),

--- a/parser/src/parser/tests/evaluator_functions.rs
+++ b/parser/src/parser/tests/evaluator_functions.rs
@@ -1,8 +1,8 @@
 use super::{build_parse_test, Identifier, IntegrityConstraint, Source, SourceSection};
 use crate::{
     ast::{
-        AccessType, BindingAccess, ConstraintType, EvaluatorFunction, EvaluatorFunctionCall,
-        Expression::*, IntegrityStmt::*, Range, TraceBinding, TraceBindingAccess,
+        AccessType, ConstraintType, EvaluatorFunction, EvaluatorFunctionCall, Expression::*,
+        IntegrityStmt::*, Range, SymbolAccess, TraceBinding, TraceBindingAccess,
         TraceBindingAccessSize, VariableBinding, VariableValueExpr,
     },
     error::{Error, ParseError},
@@ -29,7 +29,7 @@ fn ev_fn_main_cols() {
                         1,
                     )),
                     Add(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("clk".to_string()),
                             AccessType::Default,
                         ))),
@@ -63,11 +63,11 @@ fn ev_fn_main_and_aux_cols() {
                 VariableBinding(VariableBinding::new(
                     Identifier("z".to_string()),
                     VariableValueExpr::Scalar(Add(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("a".to_string()),
                             AccessType::Default,
                         ))),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("b".to_string()),
                             AccessType::Default,
                         ))),
@@ -82,7 +82,7 @@ fn ev_fn_main_and_aux_cols() {
                             1,
                         )),
                         Add(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("clk".to_string()),
                                 AccessType::Default,
                             ))),
@@ -100,11 +100,11 @@ fn ev_fn_main_and_aux_cols() {
                             1,
                         )),
                         Add(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("a".to_string()),
                                 AccessType::Default,
                             ))),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("z".to_string()),
                                 AccessType::Default,
                             ))),

--- a/parser/src/parser/tests/integrity_constraints.rs
+++ b/parser/src/parser/tests/integrity_constraints.rs
@@ -4,8 +4,8 @@ use super::{
 };
 use crate::{
     ast::{
-        AccessType, BindingAccess, ConstantBinding, ConstantValueExpr::*, ConstraintType,
-        EvaluatorFunction, EvaluatorFunctionCall, Expression::*, IntegrityStmt::*, TraceAccess,
+        AccessType, ConstantBinding, ConstantValueExpr::*, ConstraintType, EvaluatorFunction,
+        EvaluatorFunctionCall, Expression::*, IntegrityStmt::*, SymbolAccess, TraceAccess,
         TraceBindingAccess, TraceBindingAccessSize, VariableBinding, VariableValueExpr,
     },
     error::{Error, ParseError},
@@ -28,7 +28,7 @@ fn integrity_constraints() {
                 1,
             )),
             Add(
-                Box::new(BindingAccess(BindingAccess::new(
+                Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("clk".to_string()),
                     AccessType::Default,
                 ))),
@@ -63,7 +63,7 @@ fn multiple_integrity_constraints() {
                     1,
                 )),
                 Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
                         AccessType::Default,
                     ))),
@@ -81,7 +81,7 @@ fn multiple_integrity_constraints() {
                         TraceBindingAccessSize::Full,
                         1,
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
                         AccessType::Default,
                     ))),
@@ -102,11 +102,11 @@ fn integrity_constraint_with_periodic_col() {
     let expected = Source(vec![SourceSection::IntegrityConstraints(vec![Constraint(
         ConstraintType::Inline(IntegrityConstraint::new(
             Add(
-                Box::new(BindingAccess(BindingAccess::new(
+                Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("k0".to_string()),
                     AccessType::Default,
                 ))),
-                Box::new(BindingAccess(BindingAccess::new(
+                Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("b".to_string()),
                     AccessType::Default,
                 ))),
@@ -126,7 +126,7 @@ fn integrity_constraint_with_random_value() {
     let expected = Source(vec![SourceSection::IntegrityConstraints(vec![Constraint(
         ConstraintType::Inline(IntegrityConstraint::new(
             Add(
-                Box::new(BindingAccess(BindingAccess::new(
+                Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("a".to_string()),
                     AccessType::Default,
                 ))),
@@ -160,21 +160,21 @@ fn integrity_constraint_with_constants() {
         SourceSection::IntegrityConstraints(vec![Constraint(
             ConstraintType::Inline(IntegrityConstraint::new(
                 Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
                         AccessType::Default,
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("A".to_string()),
                         AccessType::Default,
                     ))),
                 ),
                 Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("B".to_string()),
                         AccessType::Vector(1),
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("C".to_string()),
                         AccessType::Matrix(1, 1),
                     ))),
@@ -202,13 +202,13 @@ fn integrity_constraint_with_variables() {
         VariableBinding(VariableBinding::new(
             Identifier("b".to_string()),
             VariableValueExpr::Vector(vec![
-                BindingAccess(BindingAccess::new(
+                SymbolAccess(SymbolAccess::new(
                     Identifier("a".to_string()),
                     AccessType::Default,
                 )),
                 Mul(
                     Box::new(Const(2)),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
                     ))),
@@ -220,14 +220,14 @@ fn integrity_constraint_with_variables() {
             VariableValueExpr::Matrix(vec![
                 vec![
                     Sub(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("a".to_string()),
                             AccessType::Default,
                         ))),
                         Box::new(Const(1)),
                     ),
                     Exp(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("a".to_string()),
                             AccessType::Default,
                         ))),
@@ -235,11 +235,11 @@ fn integrity_constraint_with_variables() {
                     ),
                 ],
                 vec![
-                    BindingAccess(BindingAccess::new(
+                    SymbolAccess(SymbolAccess::new(
                         Identifier("b".to_string()),
                         AccessType::Vector(0),
                     )),
-                    BindingAccess(BindingAccess::new(
+                    SymbolAccess(SymbolAccess::new(
                         Identifier("b".to_string()),
                         AccessType::Vector(1),
                     )),
@@ -249,21 +249,21 @@ fn integrity_constraint_with_variables() {
         Constraint(
             ConstraintType::Inline(IntegrityConstraint::new(
                 Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
                         AccessType::Default,
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
                     ))),
                 ),
                 Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("b".to_string()),
                         AccessType::Vector(1),
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("c".to_string()),
                         AccessType::Matrix(1, 1),
                     ))),
@@ -326,16 +326,16 @@ fn ic_comprehension_one_iterable_identifier() {
         ]]),
         SourceSection::IntegrityConstraints(vec![ConstraintComprehension(
             ConstraintType::Inline(IntegrityConstraint::new(
-                BindingAccess(BindingAccess::new(
+                SymbolAccess(SymbolAccess::new(
                     Identifier("x".to_string()),
                     AccessType::Default,
                 )),
                 Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("b".to_string()),
                         AccessType::Default,
                     ))),
@@ -368,16 +368,16 @@ fn ic_comprehension_one_iterable_range() {
         ]]),
         SourceSection::IntegrityConstraints(vec![ConstraintComprehension(
             ConstraintType::Inline(IntegrityConstraint::new(
-                BindingAccess(BindingAccess::new(
+                SymbolAccess(SymbolAccess::new(
                     Identifier("x".to_string()),
                     AccessType::Default,
                 )),
                 Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("b".to_string()),
                         AccessType::Default,
                     ))),
@@ -411,27 +411,27 @@ fn ic_comprehension_with_selectors() {
         ]]),
         SourceSection::IntegrityConstraints(vec![ConstraintComprehension(
             ConstraintType::Inline(IntegrityConstraint::new(
-                BindingAccess(BindingAccess::new(
+                SymbolAccess(SymbolAccess::new(
                     Identifier("x".to_string()),
                     AccessType::Default,
                 )),
                 Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("b".to_string()),
                         AccessType::Default,
                     ))),
                 ),
             )),
             Some(Mul(
-                Box::new(BindingAccess(BindingAccess::new(
+                Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("s".to_string()),
                     AccessType::Vector(0),
                 ))),
-                Box::new(BindingAccess(BindingAccess::new(
+                Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("s".to_string()),
                     AccessType::Vector(1),
                 ))),
@@ -464,13 +464,13 @@ fn ic_comprehension_with_evaluator_call() {
             vec![Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
                     Exp(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Default,
                         ))),
                         Box::new(Const(2)),
                     ),
-                    BindingAccess(BindingAccess::new(
+                    SymbolAccess(SymbolAccess::new(
                         Identifier("x".to_string()),
                         AccessType::Default,
                     )),
@@ -523,13 +523,13 @@ fn ic_comprehension_with_evaluator_and_selectors() {
             vec![Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
                     Exp(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Default,
                         ))),
                         Box::new(Const(2)),
                     ),
-                    BindingAccess(BindingAccess::new(
+                    SymbolAccess(SymbolAccess::new(
                         Identifier("x".to_string()),
                         AccessType::Default,
                     )),
@@ -555,11 +555,11 @@ fn ic_comprehension_with_evaluator_and_selectors() {
                 )]],
             )),
             Some(Mul(
-                Box::new(BindingAccess(BindingAccess::new(
+                Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("s".to_string()),
                     AccessType::Vector(0),
                 ))),
-                Box::new(BindingAccess(BindingAccess::new(
+                Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("s".to_string()),
                     AccessType::Vector(1),
                 ))),

--- a/parser/src/parser/tests/list_comprehension.rs
+++ b/parser/src/parser/tests/list_comprehension.rs
@@ -3,8 +3,8 @@ use air_script_core::{Iterable, ListComprehension, Range};
 use super::{build_parse_test, Identifier, IntegrityConstraint, Source};
 use crate::{
     ast::{
-        AccessType, BindingAccess, Boundary, BoundaryConstraint, BoundaryStmt, ConstraintType,
-        Expression::*, IntegrityStmt, SourceSection::*, TraceBinding, TraceBindingAccess,
+        AccessType, Boundary, BoundaryConstraint, BoundaryStmt, ConstraintType, Expression::*,
+        IntegrityStmt, SourceSection::*, SymbolAccess, TraceBinding, TraceBindingAccess,
         TraceBindingAccessSize, VariableBinding, VariableValueExpr,
     },
     error::{Error, ParseError},
@@ -36,7 +36,7 @@ fn bc_one_iterable_identifier_lc() {
                 Identifier("x".to_string()),
                 VariableValueExpr::ListComprehension(ListComprehension::new(
                     Exp(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("col".to_string()),
                             AccessType::Default,
                         ))),
@@ -59,21 +59,21 @@ fn bc_one_iterable_identifier_lc() {
                 Add(
                     Box::new(Add(
                         Box::new(Add(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
                                 AccessType::Vector(0),
                             ))),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
                                 AccessType::Vector(1),
                             ))),
                         )),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Vector(2),
                         ))),
                     )),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("x".to_string()),
                         AccessType::Vector(3),
                     ))),
@@ -108,12 +108,12 @@ fn bc_identifier_and_range_lc() {
                     Mul(
                         Box::new(Exp(
                             Box::new(Const(2)),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("i".to_string()),
                                 AccessType::Default,
                             ))),
                         )),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("c".to_string()),
                             AccessType::Default,
                         ))),
@@ -141,21 +141,21 @@ fn bc_identifier_and_range_lc() {
                 Add(
                     Box::new(Add(
                         Box::new(Add(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
                                 AccessType::Vector(0),
                             ))),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
                                 AccessType::Vector(1),
                             ))),
                         )),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Vector(2),
                         ))),
                     )),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("x".to_string()),
                         AccessType::Vector(3),
                     ))),
@@ -187,7 +187,7 @@ fn bc_iterable_slice_lc() {
             BoundaryStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableValueExpr::ListComprehension(ListComprehension::new(
-                    BindingAccess(BindingAccess::new(
+                    SymbolAccess(SymbolAccess::new(
                         Identifier("c".to_string()),
                         AccessType::Default,
                     )),
@@ -208,21 +208,21 @@ fn bc_iterable_slice_lc() {
                 Add(
                     Box::new(Add(
                         Box::new(Add(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
                                 AccessType::Vector(0),
                             ))),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
                                 AccessType::Vector(1),
                             ))),
                         )),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Vector(2),
                         ))),
                     )),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("x".to_string()),
                         AccessType::Vector(3),
                     ))),
@@ -256,11 +256,11 @@ fn bc_two_iterable_identifier_lc() {
                 Identifier("diff".to_string()),
                 VariableValueExpr::ListComprehension(ListComprehension::new(
                     Sub(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Default,
                         ))),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("y".to_string()),
                             AccessType::Default,
                         ))),
@@ -288,21 +288,21 @@ fn bc_two_iterable_identifier_lc() {
                 Add(
                     Box::new(Add(
                         Box::new(Add(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
                                 AccessType::Vector(0),
                             ))),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
                                 AccessType::Vector(1),
                             ))),
                         )),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Vector(2),
                         ))),
                     )),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("x".to_string()),
                         AccessType::Vector(3),
                     ))),
@@ -338,21 +338,21 @@ fn bc_multiple_iterables_lc() {
                     Sub(
                         Box::new(Sub(
                             Box::new(Add(
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("w".to_string()),
                                     AccessType::Default,
                                 ))),
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("x".to_string()),
                                     AccessType::Default,
                                 ))),
                             )),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("y".to_string()),
                                 AccessType::Default,
                             ))),
                         )),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("z".to_string()),
                             AccessType::Default,
                         ))),
@@ -388,21 +388,21 @@ fn bc_multiple_iterables_lc() {
                 Add(
                     Box::new(Add(
                         Box::new(Add(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
                                 AccessType::Vector(0),
                             ))),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
                                 AccessType::Vector(1),
                             ))),
                         )),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Vector(2),
                         ))),
                     )),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("x".to_string()),
                         AccessType::Vector(3),
                     ))),
@@ -439,7 +439,7 @@ fn ic_one_iterable_identifier_lc() {
                 Identifier("x".to_string()),
                 VariableValueExpr::ListComprehension(ListComprehension::new(
                     Exp(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("col".to_string()),
                             AccessType::Default,
                         ))),
@@ -471,28 +471,28 @@ fn ic_one_iterable_identifier_lc() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    BindingAccess(BindingAccess::new(
+                    SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
                     )),
                     Add(
                         Box::new(Add(
                             Box::new(Add(
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("x".to_string()),
                                     AccessType::Vector(0),
                                 ))),
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("x".to_string()),
                                     AccessType::Vector(1),
                                 ))),
                             )),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
                                 AccessType::Vector(2),
                             ))),
                         )),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Vector(3),
                         ))),
@@ -529,12 +529,12 @@ fn ic_iterable_identifier_range_lc() {
                     Mul(
                         Box::new(Exp(
                             Box::new(Const(2)),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("i".to_string()),
                                 AccessType::Default,
                             ))),
                         )),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("c".to_string()),
                             AccessType::Default,
                         ))),
@@ -553,28 +553,28 @@ fn ic_iterable_identifier_range_lc() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    BindingAccess(BindingAccess::new(
+                    SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
                     )),
                     Add(
                         Box::new(Add(
                             Box::new(Add(
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("x".to_string()),
                                     AccessType::Vector(0),
                                 ))),
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("x".to_string()),
                                     AccessType::Vector(1),
                                 ))),
                             )),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
                                 AccessType::Vector(2),
                             ))),
                         )),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Vector(3),
                         ))),
@@ -608,7 +608,7 @@ fn ic_iterable_slice_lc() {
             IntegrityStmt::VariableBinding(VariableBinding::new(
                 Identifier("x".to_string()),
                 VariableValueExpr::ListComprehension(ListComprehension::new(
-                    BindingAccess(BindingAccess::new(
+                    SymbolAccess(SymbolAccess::new(
                         Identifier("c".to_string()),
                         AccessType::Default,
                     )),
@@ -620,28 +620,28 @@ fn ic_iterable_slice_lc() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    BindingAccess(BindingAccess::new(
+                    SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
                     )),
                     Add(
                         Box::new(Add(
                             Box::new(Add(
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("x".to_string()),
                                     AccessType::Vector(0),
                                 ))),
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("x".to_string()),
                                     AccessType::Vector(1),
                                 ))),
                             )),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
                                 AccessType::Vector(2),
                             ))),
                         )),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Vector(3),
                         ))),
@@ -677,11 +677,11 @@ fn ic_two_iterable_identifier_lc() {
                 Identifier("diff".to_string()),
                 VariableValueExpr::ListComprehension(ListComprehension::new(
                     Sub(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Default,
                         ))),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("y".to_string()),
                             AccessType::Default,
                         ))),
@@ -700,28 +700,28 @@ fn ic_two_iterable_identifier_lc() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    BindingAccess(BindingAccess::new(
+                    SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
                     )),
                     Add(
                         Box::new(Add(
                             Box::new(Add(
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("x".to_string()),
                                     AccessType::Vector(0),
                                 ))),
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("x".to_string()),
                                     AccessType::Vector(1),
                                 ))),
                             )),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
                                 AccessType::Vector(2),
                             ))),
                         )),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Vector(3),
                         ))),
@@ -759,21 +759,21 @@ fn ic_multiple_iterables_lc() {
                     Sub(
                         Box::new(Sub(
                             Box::new(Add(
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("w".to_string()),
                                     AccessType::Default,
                                 ))),
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("x".to_string()),
                                     AccessType::Default,
                                 ))),
                             )),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("y".to_string()),
                                 AccessType::Default,
                             ))),
                         )),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("z".to_string()),
                             AccessType::Default,
                         ))),
@@ -800,28 +800,28 @@ fn ic_multiple_iterables_lc() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    BindingAccess(BindingAccess::new(
+                    SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
                     )),
                     Add(
                         Box::new(Add(
                             Box::new(Add(
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("x".to_string()),
                                     AccessType::Vector(0),
                                 ))),
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("x".to_string()),
                                     AccessType::Vector(1),
                                 ))),
                             )),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
                                 AccessType::Vector(2),
                             ))),
                         )),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Vector(3),
                         ))),

--- a/parser/src/parser/tests/list_folding.rs
+++ b/parser/src/parser/tests/list_folding.rs
@@ -3,8 +3,8 @@ use air_script_core::{Iterable, ListComprehension, ListFolding, ListFoldingValue
 use super::{build_parse_test, Identifier, IntegrityConstraint, Source};
 use crate::{
     ast::{
-        AccessType, BindingAccess, Boundary, BoundaryConstraint, BoundaryStmt, ConstraintType,
-        Expression::*, IntegrityStmt, SourceSection::*, TraceBinding, TraceBindingAccess,
+        AccessType, Boundary, BoundaryConstraint, BoundaryStmt, ConstraintType, Expression::*,
+        IntegrityStmt, SourceSection::*, SymbolAccess, TraceBinding, TraceBindingAccess,
         TraceBindingAccessSize, VariableBinding, VariableValueExpr,
     },
     error::{Error, ParseError},
@@ -51,11 +51,11 @@ fn identifier_lf() {
                 ),
                 Boundary::First,
                 Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("x".to_string()),
                         AccessType::Default,
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("y".to_string()),
                         AccessType::Default,
                     ))),
@@ -87,15 +87,15 @@ fn vector_lf() {
                 Identifier("x".to_string()),
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueExpr::Vector(vec![
-                        BindingAccess(BindingAccess::new(
+                        SymbolAccess(SymbolAccess::new(
                             Identifier("a".to_string()),
                             AccessType::Default,
                         )),
-                        BindingAccess(BindingAccess::new(
+                        SymbolAccess(SymbolAccess::new(
                             Identifier("b".to_string()),
                             AccessType::Default,
                         )),
-                        BindingAccess(BindingAccess::new(
+                        SymbolAccess(SymbolAccess::new(
                             Identifier("c".to_string()),
                             AccessType::Vector(0),
                         )),
@@ -106,15 +106,15 @@ fn vector_lf() {
                 Identifier("y".to_string()),
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueExpr::Vector(vec![
-                        BindingAccess(BindingAccess::new(
+                        SymbolAccess(SymbolAccess::new(
                             Identifier("a".to_string()),
                             AccessType::Default,
                         )),
-                        BindingAccess(BindingAccess::new(
+                        SymbolAccess(SymbolAccess::new(
                             Identifier("b".to_string()),
                             AccessType::Default,
                         )),
-                        BindingAccess(BindingAccess::new(
+                        SymbolAccess(SymbolAccess::new(
                             Identifier("c".to_string()),
                             AccessType::Vector(0),
                         )),
@@ -130,11 +130,11 @@ fn vector_lf() {
                 ),
                 Boundary::First,
                 Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("x".to_string()),
                         AccessType::Default,
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("y".to_string()),
                         AccessType::Default,
                     ))),
@@ -168,7 +168,7 @@ fn bc_one_iterable_identifier_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Exp(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("col".to_string()),
                                 AccessType::Default,
                             ))),
@@ -186,7 +186,7 @@ fn bc_one_iterable_identifier_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Exp(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("col".to_string()),
                                 AccessType::Default,
                             ))),
@@ -208,11 +208,11 @@ fn bc_one_iterable_identifier_lf() {
                 ),
                 Boundary::First,
                 Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("x".to_string()),
                         AccessType::Default,
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("y".to_string()),
                         AccessType::Default,
                     ))),
@@ -247,11 +247,11 @@ fn bc_two_iterable_identifier_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("c".to_string()),
                                 AccessType::Default,
                             ))),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("d".to_string()),
                                 AccessType::Default,
                             ))),
@@ -274,11 +274,11 @@ fn bc_two_iterable_identifier_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Add(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("c".to_string()),
                                 AccessType::Default,
                             ))),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("d".to_string()),
                                 AccessType::Default,
                             ))),
@@ -305,11 +305,11 @@ fn bc_two_iterable_identifier_lf() {
                 ),
                 Boundary::First,
                 Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("x".to_string()),
                         AccessType::Default,
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("y".to_string()),
                         AccessType::Default,
                     ))),
@@ -343,11 +343,11 @@ fn bc_two_iterables_identifier_range_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("i".to_string()),
                                 AccessType::Default,
                             ))),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("c".to_string()),
                                 AccessType::Default,
                             ))),
@@ -370,11 +370,11 @@ fn bc_two_iterables_identifier_range_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Add(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("i".to_string()),
                                 AccessType::Default,
                             ))),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("c".to_string()),
                                 AccessType::Default,
                             ))),
@@ -401,11 +401,11 @@ fn bc_two_iterables_identifier_range_lf() {
                 ),
                 Boundary::First,
                 Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("x".to_string()),
                         AccessType::Default,
                     ))),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("y".to_string()),
                         AccessType::Default,
                     ))),
@@ -439,7 +439,7 @@ fn ic_one_iterable_identifier_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Exp(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("col".to_string()),
                                 AccessType::Default,
                             ))),
@@ -457,7 +457,7 @@ fn ic_one_iterable_identifier_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Exp(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("col".to_string()),
                                 AccessType::Default,
                             ))),
@@ -472,16 +472,16 @@ fn ic_one_iterable_identifier_lf() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    BindingAccess(BindingAccess::new(
+                    SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
                     )),
                     Add(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Default,
                         ))),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("y".to_string()),
                             AccessType::Default,
                         ))),
@@ -518,11 +518,11 @@ fn ic_two_iterable_identifier_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("c".to_string()),
                                 AccessType::Default,
                             ))),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("d".to_string()),
                                 AccessType::Default,
                             ))),
@@ -545,11 +545,11 @@ fn ic_two_iterable_identifier_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Add(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("c".to_string()),
                                 AccessType::Default,
                             ))),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("d".to_string()),
                                 AccessType::Default,
                             ))),
@@ -569,16 +569,16 @@ fn ic_two_iterable_identifier_lf() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    BindingAccess(BindingAccess::new(
+                    SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
                     )),
                     Add(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Default,
                         ))),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("y".to_string()),
                             AccessType::Default,
                         ))),
@@ -614,11 +614,11 @@ fn ic_two_iterables_identifier_range_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Sum(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("i".to_string()),
                                 AccessType::Default,
                             ))),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("c".to_string()),
                                 AccessType::Default,
                             ))),
@@ -641,11 +641,11 @@ fn ic_two_iterables_identifier_range_lf() {
                 VariableValueExpr::Scalar(ListFolding(ListFolding::Prod(
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Add(
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("i".to_string()),
                                 AccessType::Default,
                             ))),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("c".to_string()),
                                 AccessType::Default,
                             ))),
@@ -665,16 +665,16 @@ fn ic_two_iterables_identifier_range_lf() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    BindingAccess(BindingAccess::new(
+                    SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
                     )),
                     Add(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Default,
                         ))),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("y".to_string()),
                             AccessType::Default,
                         ))),
@@ -711,16 +711,16 @@ fn ic_three_iterables_slice_identifier_range_lf() {
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
                             Box::new(Mul(
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("m".to_string()),
                                     AccessType::Default,
                                 ))),
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("n".to_string()),
                                     AccessType::Default,
                                 ))),
                             )),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("i".to_string()),
                                 AccessType::Default,
                             ))),
@@ -748,16 +748,16 @@ fn ic_three_iterables_slice_identifier_range_lf() {
                     ListFoldingValueExpr::ListComprehension(ListComprehension::new(
                         Mul(
                             Box::new(Mul(
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("m".to_string()),
                                     AccessType::Default,
                                 ))),
-                                Box::new(BindingAccess(BindingAccess::new(
+                                Box::new(SymbolAccess(SymbolAccess::new(
                                     Identifier("n".to_string()),
                                     AccessType::Default,
                                 ))),
                             )),
-                            Box::new(BindingAccess(BindingAccess::new(
+                            Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("i".to_string()),
                                 AccessType::Default,
                             ))),
@@ -781,16 +781,16 @@ fn ic_three_iterables_slice_identifier_range_lf() {
             )),
             IntegrityStmt::Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
-                    BindingAccess(BindingAccess::new(
+                    SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
                     )),
                     Add(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
                             AccessType::Default,
                         ))),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("y".to_string()),
                             AccessType::Default,
                         ))),

--- a/parser/src/parser/tests/mod.rs
+++ b/parser/src/parser/tests/mod.rs
@@ -54,7 +54,7 @@ fn full_air_file() {
                     1,
                 )),
                 Expression::Add(
-                    Box::new(Expression::BindingAccess(BindingAccess::new(
+                    Box::new(Expression::SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
                         AccessType::Default,
                     ))),

--- a/parser/src/parser/tests/random_values.rs
+++ b/parser/src/parser/tests/random_values.rs
@@ -1,7 +1,7 @@
 use super::{
-    build_parse_test, AccessType, BindingAccess, Error, Expression::*, Identifier,
-    IntegrityConstraint, IntegrityStmt::*, ParseError, RandBinding, RandomValues, Source,
-    SourceSection, SourceSection::*,
+    build_parse_test, AccessType, Error, Expression::*, Identifier, IntegrityConstraint,
+    IntegrityStmt::*, ParseError, RandBinding, RandomValues, Source, SourceSection,
+    SourceSection::*, SymbolAccess,
 };
 use crate::ast::ConstraintType;
 
@@ -82,7 +82,7 @@ fn random_values_index_access() {
     let expected = Source(vec![SourceSection::IntegrityConstraints(vec![Constraint(
         ConstraintType::Inline(IntegrityConstraint::new(
             Add(
-                Box::new(BindingAccess(BindingAccess::new(
+                Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("a".to_string()),
                     AccessType::Default,
                 ))),

--- a/parser/src/parser/tests/selectors.rs
+++ b/parser/src/parser/tests/selectors.rs
@@ -1,6 +1,6 @@
 use super::{build_parse_test, Identifier, IntegrityConstraint, Source, SourceSection};
 use crate::ast::{
-    AccessType, BindingAccess, ConstraintType, Expression::*, IntegrityStmt::*, TraceBindingAccess,
+    AccessType, ConstraintType, Expression::*, IntegrityStmt::*, SymbolAccess, TraceBindingAccess,
     TraceBindingAccessSize,
 };
 
@@ -21,13 +21,13 @@ fn single_selector() {
                 TraceBindingAccessSize::Full,
                 1,
             )),
-            BindingAccess(BindingAccess::new(
+            SymbolAccess(SymbolAccess::new(
                 Identifier("clk".to_string()),
                 AccessType::Default,
             )),
         )),
         // n1
-        Some(BindingAccess(BindingAccess::new(
+        Some(SymbolAccess(SymbolAccess::new(
             Identifier("n1".to_string()),
             AccessType::Default,
         ))),
@@ -49,7 +49,7 @@ fn chained_selectors() {
                 TraceBindingAccessSize::Full,
                 1,
             )),
-            BindingAccess(BindingAccess::new(
+            SymbolAccess(SymbolAccess::new(
                 Identifier("clk".to_string()),
                 AccessType::Default,
             )),
@@ -58,13 +58,13 @@ fn chained_selectors() {
         Some(Sub(
             Box::new(Add(
                 Box::new(Mul(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("n1".to_string()),
                         AccessType::Default,
                     ))),
                     Box::new(Sub(
                         Box::new(Const(1)),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("n2".to_string()),
                             AccessType::Default,
                         ))),
@@ -72,7 +72,7 @@ fn chained_selectors() {
                 )),
                 Box::new(Sub(
                     Box::new(Const(1)),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("n3".to_string()),
                         AccessType::Default,
                     ))),
@@ -80,13 +80,13 @@ fn chained_selectors() {
             )),
             Box::new(Mul(
                 Box::new(Mul(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("n1".to_string()),
                         AccessType::Default,
                     ))),
                     Box::new(Sub(
                         Box::new(Const(1)),
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("n2".to_string()),
                             AccessType::Default,
                         ))),
@@ -94,7 +94,7 @@ fn chained_selectors() {
                 )),
                 Box::new(Sub(
                     Box::new(Const(1)),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("n3".to_string()),
                         AccessType::Default,
                     ))),
@@ -126,13 +126,13 @@ fn multiconstraint_selectors() {
                 Const(0),
             )),
             Some(Mul(
-                Box::new(BindingAccess(BindingAccess::new(
+                Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("n1".to_string()),
                     AccessType::Default,
                 ))),
                 Box::new(Sub(
                     Box::new(Const(1)),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("n2".to_string()),
                         AccessType::Default,
                     ))),
@@ -148,17 +148,17 @@ fn multiconstraint_selectors() {
                     TraceBindingAccessSize::Full,
                     1,
                 )),
-                BindingAccess(BindingAccess::new(
+                SymbolAccess(SymbolAccess::new(
                     Identifier("clk".to_string()),
                     AccessType::Default,
                 )),
             )),
             Some(Mul(
-                Box::new(BindingAccess(BindingAccess::new(
+                Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("n1".to_string()),
                     AccessType::Default,
                 ))),
-                Box::new(BindingAccess(BindingAccess::new(
+                Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("n2".to_string()),
                     AccessType::Default,
                 ))),
@@ -178,14 +178,14 @@ fn multiconstraint_selectors() {
             Some(Mul(
                 Box::new(Sub(
                     Box::new(Const(1)),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("n1".to_string()),
                         AccessType::Default,
                     ))),
                 )),
                 Box::new(Sub(
                     Box::new(Const(1)),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("n2".to_string()),
                         AccessType::Default,
                     ))),

--- a/parser/src/parser/tests/trace_columns.rs
+++ b/parser/src/parser/tests/trace_columns.rs
@@ -1,6 +1,6 @@
 use super::{
-    build_parse_test, AccessType, BindingAccess, Error, Expression::*, Identifier,
-    IntegrityConstraint, IntegrityStmt::*, ParseError, Source, SourceSection::*, TraceBinding,
+    build_parse_test, AccessType, Error, Expression::*, Identifier, IntegrityConstraint,
+    IntegrityStmt::*, ParseError, Source, SourceSection::*, SymbolAccess, TraceBinding,
     TraceBindingAccess, TraceBindingAccessSize,
 };
 use crate::ast::ConstraintType;
@@ -86,7 +86,7 @@ fn trace_columns_groups() {
                         1,
                     )),
                     Sub(
-                        Box::new(BindingAccess(BindingAccess::new(
+                        Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("clk".to_string()),
                             AccessType::Default,
                         ))),

--- a/parser/src/parser/tests/variables.rs
+++ b/parser/src/parser/tests/variables.rs
@@ -1,6 +1,6 @@
 use super::{build_parse_test, Identifier, IntegrityConstraint, Source, SourceSection};
 use crate::ast::{
-    AccessType, BindingAccess, ConstraintType, Expression::*, IntegrityStmt::*, TraceBindingAccess,
+    AccessType, ConstraintType, Expression::*, IntegrityStmt::*, SymbolAccess, TraceBindingAccess,
     TraceBindingAccessSize, VariableBinding, VariableValueExpr,
 };
 
@@ -16,13 +16,13 @@ fn variables_with_and_operators() {
         VariableBinding(VariableBinding::new(
             Identifier("flag".to_string()),
             VariableValueExpr::Scalar(Mul(
-                Box::new(BindingAccess(BindingAccess::new(
+                Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("n1".to_string()),
                     AccessType::Default,
                 ))),
                 Box::new(Sub(
                     Box::new(Const(1)),
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("n2".to_string()),
                         AccessType::Default,
                     ))),
@@ -38,14 +38,14 @@ fn variables_with_and_operators() {
                     1,
                 )),
                 Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
                         AccessType::Default,
                     ))),
                     Box::new(Const(1)),
                 ),
             )),
-            Some(BindingAccess(BindingAccess::new(
+            Some(SymbolAccess(SymbolAccess::new(
                 Identifier("flag".to_string()),
                 AccessType::Default,
             ))),
@@ -65,7 +65,7 @@ fn variables_with_or_operators() {
             Identifier("flag".to_string()),
             VariableValueExpr::Scalar(Sub(
                 Box::new(Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("s".to_string()),
                         AccessType::Vector(0),
                     ))),
@@ -80,7 +80,7 @@ fn variables_with_or_operators() {
                     )),
                 )),
                 Box::new(Mul(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("s".to_string()),
                         AccessType::Vector(0),
                     ))),
@@ -105,14 +105,14 @@ fn variables_with_or_operators() {
                     1,
                 )),
                 Add(
-                    Box::new(BindingAccess(BindingAccess::new(
+                    Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
                         AccessType::Default,
                     ))),
                     Box::new(Const(1)),
                 ),
             )),
-            Some(BindingAccess(BindingAccess::new(
+            Some(SymbolAccess(SymbolAccess::new(
                 Identifier("flag".to_string()),
                 AccessType::Default,
             ))),


### PR DESCRIPTION
- rename BindingAccess to SymbolAccess
- rename SymbolType to SymbolBinding
- simplify the SymbolBinding enum variant names