### PR TITLE
refactor: replace Rand with SymbolAccess

### DIFF
--- a/air-script-core/src/expression.rs
+++ b/air-script-core/src/expression.rs
@@ -1,4 +1,4 @@
-use super::{Identifier, ListFolding, SymbolAccess, TraceAccess, TraceBindingAccess};
+use super::{ListFolding, SymbolAccess, TraceAccess, TraceBindingAccess};
 
 /// Arithmetic expressions for evaluation of constraints.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -8,9 +8,6 @@ pub enum Expression {
     SymbolAccess(SymbolAccess),
     TraceAccess(TraceAccess),
     TraceBindingAccess(TraceBindingAccess),
-    /// Represents a random value provided by the verifier. The first inner value is the name of
-    /// the random values array and the second is the index of this random value in that array
-    Rand(Identifier, usize),
     Add(Box<Expression>, Box<Expression>),
     Sub(Box<Expression>, Box<Expression>),
     Mul(Box<Expression>, Box<Expression>),

--- a/ir/src/constraint_builder/expression.rs
+++ b/ir/src/constraint_builder/expression.rs
@@ -1,6 +1,6 @@
 use super::{
-    get_variable_expr, AccessType, ConstraintBuilder, Expression, ListFolding, NodeIndex,
-    Operation, SemanticError, SymbolAccess, SymbolBinding, TraceAccess, TraceBindingAccess, Value,
+    get_variable_expr, ConstraintBuilder, Expression, ListFolding, NodeIndex, Operation,
+    SemanticError, SymbolAccess, SymbolBinding, TraceAccess, TraceBindingAccess, Value,
 };
 
 impl ConstraintBuilder {
@@ -28,12 +28,6 @@ impl ConstraintBuilder {
 
             // --- IDENTIFIER EXPRESSIONS ---------------------------------------------------------
             Expression::SymbolAccess(access) => self.insert_symbol_access(access),
-            Expression::Rand(ident, index) => {
-                // TODO: replace Rand with SymbolAccess in parser?
-                let access_type = AccessType::Vector(index);
-                let access = SymbolAccess::new(ident, access_type);
-                self.insert_symbol_access(access)
-            }
             Expression::ListFolding(lf_type) => self.insert_list_folding(lf_type),
 
             // --- OPERATION EXPRESSIONS ----------------------------------------------------------

--- a/ir/src/symbol_table/mod.rs
+++ b/ir/src/symbol_table/mod.rs
@@ -112,7 +112,7 @@ impl SymbolTable {
         let mut offset = 0;
         // add the name of the random values array to the symbol table
         self.insert_symbol(
-            name,
+            format!("${name}"),
             SymbolBinding::RandomValues(offset, num_values as usize),
         )?;
 

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -260,7 +260,6 @@ BoundaryExponent: Expression = {
 
 BoundaryAtom: Expression = {
     "(" <BoundaryExpr> ")",
-    "$" <ident: Identifier> <idx: Index> => Expression::Rand(ident, idx),
     <n: Num_u64> => Expression::Const(n),
     <symbol_access: SymbolAccess> => Expression::SymbolAccess(symbol_access),
     <list_folding_type: ListFolding<BoundaryExpr>> => Expression::ListFolding(list_folding_type),
@@ -391,7 +390,6 @@ IntegrityExponent: Expression = {
 IntegrityAtom: Expression = {
     "(" <IntegrityExpr> ")",
     <col_access: TraceAccess> => Expression::TraceAccess(col_access),
-    "$" <ident: Identifier> <idx: Index> => Expression::Rand(ident, idx),
     <n: Num_u64> => Expression::Const(n),
     "!" <expr: IntegrityAtom> =>
         Expression::Sub(Box::new(Expression::Const(1)), Box::new(expr)),
@@ -442,7 +440,12 @@ SymbolAccess: SymbolAccess = {
     <ident: Identifier> <idx: Index> => 
         SymbolAccess::new(ident, AccessType::Vector(idx)),
     <ident: Identifier> <row: Index> <col: Index> =>
-        SymbolAccess::new(ident, AccessType::Matrix(row, col))
+        SymbolAccess::new(ident, AccessType::Matrix(row, col)),
+    // accessing the random values array
+    <ident: RandArrayAccess> => 
+        SymbolAccess::new(ident, AccessType::Default),
+    <ident: RandArrayAccess> <idx: Index> =>  
+        SymbolAccess::new(ident, AccessType::Vector(idx)),
 }
 
 TraceBindingAccess: TraceBindingAccess = {
@@ -524,6 +527,10 @@ Iterable: Iterable = {
 
 Range: Range = {
     <start: Num_u64> ".." <end: Num_u64> => Range::new(start as usize, end as usize)
+}
+
+RandArrayAccess: Identifier = {
+    "$" <n:identifier> => Identifier(format!("${n}"))
 }
 
 Identifier: Identifier = {

--- a/parser/src/parser/tests/integrity_constraints.rs
+++ b/parser/src/parser/tests/integrity_constraints.rs
@@ -130,7 +130,10 @@ fn integrity_constraint_with_random_value() {
                     Identifier("a".to_string()),
                     AccessType::Default,
                 ))),
-                Box::new(Rand(Identifier("rand".to_string()), 1)),
+                Box::new(SymbolAccess(SymbolAccess::new(
+                    Identifier("$rand".to_string()),
+                    AccessType::Vector(1),
+                ))),
             ),
             Const(0),
         )),

--- a/parser/src/parser/tests/random_values.rs
+++ b/parser/src/parser/tests/random_values.rs
@@ -86,7 +86,10 @@ fn random_values_index_access() {
                     Identifier("a".to_string()),
                     AccessType::Default,
                 ))),
-                Box::new(Rand(Identifier("alphas".to_string()), 1)),
+                Box::new(SymbolAccess(SymbolAccess::new(
+                    Identifier("$alphas".to_string()),
+                    AccessType::Vector(1),
+                ))),
             ),
             Const(0),
         )),


### PR DESCRIPTION
This is a minimal refactor to remove `Rand` and replace it with `SymbolAccess`. We may want to do this a bit more cleanly in the parser, but that work will coincide with consolidating `TraceBindingAccess` into `SymbolAccess`, so I wanted to keep the changeset small for now.