### PR TITLE
Remove keywords from evaluator function declaration

### DIFF
--- a/ir/src/tests/evaluators.rs
+++ b/ir/src/tests/evaluators.rs
@@ -74,7 +74,6 @@ fn evaluator_with_main_and_aux_cols() {
     assert!(result.is_ok());
 }
 
-#[ignore]
 #[test]
 fn ev_call_with_aux_only() {
     let source = "
@@ -92,7 +91,7 @@ fn ev_call_with_aux_only() {
         enf clk.first = 0
     
     integrity_constraints:
-        enf enforce_a([a, b])";
+        enf enforce_a([], [a, b])";
 
     let parsed = parse(source).expect("Parsing failed");
     let result = AirIR::new(parsed);
@@ -125,7 +124,6 @@ fn ev_call_inside_evaluator_with_main() {
     assert!(result.is_ok());
 }
 
-#[ignore]
 #[test]
 fn ev_call_inside_evaluator_with_aux() {
     let source = "

--- a/ir/src/tests/evaluators.rs
+++ b/ir/src/tests/evaluators.rs
@@ -3,7 +3,7 @@ use super::{parse, AirIR};
 #[test]
 fn simple_evaluator() {
     let source = "
-    ev advance_clock(main: [clk]):
+    ev advance_clock([clk]):
         let z = a + 1
         enf clk' = clk + 1
     
@@ -27,7 +27,7 @@ fn simple_evaluator() {
 #[test]
 fn evaluator_with_variables() {
     let source = "
-    ev advance_clock(main: [clk]):
+    ev advance_clock([clk]):
         let z = clk + 1
         enf clk' = z
     
@@ -51,7 +51,7 @@ fn evaluator_with_variables() {
 #[test]
 fn evaluator_with_main_and_aux_cols() {
     let source = "
-    ev enforce_constraints(main: [clk], aux: [a, b]):
+    ev enforce_constraints([clk], [a, b]):
         let z = a + b
         enf clk' = clk + 1
         enf a' = a + z
@@ -78,7 +78,7 @@ fn evaluator_with_main_and_aux_cols() {
 #[test]
 fn ev_call_with_aux_only() {
     let source = "
-    ev enforce_a(aux: [a, b]):
+    ev enforce_a([], [a, b]):
         enf a' = a + 1
     
     trace_columns:
@@ -102,10 +102,10 @@ fn ev_call_with_aux_only() {
 #[test]
 fn ev_call_inside_evaluator_with_main() {
     let source = "
-    ev enforce_clk(main: [clk]):
+    ev enforce_clk([clk]):
         enf clk' = clk + 1
     
-    ev enforce_all_constraints(main: [clk]):
+    ev enforce_all_constraints([clk]):
         enf enforce_clk([clk])
     
     trace_columns:
@@ -129,15 +129,15 @@ fn ev_call_inside_evaluator_with_main() {
 #[test]
 fn ev_call_inside_evaluator_with_aux() {
     let source = "
-    ev enforce_clk(main: [clk]):
+    ev enforce_clk([clk]):
         enf clk' = clk + 1
     
-    ev enforce_a(aux: [a, b]):
+    ev enforce_a([], [a, b]):
         enf a' = a + 1
     
-    ev enforce_all_constraints(main: [clk], aux: [a, b]):
+    ev enforce_all_constraints([clk], [a, b]):
         enf enforce_clk([clk])
-        enf enforce_a([a, b])
+        enf enforce_a([], [a, b])
     
     trace_columns:
         main: [clk]

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -77,9 +77,9 @@ pub enum SourceSection {
 // TRACE
 // ================================================================================================
 
-/// Given a trace segment and a vector of (Identifier, size) pairs, returns a vector of trace
+/// Given a named trace segment and a vector of (Identifier, size) pairs, returns a vector of trace
 /// bindings.
-pub fn build_trace_bindings(
+pub fn build_segment_bindings(
     trace_segment: TraceSegment,
     segment_name: Identifier,
     bindings: Vec<(Identifier, u64)>,
@@ -97,6 +97,25 @@ pub fn build_trace_bindings(
     // the size for the binding for the entire segment is the sum of the other sizes.
     let segment_binding = TraceBinding::new(segment_name, trace_segment, 0, offset);
     trace_cols.push(segment_binding);
+
+    trace_cols
+}
+
+/// Given a matrix of (Identifier, size) pairs representing a multi-segment execution trace, returns
+/// a matrix of trace bindings.
+pub fn build_trace_bindings(bindings: Vec<Vec<(Identifier, u64)>>) -> Vec<Vec<TraceBinding>> {
+    let mut trace_cols = Vec::new();
+
+    for (segment, bindings) in bindings.into_iter().enumerate() {
+        let mut segment_cols = Vec::new();
+        let mut offset = 0;
+        for (ident, size) in bindings.into_iter() {
+            let size = size as usize;
+            segment_cols.push(TraceBinding::new(ident, segment, offset, size));
+            offset += size;
+        }
+        trace_cols.push(segment_cols);
+    }
 
     trace_cols
 }

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -2,11 +2,11 @@ use crate::{
     ast::{
         boundary_constraints::{Boundary, BoundaryConstraint, BoundaryStmt},
         integrity_constraints::{ConstraintType, IntegrityConstraint, IntegrityStmt},
-        build_trace_bindings, AccessType, ComprehensionContext, ConstantBinding, ConstantValueExpr, 
-        Expression, EvaluatorFunction, EvaluatorFunctionCall, Identifier, Iterable, 
-        ListComprehension, ListFolding, ListFoldingValueExpr, PeriodicColumn, PublicInput, 
-        RandBinding, RandomValues, Range, Source, SourceSection, SymbolAccess, TraceBinding, 
-        VariableBinding, VariableValueExpr, 
+        build_segment_bindings, build_trace_bindings, AccessType, ComprehensionContext, 
+        ConstantBinding, ConstantValueExpr, Expression, EvaluatorFunction, EvaluatorFunctionCall, 
+        Identifier, Iterable, ListComprehension, ListFolding, ListFoldingValueExpr, PeriodicColumn, 
+        PublicInput, RandBinding, RandomValues, Range, Source, SourceSection, SymbolAccess, 
+        TraceBinding, VariableBinding, VariableValueExpr, 
     }, error::{Error, ParseError::*}, lexer::Token
 };
 use std::str::FromStr;
@@ -61,12 +61,12 @@ Trace: Vec<Vec<TraceBinding>> = {
 
 MainTraceBindings: Vec<TraceBinding> = {
     "main" ":" <main_cols: Vector<TraceBinding>> => 
-        build_trace_bindings(0, Identifier("$main".to_string()), main_cols),
+        build_segment_bindings(0, Identifier("$main".to_string()), main_cols),
 }
 
 AuxTraceBindings: Vec<TraceBinding> = {
     "aux" ":" <aux_cols: Vector<TraceBinding>> => 
-        build_trace_bindings(1, Identifier("$aux".to_string()), aux_cols),
+        build_segment_bindings(1, Identifier("$aux".to_string()), aux_cols),
 }
 
 TraceBinding: (Identifier, u64) = {
@@ -167,25 +167,16 @@ RandElem: RandBinding = {
 // ================================================================================================
 
 EvaluatorFunction: EvaluatorFunction = {
-    "ev" <evaluator_fn_name: Identifier> "(" <main_cols: MainTraceBindings> "," <aux_cols: AuxTraceBindings> ")" ":"
-        <integrity_stmts: IntegrityStmts> => {
-            EvaluatorFunction::new(
-                evaluator_fn_name,
-                vec![main_cols, aux_cols],
-                integrity_stmts)
-        },
-    "ev" <evaluator_fn_name: Identifier> "(" <main_cols: MainTraceBindings> ")" ":"
+    "ev" <evaluator_fn_name: Identifier> "(" <trace: EvaluatorBindings> ")" ":"
         <integrity_stmts: IntegrityStmts> => 
             EvaluatorFunction::new(
                 evaluator_fn_name,
-                vec![main_cols],
+                trace,
                 integrity_stmts),
-    "ev" <evaluator_fn_name: Identifier> "(" <aux_cols: AuxTraceBindings> ")" ":"
-        <integrity_stmts: IntegrityStmts> =>
-            EvaluatorFunction::new(
-                evaluator_fn_name,
-                vec![aux_cols],
-                integrity_stmts),
+}
+
+EvaluatorBindings: Vec<Vec<TraceBinding>> = {
+    <trace: CommaElems<Vector<TraceBinding>>> => build_trace_bindings(trace),
 }
 
 // BOUNDARY STATEMENTS

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -176,7 +176,27 @@ EvaluatorFunction: EvaluatorFunction = {
 }
 
 EvaluatorBindings: Vec<Vec<TraceBinding>> = {
-    <trace: CommaElems<Vector<TraceBinding>>> => build_trace_bindings(trace),
+    <trace: CommaElems<EvaluatorSegmentBindings>> =>? {
+        let bindings = build_trace_bindings(trace);
+
+        // the last segment of trace columns cannot be empty.
+        if let Some(last_segment) = bindings.last() {
+            if last_segment.is_empty() {
+                return Err(ParseError::User {
+                    error: Error::ParseError(InvalidEvaluatorFunction(
+                        "The last trace segment in an evaluator definition cannot be empty."
+                            .to_string(),
+                    )),
+                });
+            }
+        }
+        Ok(bindings)
+    }
+}
+
+EvaluatorSegmentBindings: Vec<(Identifier, u64)> = {
+    <elems: Vector<TraceBinding>> => elems,
+    "[" "]" => Vec::new()
 }
 
 // BOUNDARY STATEMENTS
@@ -333,18 +353,14 @@ IntegrityVariableType: VariableValueExpr = {
 }
 
 EvaluatorFunctionCall: EvaluatorFunctionCall = {
-    <ident: Identifier> "(" <args: CommaElems<Vector<SymbolAccess>>> ")" =>? {
-        if args.len() > 2 {
-            return Err(ParseError::User {
-                error: Error::ParseError(
-                    InvalidEvaluatorFunction(
-                        "Evaluator function call must have 1 or 2 arguments".to_string()
-                    )
-                )
-            });
-        }
+    <ident: Identifier> "(" <args: CommaElems<EvaluatorArg>> ")" =>? {
         Ok(EvaluatorFunctionCall::new(ident, args))
     }
+}
+
+EvaluatorArg: Vec<SymbolAccess> = {
+    <elems: Vector<SymbolAccess>> => elems,
+    "[" "]" => Vec::new()
 }
 
 // --- INTEGRITY CONSTRAINT EXPRESSIONS WITH PRECEDENCE (LOWEST TO HIGHEST) ----------------------

--- a/parser/src/parser/tests/evaluators.rs
+++ b/parser/src/parser/tests/evaluators.rs
@@ -13,15 +13,17 @@ use crate::{
 #[test]
 fn ev_fn_main_cols() {
     let source = "
-    ev advance_clock(main: [clk]):
+    ev advance_clock([clk]):
         enf clk' = clk + 1";
     let expected = Source(vec![SourceSection::EvaluatorFunction(
         EvaluatorFunction::new(
             Identifier("advance_clock".to_string()),
-            vec![vec![
-                TraceBinding::new(Identifier("clk".to_string()), 0, 0, 1),
-                TraceBinding::new(Identifier("$main".to_string()), 0, 0, 1),
-            ]],
+            vec![vec![TraceBinding::new(
+                Identifier("clk".to_string()),
+                0,
+                0,
+                1,
+            )]],
             vec![Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
                     SymbolAccess(SymbolAccess::new(
@@ -48,7 +50,7 @@ fn ev_fn_main_cols() {
 #[test]
 fn ev_fn_main_and_aux_cols() {
     let source = "
-    ev ev_func(main: [clk], aux: [a, b]):
+    ev ev_func([clk], [a, b]):
         let z = a + b
         enf clk' = clk + 1
         enf a' = a + z";
@@ -57,14 +59,10 @@ fn ev_fn_main_and_aux_cols() {
         EvaluatorFunction::new(
             Identifier("ev_func".to_string()),
             vec![
-                vec![
-                    TraceBinding::new(Identifier("clk".to_string()), 0, 0, 1),
-                    TraceBinding::new(Identifier("$main".to_string()), 0, 0, 1),
-                ],
+                vec![TraceBinding::new(Identifier("clk".to_string()), 0, 0, 1)],
                 vec![
                     TraceBinding::new(Identifier("a".to_string()), 1, 0, 1),
                     TraceBinding::new(Identifier("b".to_string()), 1, 1, 1),
-                    TraceBinding::new(Identifier("$aux".to_string()), 1, 0, 2),
                 ],
             ],
             vec![
@@ -178,21 +176,17 @@ fn ev_fn_call() {
 #[test]
 fn ev_fn_call_inside_ev_fn() {
     let source = "
-    ev ev_func(main: [clk], aux: [a, b]):
+    ev ev_func([clk], [a, b]):
         enf advance_clock([clk])";
 
     let expected = Source(vec![SourceSection::EvaluatorFunction(
         EvaluatorFunction::new(
             Identifier("ev_func".to_string()),
             vec![
-                vec![
-                    TraceBinding::new(Identifier("clk".to_string()), 0, 0, 1),
-                    TraceBinding::new(Identifier("$main".to_string()), 0, 0, 1),
-                ],
+                vec![TraceBinding::new(Identifier("clk".to_string()), 0, 0, 1)],
                 vec![
                     TraceBinding::new(Identifier("a".to_string()), 1, 0, 1),
                     TraceBinding::new(Identifier("b".to_string()), 1, 1, 1),
-                    TraceBinding::new(Identifier("$aux".to_string()), 1, 0, 2),
                 ],
             ],
             vec![Constraint(

--- a/parser/src/parser/tests/integrity_constraints.rs
+++ b/parser/src/parser/tests/integrity_constraints.rs
@@ -499,7 +499,7 @@ fn ic_comprehension_with_selectors() {
 #[test]
 fn ic_comprehension_with_evaluator_call() {
     let source = "
-    ev is_binary(main: [x]):
+    ev is_binary([x]):
         enf x^2 = x
 
     trace_columns:
@@ -511,10 +511,12 @@ fn ic_comprehension_with_evaluator_call() {
     let expected = Source(vec![
         SourceSection::EvaluatorFunction(EvaluatorFunction::new(
             Identifier("is_binary".to_string()),
-            vec![vec![
-                TraceBinding::new(Identifier("x".to_string()), 0, 0, 1),
-                TraceBinding::new(Identifier("$main".to_string()), 0, 0, 1),
-            ]],
+            vec![vec![TraceBinding::new(
+                Identifier("x".to_string()),
+                0,
+                0,
+                1,
+            )]],
             vec![Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
                     Exp(
@@ -563,7 +565,7 @@ fn ic_comprehension_with_evaluator_call() {
 #[test]
 fn ic_comprehension_with_evaluator_and_selectors() {
     let source = "
-    ev is_binary(main: [x]):
+    ev is_binary([x]):
         enf x^2 = x
 
     trace_columns:
@@ -575,10 +577,12 @@ fn ic_comprehension_with_evaluator_and_selectors() {
     let expected = Source(vec![
         SourceSection::EvaluatorFunction(EvaluatorFunction::new(
             Identifier("is_binary".to_string()),
-            vec![vec![
-                TraceBinding::new(Identifier("x".to_string()), 0, 0, 1),
-                TraceBinding::new(Identifier("$main".to_string()), 0, 0, 1),
-            ]],
+            vec![vec![TraceBinding::new(
+                Identifier("x".to_string()),
+                0,
+                0,
+                1,
+            )]],
             vec![Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
                     Exp(


### PR DESCRIPTION
This PR removes the keywords `main` and `aux` from evaluator function declarations. Instead, it parses the trace segments in order and accepts empty trace segments as long as the final trace segment is not empty. This enables the definition of evaluator functions which only use the trace for the auxiliary segment, which completes support for #124 .

This fixes the error from the previous evaluator function implementation where evaluators could not accept only an auxiliary trace. It also enables unlimited trace segments. A check should be added to the IR to ensure that no columns are passed to the wrong trace segment. This will ensure that evaluator functions cannot use trace segments that haven't been defined.

Example of the syntax that is now supported:

```
ev foo([a,b,c], [p]):
  ...

ev bar([], [p]):
  ...

ev bat([a, b]):
  ...

enf foo([x, y, z], [p])
enf bar([], [p])
enf bat([x, y])
```