### PR TITLE
refactor(parser): refactor constraint comprehension grammar

### DIFF
--- a/ir/src/constraint_builder/boundary_constraints.rs
+++ b/ir/src/constraint_builder/boundary_constraints.rs
@@ -46,7 +46,7 @@ impl ConstraintBuilder {
         stmt: BoundaryStmt,
     ) -> Result<(), SemanticError> {
         match stmt {
-            BoundaryStmt::Constraint(constraint) => {
+            BoundaryStmt::Constraint(constraint, _) => {
                 let (boundary, access, value) = constraint.into_parts();
 
                 let trace_access = self.symbol_table.get_trace_access(&access)?;
@@ -102,7 +102,6 @@ impl ConstraintBuilder {
             BoundaryStmt::VariableBinding(variable) => {
                 self.symbol_table.insert_variable(variable)?
             }
-            BoundaryStmt::ConstraintComprehension(_, _) => todo!(),
         }
 
         Ok(())

--- a/ir/src/constraint_builder/boundary_constraints.rs
+++ b/ir/src/constraint_builder/boundary_constraints.rs
@@ -46,8 +46,8 @@ impl ConstraintBuilder {
         stmt: BoundaryStmt,
     ) -> Result<(), SemanticError> {
         match stmt {
-            BoundaryStmt::Constraint(constraint, _) => {
-                let (boundary, access, value) = constraint.into_parts();
+            BoundaryStmt::Constraint(constraint) => {
+                let (boundary, access, value, _) = constraint.into_parts();
 
                 let trace_access = self.symbol_table.get_trace_access(&access)?;
                 let domain = boundary.into();

--- a/ir/src/constraint_builder/integrity_constraints/mod.rs
+++ b/ir/src/constraint_builder/integrity_constraints/mod.rs
@@ -22,7 +22,7 @@ impl ConstraintBuilder {
         stmt: IntegrityStmt,
     ) -> Result<(), SemanticError> {
         match stmt {
-            IntegrityStmt::Constraint(ConstraintType::Inline(constraint), _) => {
+            IntegrityStmt::Constraint(ConstraintType::Inline(constraint), _, _) => {
                 let (lhs, rhs) = constraint.into_parts();
                 // add the left hand side expression to the graph.
                 let lhs = self.insert_expr(lhs)?;
@@ -52,10 +52,9 @@ impl ConstraintBuilder {
                     self.symbol_table.insert_variable(variable)?
                 }
             }
-            IntegrityStmt::Constraint(ConstraintType::Evaluator(ev_call), _) => {
+            IntegrityStmt::Constraint(ConstraintType::Evaluator(ev_call), _, _) => {
                 self.process_evaluator_call(ev_call)?;
             }
-            IntegrityStmt::ConstraintComprehension(_, _, _) => todo!(),
         }
 
         Ok(())

--- a/parser/src/ast/boundary_constraints.rs
+++ b/parser/src/ast/boundary_constraints.rs
@@ -8,7 +8,7 @@ use std::fmt::Display;
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum BoundaryStmt {
-    Constraint(BoundaryConstraint, Option<ComprehensionContext>),
+    Constraint(BoundaryConstraint),
     VariableBinding(VariableBinding),
 }
 
@@ -18,14 +18,21 @@ pub struct BoundaryConstraint {
     access: SymbolAccess,
     boundary: Boundary,
     value: Expression,
+    comprehension_context: Option<ComprehensionContext>,
 }
 
 impl BoundaryConstraint {
-    pub fn new(access: SymbolAccess, boundary: Boundary, value: Expression) -> Self {
+    pub fn new(
+        access: SymbolAccess,
+        boundary: Boundary,
+        value: Expression,
+        comprehension_context: Option<ComprehensionContext>,
+    ) -> Self {
         Self {
             access,
             boundary,
             value,
+            comprehension_context,
         }
     }
 
@@ -42,8 +49,24 @@ impl BoundaryConstraint {
         &self.value
     }
 
-    pub fn into_parts(self) -> (Boundary, SymbolAccess, Expression) {
-        (self.boundary, self.access, self.value)
+    pub fn comprehension_context(&self) -> Option<&ComprehensionContext> {
+        self.comprehension_context.as_ref()
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        Boundary,
+        SymbolAccess,
+        Expression,
+        Option<ComprehensionContext>,
+    ) {
+        (
+            self.boundary,
+            self.access,
+            self.value,
+            self.comprehension_context,
+        )
     }
 }
 

--- a/parser/src/ast/boundary_constraints.rs
+++ b/parser/src/ast/boundary_constraints.rs
@@ -8,8 +8,7 @@ use std::fmt::Display;
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum BoundaryStmt {
-    Constraint(BoundaryConstraint),
-    ConstraintComprehension(BoundaryConstraint, ComprehensionContext),
+    Constraint(BoundaryConstraint, Option<ComprehensionContext>),
     VariableBinding(VariableBinding),
 }
 

--- a/parser/src/ast/integrity_constraints.rs
+++ b/parser/src/ast/integrity_constraints.rs
@@ -7,28 +7,71 @@ use super::{EvaluatorFunctionCall, Expression, VariableBinding};
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum IntegrityStmt {
-    Constraint(
-        ConstraintType,
-        Option<Expression>,
-        Option<ComprehensionContext>,
-    ),
+    Constraint(IntegrityConstraint),
     VariableBinding(VariableBinding),
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub enum ConstraintType {
-    Inline(IntegrityConstraint),
+pub struct IntegrityConstraint {
+    constraint_expr: ConstraintExpr,
+    comprehension_context: Option<ComprehensionContext>,
+    selectors: Option<Expression>,
+}
+
+impl IntegrityConstraint {
+    pub fn new(
+        constraint_expr: ConstraintExpr,
+        comprehension_context: Option<ComprehensionContext>,
+        selectors: Option<Expression>,
+    ) -> Self {
+        Self {
+            constraint_expr,
+            comprehension_context,
+            selectors,
+        }
+    }
+
+    pub fn constraint_expr(&self) -> &ConstraintExpr {
+        &self.constraint_expr
+    }
+
+    pub fn comprehension_context(&self) -> Option<&ComprehensionContext> {
+        self.comprehension_context.as_ref()
+    }
+
+    pub fn selectors(&self) -> Option<&Expression> {
+        self.selectors.as_ref()
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        ConstraintExpr,
+        Option<ComprehensionContext>,
+        Option<Expression>,
+    ) {
+        (
+            self.constraint_expr,
+            self.comprehension_context,
+            self.selectors,
+        )
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum ConstraintExpr {
+    Inline(InlineConstraintExpr),
     Evaluator(EvaluatorFunctionCall),
 }
 
 /// Stores the expression corresponding to the integrity constraint.
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct IntegrityConstraint {
+pub struct InlineConstraintExpr {
     lhs: Expression,
     rhs: Expression,
 }
 
-impl IntegrityConstraint {
+impl InlineConstraintExpr {
     /// Creates a new integrity constraint.
     pub fn new(lhs: Expression, rhs: Expression) -> Self {
         Self { lhs, rhs }

--- a/parser/src/ast/integrity_constraints.rs
+++ b/parser/src/ast/integrity_constraints.rs
@@ -7,8 +7,11 @@ use super::{EvaluatorFunctionCall, Expression, VariableBinding};
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum IntegrityStmt {
-    Constraint(ConstraintType, Option<Expression>),
-    ConstraintComprehension(ConstraintType, Option<Expression>, ComprehensionContext),
+    Constraint(
+        ConstraintType,
+        Option<Expression>,
+        Option<ComprehensionContext>,
+    ),
     VariableBinding(VariableBinding),
 }
 

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -206,7 +206,7 @@ BoundaryConstraints: Vec<BoundaryStmt> = {
     "boundary_constraints" ":" <boundary_stmts: BoundaryStmt+> =>? {
         // check if at least one boundary constraint is defined
         let boundary_constraints_exist = boundary_stmts.iter().any(|stmt| match stmt {
-            BoundaryStmt::Constraint(_) | BoundaryStmt::ConstraintComprehension(_, _) => true,
+            BoundaryStmt::Constraint(_, _) => true,
             _ => false,
         });
         if !boundary_constraints_exist {
@@ -226,10 +226,10 @@ BoundaryStmt: BoundaryStmt = {
     "let" <name: Identifier> "=" <boundary_variable_type: BoundaryVariableType> =>
         BoundaryStmt::VariableBinding(VariableBinding::new(name, boundary_variable_type)),
     "enf" <boundary_constraint: BoundaryConstraintExpr> =>
-        BoundaryStmt::Constraint(boundary_constraint),
+        BoundaryStmt::Constraint(boundary_constraint, None),
     "enf" <boundary_constraint: BoundaryConstraintExpr>
         <comprehension: ConstraintComprehension<BoundaryExpr>> =>
-        BoundaryStmt::ConstraintComprehension(boundary_constraint, comprehension),
+        BoundaryStmt::Constraint(boundary_constraint, Some(comprehension)),
 }
 
 BoundaryConstraintExpr: BoundaryConstraint = {
@@ -294,7 +294,7 @@ IntegrityStmts: Vec<IntegrityStmt> = {
         let integrity_stmts: Vec<IntegrityStmt> = integrity_stmts_groups.into_iter().flatten().collect();
         // check if at least one integrity constraint is defined
         let integrity_constraints_exist = integrity_stmts.iter().any(|stmt| match stmt {
-            IntegrityStmt::Constraint(_, _) | IntegrityStmt::ConstraintComprehension(_, _, _) => true,
+            IntegrityStmt::Constraint(_, _, _) => true,
             _ => false,
         });
         if !integrity_constraints_exist {
@@ -316,29 +316,23 @@ IntegrityStmtGroup: Vec<IntegrityStmt> = {
         vec![IntegrityStmt::VariableBinding(VariableBinding::new(name, integrity_variable_type))],
     "enf" <integrity_constraint: IntegrityConstraintExpr> => vec![integrity_constraint],
     "match" "enf" ":" <integrity_stmts: IntegrityConstraintExpr+> => integrity_stmts,
-    "enf" <integrity_constraint: IntegrityConstraintExpr>
-        <comprehension: ConstraintComprehension<IntegrityExpr>> => match integrity_constraint {
-            IntegrityStmt::Constraint(constraint_type, selectors) =>
-                return vec![IntegrityStmt::ConstraintComprehension(constraint_type, selectors, comprehension)],
-            _ => unreachable!() // this should never happen
-        }
 }
 
 IntegrityConstraintExpr: IntegrityStmt = {
-    <lhs: IntegrityExpr> "=" <rhs: IntegrityExpr> =>
-        IntegrityStmt::Constraint(ConstraintType::Inline(IntegrityConstraint::new(lhs, rhs)), None),
-    <evaluator_fn_call: EvaluatorFunctionCall> =>
-        IntegrityStmt::Constraint(ConstraintType::Evaluator(evaluator_fn_call), None),
-    <integrity_stmt_with_selector: IntegrityConstraintWithSelector> =>
-        integrity_stmt_with_selector,
+    <constraint: IntegrityConstraintExprValue>
+        <comprehension: ConstraintComprehension<IntegrityExpr>?>
+        <selectors: WithSelectors?> =>
+            IntegrityStmt::Constraint(constraint, selectors, comprehension),
 }
 
-IntegrityConstraintWithSelector: IntegrityStmt = {
-    <lhs: IntegrityExpr> "=" <rhs: IntegrityExpr> "when" <selectors: IntegrityExpr> =>
-        IntegrityStmt::Constraint(ConstraintType::Inline(IntegrityConstraint::new(lhs, rhs)),
-        Some(selectors)),
-    <evaluator_fn_call: EvaluatorFunctionCall> "when" <selectors: IntegrityExpr> =>
-        IntegrityStmt::Constraint(ConstraintType::Evaluator(evaluator_fn_call), Some(selectors)),
+IntegrityConstraintExprValue: ConstraintType = {
+    <lhs: IntegrityExpr> "=" <rhs: IntegrityExpr> =>
+        ConstraintType::Inline(IntegrityConstraint::new(lhs, rhs)),
+    <evaluator_fn_call: EvaluatorFunctionCall> => ConstraintType::Evaluator(evaluator_fn_call)
+}
+
+WithSelectors: Expression = {
+    "when" <selectors: IntegrityExpr> => selectors,
 }
 
 IntegrityVariableType: VariableValueExpr = {

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -1,10 +1,10 @@
 use crate::{
     ast::{
         boundary_constraints::{Boundary, BoundaryConstraint, BoundaryStmt},
-        integrity_constraints::{ConstraintType, IntegrityConstraint, IntegrityStmt},
+        integrity_constraints::{ConstraintExpr, IntegrityConstraint, IntegrityStmt},
         build_segment_bindings, build_trace_bindings, AccessType, ComprehensionContext, 
         ConstantBinding, ConstantValueExpr, Expression, EvaluatorFunction, EvaluatorFunctionCall, 
-        Identifier, Iterable, ListComprehension, ListFolding, ListFoldingValueExpr, PeriodicColumn, 
+        Identifier, InlineConstraintExpr, Iterable, ListComprehension, ListFolding, ListFoldingValueExpr, PeriodicColumn, 
         PublicInput, RandBinding, RandomValues, Range, Source, SourceSection, SymbolAccess, 
         TraceBinding, VariableBinding, VariableValueExpr, 
     }, error::{Error, ParseError::*}, lexer::Token
@@ -206,7 +206,7 @@ BoundaryConstraints: Vec<BoundaryStmt> = {
     "boundary_constraints" ":" <boundary_stmts: BoundaryStmt+> =>? {
         // check if at least one boundary constraint is defined
         let boundary_constraints_exist = boundary_stmts.iter().any(|stmt| match stmt {
-            BoundaryStmt::Constraint(_, _) => true,
+            BoundaryStmt::Constraint(_) => true,
             _ => false,
         });
         if !boundary_constraints_exist {
@@ -226,15 +226,13 @@ BoundaryStmt: BoundaryStmt = {
     "let" <name: Identifier> "=" <boundary_variable_type: BoundaryVariableType> =>
         BoundaryStmt::VariableBinding(VariableBinding::new(name, boundary_variable_type)),
     "enf" <boundary_constraint: BoundaryConstraintExpr> =>
-        BoundaryStmt::Constraint(boundary_constraint, None),
-    "enf" <boundary_constraint: BoundaryConstraintExpr>
-        <comprehension: ConstraintComprehension<BoundaryExpr>> =>
-        BoundaryStmt::Constraint(boundary_constraint, Some(comprehension)),
+        BoundaryStmt::Constraint(boundary_constraint),
 }
 
 BoundaryConstraintExpr: BoundaryConstraint = {
-    <column: SymbolAccess> "." <boundary: Boundary> "=" <value: BoundaryExpr> =>
-        BoundaryConstraint::new(column, boundary, value),
+    <column: SymbolAccess> "." <boundary: Boundary> "=" <value: BoundaryExpr>
+        <comprehension: ConstraintComprehension<BoundaryExpr>?> =>
+            BoundaryConstraint::new(column, boundary, value, comprehension),
 }
 
 BoundaryVariableType: VariableValueExpr = {
@@ -294,7 +292,7 @@ IntegrityStmts: Vec<IntegrityStmt> = {
         let integrity_stmts: Vec<IntegrityStmt> = integrity_stmts_groups.into_iter().flatten().collect();
         // check if at least one integrity constraint is defined
         let integrity_constraints_exist = integrity_stmts.iter().any(|stmt| match stmt {
-            IntegrityStmt::Constraint(_, _, _) => true,
+            IntegrityStmt::Constraint(_) => true,
             _ => false,
         });
         if !integrity_constraints_exist {
@@ -322,13 +320,13 @@ IntegrityConstraintExpr: IntegrityStmt = {
     <constraint: IntegrityConstraintExprValue>
         <comprehension: ConstraintComprehension<IntegrityExpr>?>
         <selectors: WithSelectors?> =>
-            IntegrityStmt::Constraint(constraint, selectors, comprehension),
+            IntegrityStmt::Constraint(IntegrityConstraint::new(constraint, comprehension, selectors)),
 }
 
-IntegrityConstraintExprValue: ConstraintType = {
+IntegrityConstraintExprValue: ConstraintExpr = {
     <lhs: IntegrityExpr> "=" <rhs: IntegrityExpr> =>
-        ConstraintType::Inline(IntegrityConstraint::new(lhs, rhs)),
-    <evaluator_fn_call: EvaluatorFunctionCall> => ConstraintType::Evaluator(evaluator_fn_call)
+        ConstraintExpr::Inline(InlineConstraintExpr::new(lhs, rhs)),
+    <evaluator_fn_call: EvaluatorFunctionCall> => ConstraintExpr::Evaluator(evaluator_fn_call)
 }
 
 WithSelectors: Expression = {

--- a/parser/src/parser/tests/arithmetic_ops.rs
+++ b/parser/src/parser/tests/arithmetic_ops.rs
@@ -1,8 +1,7 @@
 use super::{
-    build_parse_test, AccessType, Expression::*, Identifier, IntegrityConstraint, IntegrityStmt::*,
-    Source, SourceSection::*, SymbolAccess,
+    build_parse_test, AccessType, ConstraintExpr, Expression::*, Identifier, InlineConstraintExpr,
+    IntegrityConstraint, IntegrityStmt::*, Source, SourceSection::*, SymbolAccess,
 };
-use crate::ast::ConstraintType;
 
 // EXPRESSIONS
 // ================================================================================================
@@ -14,23 +13,25 @@ fn single_addition() {
     integrity_constraints:
         enf clk' + clk = 0";
     let expected = Source(vec![IntegrityConstraints(vec![Constraint(
-        ConstraintType::Inline(IntegrityConstraint::new(
-            Add(
-                Box::new(SymbolAccess(SymbolAccess::new(
-                    Identifier("clk".to_string()),
-                    AccessType::Default,
-                    1,
-                ))),
-                Box::new(SymbolAccess(SymbolAccess::new(
-                    Identifier("clk".to_string()),
-                    AccessType::Default,
-                    0,
-                ))),
-            ),
-            Const(0),
-        )),
-        None,
-        None,
+        IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
+                Add(
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("clk".to_string()),
+                        AccessType::Default,
+                        1,
+                    ))),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("clk".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
+                ),
+                Const(0),
+            )),
+            None,
+            None,
+        ),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -42,26 +43,28 @@ fn multi_addition() {
     integrity_constraints:
         enf clk' + clk + 2 = 0";
     let expected = Source(vec![IntegrityConstraints(vec![Constraint(
-        ConstraintType::Inline(IntegrityConstraint::new(
-            Add(
-                Box::new(Add(
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("clk".to_string()),
-                        AccessType::Default,
-                        1,
-                    ))),
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("clk".to_string()),
-                        AccessType::Default,
-                        0,
-                    ))),
-                )),
-                Box::new(Const(2)),
-            ),
-            Const(0),
-        )),
-        None,
-        None,
+        IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
+                Add(
+                    Box::new(Add(
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("clk".to_string()),
+                            AccessType::Default,
+                            1,
+                        ))),
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("clk".to_string()),
+                            AccessType::Default,
+                            0,
+                        ))),
+                    )),
+                    Box::new(Const(2)),
+                ),
+                Const(0),
+            )),
+            None,
+            None,
+        ),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -73,23 +76,25 @@ fn single_subtraction() {
     integrity_constraints:
         enf clk' - clk = 0";
     let expected = Source(vec![IntegrityConstraints(vec![Constraint(
-        ConstraintType::Inline(IntegrityConstraint::new(
-            Sub(
-                Box::new(SymbolAccess(SymbolAccess::new(
-                    Identifier("clk".to_string()),
-                    AccessType::Default,
-                    1,
-                ))),
-                Box::new(SymbolAccess(SymbolAccess::new(
-                    Identifier("clk".to_string()),
-                    AccessType::Default,
-                    0,
-                ))),
-            ),
-            Const(0),
-        )),
-        None,
-        None,
+        IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
+                Sub(
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("clk".to_string()),
+                        AccessType::Default,
+                        1,
+                    ))),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("clk".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
+                ),
+                Const(0),
+            )),
+            None,
+            None,
+        ),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -101,26 +106,28 @@ fn multi_subtraction() {
     integrity_constraints:
         enf clk' - clk - 1 = 0";
     let expected = Source(vec![IntegrityConstraints(vec![Constraint(
-        ConstraintType::Inline(IntegrityConstraint::new(
-            Sub(
-                Box::new(Sub(
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("clk".to_string()),
-                        AccessType::Default,
-                        1,
-                    ))),
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("clk".to_string()),
-                        AccessType::Default,
-                        0,
-                    ))),
-                )),
-                Box::new(Const(1)),
-            ),
-            Const(0),
-        )),
-        None,
-        None,
+        IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
+                Sub(
+                    Box::new(Sub(
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("clk".to_string()),
+                            AccessType::Default,
+                            1,
+                        ))),
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("clk".to_string()),
+                            AccessType::Default,
+                            0,
+                        ))),
+                    )),
+                    Box::new(Const(1)),
+                ),
+                Const(0),
+            )),
+            None,
+            None,
+        ),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -132,23 +139,25 @@ fn single_multiplication() {
     integrity_constraints:
         enf clk' * clk = 0";
     let expected = Source(vec![IntegrityConstraints(vec![Constraint(
-        ConstraintType::Inline(IntegrityConstraint::new(
-            Mul(
-                Box::new(SymbolAccess(SymbolAccess::new(
-                    Identifier("clk".to_string()),
-                    AccessType::Default,
-                    1,
-                ))),
-                Box::new(SymbolAccess(SymbolAccess::new(
-                    Identifier("clk".to_string()),
-                    AccessType::Default,
-                    0,
-                ))),
-            ),
-            Const(0),
-        )),
-        None,
-        None,
+        IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
+                Mul(
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("clk".to_string()),
+                        AccessType::Default,
+                        1,
+                    ))),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("clk".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
+                ),
+                Const(0),
+            )),
+            None,
+            None,
+        ),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -160,26 +169,28 @@ fn multi_multiplication() {
     integrity_constraints:
         enf clk' * clk * 2 = 0";
     let expected = Source(vec![IntegrityConstraints(vec![Constraint(
-        ConstraintType::Inline(IntegrityConstraint::new(
-            Mul(
-                Box::new(Mul(
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("clk".to_string()),
-                        AccessType::Default,
-                        1,
-                    ))),
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("clk".to_string()),
-                        AccessType::Default,
-                        0,
-                    ))),
-                )),
-                Box::new(Const(2)),
-            ),
-            Const(0),
-        )),
-        None,
-        None,
+        IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
+                Mul(
+                    Box::new(Mul(
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("clk".to_string()),
+                            AccessType::Default,
+                            1,
+                        ))),
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("clk".to_string()),
+                            AccessType::Default,
+                            0,
+                        ))),
+                    )),
+                    Box::new(Const(2)),
+                ),
+                Const(0),
+            )),
+            None,
+            None,
+        ),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -191,12 +202,14 @@ fn unit_with_parens() {
     integrity_constraints:
         enf (2) + 1 = 3";
     let expected = Source(vec![IntegrityConstraints(vec![Constraint(
-        ConstraintType::Inline(IntegrityConstraint::new(
-            Add(Box::new(Const(2)), Box::new(Const(1))),
-            Const(3),
-        )),
-        None,
-        None,
+        IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
+                Add(Box::new(Const(2)), Box::new(Const(1))),
+                Const(3),
+            )),
+            None,
+            None,
+        ),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -208,26 +221,28 @@ fn ops_with_parens() {
     integrity_constraints:
         enf (clk' + clk) * 2 = 4";
     let expected = Source(vec![IntegrityConstraints(vec![Constraint(
-        ConstraintType::Inline(IntegrityConstraint::new(
-            Mul(
-                Box::new(Add(
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("clk".to_string()),
-                        AccessType::Default,
-                        1,
-                    ))),
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("clk".to_string()),
-                        AccessType::Default,
-                        0,
-                    ))),
-                )),
-                Box::new(Const(2)),
-            ),
-            Const(4),
-        )),
-        None,
-        None,
+        IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
+                Mul(
+                    Box::new(Add(
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("clk".to_string()),
+                            AccessType::Default,
+                            1,
+                        ))),
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("clk".to_string()),
+                            AccessType::Default,
+                            0,
+                        ))),
+                    )),
+                    Box::new(Const(2)),
+                ),
+                Const(4),
+            )),
+            None,
+            None,
+        ),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -239,19 +254,21 @@ fn const_exponentiation() {
     integrity_constraints:
         enf clk'^2 = 1";
     let expected = Source(vec![IntegrityConstraints(vec![Constraint(
-        ConstraintType::Inline(IntegrityConstraint::new(
-            Exp(
-                Box::new(SymbolAccess(SymbolAccess::new(
-                    Identifier("clk".to_string()),
-                    AccessType::Default,
-                    1,
-                ))),
-                Box::new(Const(2)),
-            ),
-            Const(1),
-        )),
-        None,
-        None,
+        IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
+                Exp(
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("clk".to_string()),
+                        AccessType::Default,
+                        1,
+                    ))),
+                    Box::new(Const(2)),
+                ),
+                Const(1),
+            )),
+            None,
+            None,
+        ),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -263,26 +280,28 @@ fn non_const_exponentiation() {
     integrity_constraints:
         enf clk'^(clk + 2) = 1";
     let expected = Source(vec![IntegrityConstraints(vec![Constraint(
-        ConstraintType::Inline(IntegrityConstraint::new(
-            Exp(
-                Box::new(SymbolAccess(SymbolAccess::new(
-                    Identifier("clk".to_string()),
-                    AccessType::Default,
-                    1,
-                ))),
-                Box::new(Add(
+        IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
+                Exp(
                     Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
                         AccessType::Default,
-                        0,
+                        1,
                     ))),
-                    Box::new(Const(2)),
-                )),
-            ),
-            Const(1),
-        )),
-        None,
-        None,
+                    Box::new(Add(
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("clk".to_string()),
+                            AccessType::Default,
+                            0,
+                        ))),
+                        Box::new(Const(2)),
+                    )),
+                ),
+                Const(1),
+            )),
+            None,
+            None,
+        ),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -312,29 +331,31 @@ fn multi_arithmetic_ops_same_precedence() {
     integrity_constraints:
         enf clk' - clk - 2 + 1 = 0";
     let expected = Source(vec![IntegrityConstraints(vec![Constraint(
-        ConstraintType::Inline(IntegrityConstraint::new(
-            Add(
-                Box::new(Sub(
+        IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
+                Add(
                     Box::new(Sub(
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("clk".to_string()),
-                            AccessType::Default,
-                            1,
-                        ))),
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("clk".to_string()),
-                            AccessType::Default,
-                            0,
-                        ))),
+                        Box::new(Sub(
+                            Box::new(SymbolAccess(SymbolAccess::new(
+                                Identifier("clk".to_string()),
+                                AccessType::Default,
+                                1,
+                            ))),
+                            Box::new(SymbolAccess(SymbolAccess::new(
+                                Identifier("clk".to_string()),
+                                AccessType::Default,
+                                0,
+                            ))),
+                        )),
+                        Box::new(Const(2)),
                     )),
-                    Box::new(Const(2)),
-                )),
-                Box::new(Const(1)),
-            ),
-            Const(0),
-        )),
-        None,
-        None,
+                    Box::new(Const(1)),
+                ),
+                Const(0),
+            )),
+            None,
+            None,
+        ),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -351,32 +372,34 @@ fn multi_arithmetic_ops_different_precedence() {
     // 3. Addition/Subtraction
     // These operations are evaluated in the order of decreasing precedence.
     let expected = Source(vec![IntegrityConstraints(vec![Constraint(
-        ConstraintType::Inline(IntegrityConstraint::new(
-            Sub(
-                Box::new(Sub(
-                    Box::new(Exp(
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("clk".to_string()),
-                            AccessType::Default,
-                            1,
-                        ))),
-                        Box::new(Const(2)),
+        IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
+                Sub(
+                    Box::new(Sub(
+                        Box::new(Exp(
+                            Box::new(SymbolAccess(SymbolAccess::new(
+                                Identifier("clk".to_string()),
+                                AccessType::Default,
+                                1,
+                            ))),
+                            Box::new(Const(2)),
+                        )),
+                        Box::new(Mul(
+                            Box::new(SymbolAccess(SymbolAccess::new(
+                                Identifier("clk".to_string()),
+                                AccessType::Default,
+                                0,
+                            ))),
+                            Box::new(Const(2)),
+                        )),
                     )),
-                    Box::new(Mul(
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("clk".to_string()),
-                            AccessType::Default,
-                            0,
-                        ))),
-                        Box::new(Const(2)),
-                    )),
-                )),
-                Box::new(Const(1)),
-            ),
-            Const(0),
-        )),
-        None,
-        None,
+                    Box::new(Const(1)),
+                ),
+                Const(0),
+            )),
+            None,
+            None,
+        ),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -394,29 +417,31 @@ fn multi_arithmetic_ops_different_precedence_w_parens() {
     // 4. Addition/Subtraction
     // These operations are evaluated in the order of decreasing precedence.
     let expected = Source(vec![IntegrityConstraints(vec![Constraint(
-        ConstraintType::Inline(IntegrityConstraint::new(
-            Sub(
-                Box::new(SymbolAccess(SymbolAccess::new(
-                    Identifier("clk".to_string()),
-                    AccessType::Default,
-                    1,
-                ))),
-                Box::new(Mul(
-                    Box::new(Exp(
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("clk".to_string()),
-                            AccessType::Default,
-                            0,
-                        ))),
-                        Box::new(Const(2)),
+        IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
+                Sub(
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("clk".to_string()),
+                        AccessType::Default,
+                        1,
+                    ))),
+                    Box::new(Mul(
+                        Box::new(Exp(
+                            Box::new(SymbolAccess(SymbolAccess::new(
+                                Identifier("clk".to_string()),
+                                AccessType::Default,
+                                0,
+                            ))),
+                            Box::new(Const(2)),
+                        )),
+                        Box::new(Sub(Box::new(Const(2)), Box::new(Const(1)))),
                     )),
-                    Box::new(Sub(Box::new(Const(2)), Box::new(Const(1)))),
-                )),
-            ),
-            Const(0),
-        )),
-        None,
-        None,
+                ),
+                Const(0),
+            )),
+            None,
+            None,
+        ),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }

--- a/parser/src/parser/tests/arithmetic_ops.rs
+++ b/parser/src/parser/tests/arithmetic_ops.rs
@@ -30,6 +30,7 @@ fn single_addition() {
             Const(0),
         )),
         None,
+        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -60,6 +61,7 @@ fn multi_addition() {
             Const(0),
         )),
         None,
+        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -86,6 +88,7 @@ fn single_subtraction() {
             ),
             Const(0),
         )),
+        None,
         None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
@@ -117,6 +120,7 @@ fn multi_subtraction() {
             Const(0),
         )),
         None,
+        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -143,6 +147,7 @@ fn single_multiplication() {
             ),
             Const(0),
         )),
+        None,
         None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
@@ -174,6 +179,7 @@ fn multi_multiplication() {
             Const(0),
         )),
         None,
+        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -189,6 +195,7 @@ fn unit_with_parens() {
             Add(Box::new(Const(2)), Box::new(Const(1))),
             Const(3),
         )),
+        None,
         None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
@@ -220,6 +227,7 @@ fn ops_with_parens() {
             Const(4),
         )),
         None,
+        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -242,6 +250,7 @@ fn const_exponentiation() {
             ),
             Const(1),
         )),
+        None,
         None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
@@ -272,6 +281,7 @@ fn non_const_exponentiation() {
             ),
             Const(1),
         )),
+        None,
         None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
@@ -324,6 +334,7 @@ fn multi_arithmetic_ops_same_precedence() {
             Const(0),
         )),
         None,
+        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -365,6 +376,7 @@ fn multi_arithmetic_ops_different_precedence() {
             Const(0),
         )),
         None,
+        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -403,6 +415,7 @@ fn multi_arithmetic_ops_different_precedence_w_parens() {
             ),
             Const(0),
         )),
+        None,
         None,
     )])]);
     build_parse_test!(source).expect_ast(expected);

--- a/parser/src/parser/tests/boundary_constraints.rs
+++ b/parser/src/parser/tests/boundary_constraints.rs
@@ -24,6 +24,7 @@ fn boundary_constraint_at_first() {
             Boundary::First,
             Const(0),
         ),
+        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -39,6 +40,7 @@ fn boundary_constraint_at_last() {
             Boundary::Last,
             Const(15),
         ),
+        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -58,16 +60,22 @@ fn multiple_boundary_constraints() {
         enf clk.first = 0
         enf clk.last = 1";
     let expected = Source(vec![SourceSection::BoundaryConstraints(vec![
-        Constraint(BoundaryConstraint::new(
-            SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
-            Boundary::First,
-            Const(0),
-        )),
-        Constraint(BoundaryConstraint::new(
-            SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
-            Boundary::Last,
-            Const(1),
-        )),
+        Constraint(
+            BoundaryConstraint::new(
+                SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
+                Boundary::First,
+                Const(0),
+            ),
+            None,
+        ),
+        Constraint(
+            BoundaryConstraint::new(
+                SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
+                Boundary::Last,
+                Const(1),
+            ),
+            None,
+        ),
     ])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -81,15 +89,18 @@ fn boundary_constraint_with_pub_input() {
         enf clk.first = a[0]";
     let expected = Source(vec![
         SourceSection::PublicInputs(vec![PublicInput::new(Identifier("a".to_string()), 16)]),
-        SourceSection::BoundaryConstraints(vec![Constraint(BoundaryConstraint::new(
-            SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
-            Boundary::First,
-            SymbolAccess(SymbolAccess::new(
-                Identifier("a".to_string()),
-                AccessType::Vector(0),
-                0,
-            )),
-        ))]),
+        SourceSection::BoundaryConstraints(vec![Constraint(
+            BoundaryConstraint::new(
+                SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
+                Boundary::First,
+                SymbolAccess(SymbolAccess::new(
+                    Identifier("a".to_string()),
+                    AccessType::Vector(0),
+                    0,
+                )),
+            ),
+            None,
+        )]),
     ]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -115,6 +126,7 @@ fn boundary_constraint_with_expr() {
                 Box::new(Const(6)),
             ),
         ),
+        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -137,29 +149,32 @@ fn boundary_constraint_with_const() {
             Identifier("C".to_string()),
             Matrix(vec![vec![0, 1], vec![1, 0]]),
         )),
-        SourceSection::BoundaryConstraints(vec![Constraint(BoundaryConstraint::new(
-            SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
-            Boundary::First,
-            Sub(
-                Box::new(Add(
+        SourceSection::BoundaryConstraints(vec![Constraint(
+            BoundaryConstraint::new(
+                SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
+                Boundary::First,
+                Sub(
+                    Box::new(Add(
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("A".to_string()),
+                            AccessType::Default,
+                            0,
+                        ))),
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("B".to_string()),
+                            AccessType::Vector(1),
+                            0,
+                        ))),
+                    )),
                     Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("A".to_string()),
-                        AccessType::Default,
+                        Identifier("C".to_string()),
+                        AccessType::Matrix(0, 1),
                         0,
                     ))),
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("B".to_string()),
-                        AccessType::Vector(1),
-                        0,
-                    ))),
-                )),
-                Box::new(SymbolAccess(SymbolAccess::new(
-                    Identifier("C".to_string()),
-                    AccessType::Matrix(0, 1),
-                    0,
-                ))),
+                ),
             ),
-        ))]),
+            None,
+        )]),
     ]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -230,21 +245,24 @@ fn boundary_constraint_with_variables() {
                 ],
             ]),
         )),
-        Constraint(BoundaryConstraint::new(
-            SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
-            Boundary::First,
-            Add(
-                Box::new(Add(
-                    Box::new(Const(5)),
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("a".to_string()),
-                        AccessType::Vector(3),
-                        0,
-                    ))),
-                )),
-                Box::new(Const(6)),
+        Constraint(
+            BoundaryConstraint::new(
+                SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
+                Boundary::First,
+                Add(
+                    Box::new(Add(
+                        Box::new(Const(5)),
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("a".to_string()),
+                            AccessType::Vector(3),
+                            0,
+                        ))),
+                    )),
+                    Box::new(Const(6)),
+                ),
             ),
-        )),
+            None,
+        ),
     ])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -268,16 +286,16 @@ fn bc_comprehension_one_iterable_identifier() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 6),
         ]]),
-        SourceSection::BoundaryConstraints(vec![ConstraintComprehension(
+        SourceSection::BoundaryConstraints(vec![Constraint(
             BoundaryConstraint::new(
                 SymbolAccess::new(Identifier("x".to_string()), AccessType::Default, 0),
                 Boundary::First,
                 Const(0),
             ),
-            vec![(
+            Some(vec![(
                 Identifier("x".to_string()),
                 Iterable::Identifier(Identifier("c".to_string())),
-            )],
+            )]),
         )]),
     ]);
 
@@ -300,16 +318,16 @@ fn bc_comprehension_one_iterable_range() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 6),
         ]]),
-        SourceSection::BoundaryConstraints(vec![ConstraintComprehension(
+        SourceSection::BoundaryConstraints(vec![Constraint(
             BoundaryConstraint::new(
                 SymbolAccess::new(Identifier("x".to_string()), AccessType::Default, 0),
                 Boundary::First,
                 Const(0),
             ),
-            vec![(
+            Some(vec![(
                 Identifier("x".to_string()),
                 Iterable::Range(Range::new(0, 4)),
-            )],
+            )]),
         )]),
     ]);
 
@@ -332,16 +350,16 @@ fn bc_comprehension_one_iterable_slice() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 6),
         ]]),
-        SourceSection::BoundaryConstraints(vec![ConstraintComprehension(
+        SourceSection::BoundaryConstraints(vec![Constraint(
             BoundaryConstraint::new(
                 SymbolAccess::new(Identifier("x".to_string()), AccessType::Default, 0),
                 Boundary::First,
                 Const(0),
             ),
-            vec![(
+            Some(vec![(
                 Identifier("x".to_string()),
                 Iterable::Slice(Identifier("c".to_string()), Range::new(1, 3)),
-            )],
+            )]),
         )]),
     ]);
     build_parse_test!(source).expect_ast(expected);
@@ -364,7 +382,7 @@ fn bc_comprehension_two_iterable_identifiers() {
             TraceBinding::new(Identifier("d".to_string()), 0, 6, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 10),
         ]]),
-        SourceSection::BoundaryConstraints(vec![ConstraintComprehension(
+        SourceSection::BoundaryConstraints(vec![Constraint(
             BoundaryConstraint::new(
                 SymbolAccess::new(Identifier("x".to_string()), AccessType::Default, 0),
                 Boundary::First,
@@ -374,7 +392,7 @@ fn bc_comprehension_two_iterable_identifiers() {
                     0,
                 )),
             ),
-            vec![
+            Some(vec![
                 (
                     Identifier("x".to_string()),
                     Iterable::Identifier(Identifier("c".to_string())),
@@ -383,7 +401,7 @@ fn bc_comprehension_two_iterable_identifiers() {
                     Identifier("y".to_string()),
                     Iterable::Identifier(Identifier("d".to_string())),
                 ),
-            ],
+            ]),
         )]),
     ]);
 

--- a/parser/src/parser/tests/boundary_constraints.rs
+++ b/parser/src/parser/tests/boundary_constraints.rs
@@ -23,8 +23,8 @@ fn boundary_constraint_at_first() {
             SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
             Boundary::First,
             Const(0),
+            None,
         ),
-        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -39,8 +39,8 @@ fn boundary_constraint_at_last() {
             SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
             Boundary::Last,
             Const(15),
+            None,
         ),
-        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -60,22 +60,18 @@ fn multiple_boundary_constraints() {
         enf clk.first = 0
         enf clk.last = 1";
     let expected = Source(vec![SourceSection::BoundaryConstraints(vec![
-        Constraint(
-            BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                Const(0),
-            ),
+        Constraint(BoundaryConstraint::new(
+            SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
+            Boundary::First,
+            Const(0),
             None,
-        ),
-        Constraint(
-            BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
-                Boundary::Last,
-                Const(1),
-            ),
+        )),
+        Constraint(BoundaryConstraint::new(
+            SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
+            Boundary::Last,
+            Const(1),
             None,
-        ),
+        )),
     ])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -89,18 +85,16 @@ fn boundary_constraint_with_pub_input() {
         enf clk.first = a[0]";
     let expected = Source(vec![
         SourceSection::PublicInputs(vec![PublicInput::new(Identifier("a".to_string()), 16)]),
-        SourceSection::BoundaryConstraints(vec![Constraint(
-            BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                SymbolAccess(SymbolAccess::new(
-                    Identifier("a".to_string()),
-                    AccessType::Vector(0),
-                    0,
-                )),
-            ),
+        SourceSection::BoundaryConstraints(vec![Constraint(BoundaryConstraint::new(
+            SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
+            Boundary::First,
+            SymbolAccess(SymbolAccess::new(
+                Identifier("a".to_string()),
+                AccessType::Vector(0),
+                0,
+            )),
             None,
-        )]),
+        ))]),
     ]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -125,8 +119,8 @@ fn boundary_constraint_with_expr() {
                 )),
                 Box::new(Const(6)),
             ),
+            None,
         ),
-        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -149,32 +143,30 @@ fn boundary_constraint_with_const() {
             Identifier("C".to_string()),
             Matrix(vec![vec![0, 1], vec![1, 0]]),
         )),
-        SourceSection::BoundaryConstraints(vec![Constraint(
-            BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                Sub(
-                    Box::new(Add(
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("A".to_string()),
-                            AccessType::Default,
-                            0,
-                        ))),
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("B".to_string()),
-                            AccessType::Vector(1),
-                            0,
-                        ))),
-                    )),
+        SourceSection::BoundaryConstraints(vec![Constraint(BoundaryConstraint::new(
+            SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
+            Boundary::First,
+            Sub(
+                Box::new(Add(
                     Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("C".to_string()),
-                        AccessType::Matrix(0, 1),
+                        Identifier("A".to_string()),
+                        AccessType::Default,
                         0,
                     ))),
-                ),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("B".to_string()),
+                        AccessType::Vector(1),
+                        0,
+                    ))),
+                )),
+                Box::new(SymbolAccess(SymbolAccess::new(
+                    Identifier("C".to_string()),
+                    AccessType::Matrix(0, 1),
+                    0,
+                ))),
             ),
             None,
-        )]),
+        ))]),
     ]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -245,24 +237,22 @@ fn boundary_constraint_with_variables() {
                 ],
             ]),
         )),
-        Constraint(
-            BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                Add(
-                    Box::new(Add(
-                        Box::new(Const(5)),
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("a".to_string()),
-                            AccessType::Vector(3),
-                            0,
-                        ))),
-                    )),
-                    Box::new(Const(6)),
-                ),
+        Constraint(BoundaryConstraint::new(
+            SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
+            Boundary::First,
+            Add(
+                Box::new(Add(
+                    Box::new(Const(5)),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("a".to_string()),
+                        AccessType::Vector(3),
+                        0,
+                    ))),
+                )),
+                Box::new(Const(6)),
             ),
             None,
-        ),
+        )),
     ])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -286,17 +276,15 @@ fn bc_comprehension_one_iterable_identifier() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 6),
         ]]),
-        SourceSection::BoundaryConstraints(vec![Constraint(
-            BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("x".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                Const(0),
-            ),
+        SourceSection::BoundaryConstraints(vec![Constraint(BoundaryConstraint::new(
+            SymbolAccess::new(Identifier("x".to_string()), AccessType::Default, 0),
+            Boundary::First,
+            Const(0),
             Some(vec![(
                 Identifier("x".to_string()),
                 Iterable::Identifier(Identifier("c".to_string())),
             )]),
-        )]),
+        ))]),
     ]);
 
     build_parse_test!(source).expect_ast(expected);
@@ -318,17 +306,15 @@ fn bc_comprehension_one_iterable_range() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 6),
         ]]),
-        SourceSection::BoundaryConstraints(vec![Constraint(
-            BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("x".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                Const(0),
-            ),
+        SourceSection::BoundaryConstraints(vec![Constraint(BoundaryConstraint::new(
+            SymbolAccess::new(Identifier("x".to_string()), AccessType::Default, 0),
+            Boundary::First,
+            Const(0),
             Some(vec![(
                 Identifier("x".to_string()),
                 Iterable::Range(Range::new(0, 4)),
             )]),
-        )]),
+        ))]),
     ]);
 
     build_parse_test!(source).expect_ast(expected);
@@ -350,17 +336,15 @@ fn bc_comprehension_one_iterable_slice() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 6),
         ]]),
-        SourceSection::BoundaryConstraints(vec![Constraint(
-            BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("x".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                Const(0),
-            ),
+        SourceSection::BoundaryConstraints(vec![Constraint(BoundaryConstraint::new(
+            SymbolAccess::new(Identifier("x".to_string()), AccessType::Default, 0),
+            Boundary::First,
+            Const(0),
             Some(vec![(
                 Identifier("x".to_string()),
                 Iterable::Slice(Identifier("c".to_string()), Range::new(1, 3)),
             )]),
-        )]),
+        ))]),
     ]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -382,16 +366,14 @@ fn bc_comprehension_two_iterable_identifiers() {
             TraceBinding::new(Identifier("d".to_string()), 0, 6, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 10),
         ]]),
-        SourceSection::BoundaryConstraints(vec![Constraint(
-            BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("x".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                SymbolAccess(SymbolAccess::new(
-                    Identifier("y".to_string()),
-                    AccessType::Default,
-                    0,
-                )),
-            ),
+        SourceSection::BoundaryConstraints(vec![Constraint(BoundaryConstraint::new(
+            SymbolAccess::new(Identifier("x".to_string()), AccessType::Default, 0),
+            Boundary::First,
+            SymbolAccess(SymbolAccess::new(
+                Identifier("y".to_string()),
+                AccessType::Default,
+                0,
+            )),
             Some(vec![
                 (
                     Identifier("x".to_string()),
@@ -402,7 +384,7 @@ fn bc_comprehension_two_iterable_identifiers() {
                     Iterable::Identifier(Identifier("d".to_string())),
                 ),
             ]),
-        )]),
+        ))]),
     ]);
 
     build_parse_test!(source).expect_ast(expected);

--- a/parser/src/parser/tests/evaluators.rs
+++ b/parser/src/parser/tests/evaluators.rs
@@ -41,6 +41,7 @@ fn ev_fn_main_cols() {
                     ),
                 )),
                 None,
+                None,
             )],
         ),
     )]);
@@ -75,6 +76,7 @@ fn ev_fn_aux_cols() {
                         Box::new(Const(1)),
                     ),
                 )),
+                None,
                 None,
             )],
         ),
@@ -133,6 +135,7 @@ fn ev_fn_main_and_aux_cols() {
                         ),
                     )),
                     None,
+                    None,
                 ),
                 Constraint(
                     ConstraintType::Inline(IntegrityConstraint::new(
@@ -154,6 +157,7 @@ fn ev_fn_main_and_aux_cols() {
                             ))),
                         ),
                     )),
+                    None,
                     None,
                 ),
             ],
@@ -177,6 +181,7 @@ fn ev_fn_call_simple() {
                 0,
             )]],
         )),
+        None,
         None,
     )])]);
 
@@ -202,6 +207,7 @@ fn ev_fn_call() {
                 ),
             ]],
         )),
+        None,
         None,
     )])]);
 
@@ -233,6 +239,7 @@ fn ev_fn_call_inside_ev_fn() {
                         0,
                     )]],
                 )),
+                None,
                 None,
             )],
         ),
@@ -268,6 +275,7 @@ fn ev_fn_call_with_more_than_two_args() {
                 )],
             ],
         )),
+        None,
         None,
     )])]);
 

--- a/parser/src/parser/tests/integrity_constraints.rs
+++ b/parser/src/parser/tests/integrity_constraints.rs
@@ -4,9 +4,9 @@ use super::{
 };
 use crate::{
     ast::{
-        AccessType, ConstantBinding, ConstantValueExpr::*, ConstraintType, EvaluatorFunction,
-        EvaluatorFunctionCall, Expression::*, IntegrityStmt::*, SymbolAccess, VariableBinding,
-        VariableValueExpr,
+        AccessType, ConstantBinding, ConstantValueExpr::*, ConstraintExpr, EvaluatorFunction,
+        EvaluatorFunctionCall, Expression::*, InlineConstraintExpr, IntegrityStmt::*, SymbolAccess,
+        VariableBinding, VariableValueExpr,
     },
     error::{Error, ParseError},
 };
@@ -20,23 +20,25 @@ fn integrity_constraints() {
     integrity_constraints:
         enf clk' = clk + 1";
     let expected = Source(vec![SourceSection::IntegrityConstraints(vec![Constraint(
-        ConstraintType::Inline(IntegrityConstraint::new(
-            SymbolAccess(SymbolAccess::new(
-                Identifier("clk".to_string()),
-                AccessType::Default,
-                1,
-            )),
-            Add(
-                Box::new(SymbolAccess(SymbolAccess::new(
+        IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
+                SymbolAccess(SymbolAccess::new(
                     Identifier("clk".to_string()),
                     AccessType::Default,
-                    0,
-                ))),
-                Box::new(Const(1)),
-            ),
-        )),
-        None,
-        None,
+                    1,
+                )),
+                Add(
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("clk".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
+                    Box::new(Const(1)),
+                ),
+            )),
+            None,
+            None,
+        ),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -55,8 +57,8 @@ fn multiple_integrity_constraints() {
         enf clk' = clk + 1
         enf clk' - clk = 1";
     let expected = Source(vec![SourceSection::IntegrityConstraints(vec![
-        Constraint(
-            ConstraintType::Inline(IntegrityConstraint::new(
+        Constraint(IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
                 SymbolAccess(SymbolAccess::new(
                     Identifier("clk".to_string()),
                     AccessType::Default,
@@ -73,9 +75,9 @@ fn multiple_integrity_constraints() {
             )),
             None,
             None,
-        ),
-        Constraint(
-            ConstraintType::Inline(IntegrityConstraint::new(
+        )),
+        Constraint(IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
                 Sub(
                     Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
@@ -92,7 +94,7 @@ fn multiple_integrity_constraints() {
             )),
             None,
             None,
-        ),
+        )),
     ])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -103,23 +105,25 @@ fn integrity_constraint_with_periodic_col() {
     integrity_constraints:
         enf k0 + b = 0";
     let expected = Source(vec![SourceSection::IntegrityConstraints(vec![Constraint(
-        ConstraintType::Inline(IntegrityConstraint::new(
-            Add(
-                Box::new(SymbolAccess(SymbolAccess::new(
-                    Identifier("k0".to_string()),
-                    AccessType::Default,
-                    0,
-                ))),
-                Box::new(SymbolAccess(SymbolAccess::new(
-                    Identifier("b".to_string()),
-                    AccessType::Default,
-                    0,
-                ))),
-            ),
-            Const(0),
-        )),
-        None,
-        None,
+        IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
+                Add(
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("k0".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("b".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
+                ),
+                Const(0),
+            )),
+            None,
+            None,
+        ),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -130,23 +134,25 @@ fn integrity_constraint_with_random_value() {
     integrity_constraints:
         enf a + $rand[1] = 0";
     let expected = Source(vec![SourceSection::IntegrityConstraints(vec![Constraint(
-        ConstraintType::Inline(IntegrityConstraint::new(
-            Add(
-                Box::new(SymbolAccess(SymbolAccess::new(
-                    Identifier("a".to_string()),
-                    AccessType::Default,
-                    0,
-                ))),
-                Box::new(SymbolAccess(SymbolAccess::new(
-                    Identifier("$rand".to_string()),
-                    AccessType::Vector(1),
-                    0,
-                ))),
-            ),
-            Const(0),
-        )),
-        None,
-        None,
+        IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
+                Add(
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("a".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("$rand".to_string()),
+                        AccessType::Vector(1),
+                        0,
+                    ))),
+                ),
+                Const(0),
+            )),
+            None,
+            None,
+        ),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -169,8 +175,8 @@ fn integrity_constraint_with_constants() {
             Identifier("C".to_string()),
             Matrix(vec![vec![0, 1], vec![1, 0]]),
         )),
-        SourceSection::IntegrityConstraints(vec![Constraint(
-            ConstraintType::Inline(IntegrityConstraint::new(
+        SourceSection::IntegrityConstraints(vec![Constraint(IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
                 Add(
                     Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
@@ -198,7 +204,7 @@ fn integrity_constraint_with_constants() {
             )),
             None,
             None,
-        )]),
+        ))]),
     ]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -269,8 +275,8 @@ fn integrity_constraint_with_variables() {
                 ],
             ]),
         )),
-        Constraint(
-            ConstraintType::Inline(IntegrityConstraint::new(
+        Constraint(IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
                 Add(
                     Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
@@ -298,7 +304,7 @@ fn integrity_constraint_with_variables() {
             )),
             None,
             None,
-        ),
+        )),
     ])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -310,8 +316,8 @@ fn integrity_constraint_with_indexed_trace_access() {
         enf $main[0]' = $main[1] + 1
         enf $aux[0]' - $aux[1] = 1";
     let expected = Source(vec![SourceSection::IntegrityConstraints(vec![
-        Constraint(
-            ConstraintType::Inline(IntegrityConstraint::new(
+        Constraint(IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
                 SymbolAccess(SymbolAccess::new(
                     Identifier("$main".to_string()),
                     AccessType::Vector(0),
@@ -328,9 +334,9 @@ fn integrity_constraint_with_indexed_trace_access() {
             )),
             None,
             None,
-        ),
-        Constraint(
-            ConstraintType::Inline(IntegrityConstraint::new(
+        )),
+        Constraint(IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
                 Sub(
                     Box::new(SymbolAccess(SymbolAccess::new(
                         Identifier("$aux".to_string()),
@@ -347,7 +353,7 @@ fn integrity_constraint_with_indexed_trace_access() {
             )),
             None,
             None,
-        ),
+        )),
     ])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -371,8 +377,8 @@ fn ic_comprehension_one_iterable_identifier() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 6),
         ]]),
-        SourceSection::IntegrityConstraints(vec![Constraint(
-            ConstraintType::Inline(IntegrityConstraint::new(
+        SourceSection::IntegrityConstraints(vec![Constraint(IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
                 SymbolAccess(SymbolAccess::new(
                     Identifier("x".to_string()),
                     AccessType::Default,
@@ -391,12 +397,12 @@ fn ic_comprehension_one_iterable_identifier() {
                     ))),
                 ),
             )),
-            None,
             Some(vec![(
                 Identifier("x".to_string()),
                 Iterable::Identifier(Identifier("c".to_string())),
             )]),
-        )]),
+            None,
+        ))]),
     ]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -417,8 +423,8 @@ fn ic_comprehension_one_iterable_range() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 6),
         ]]),
-        SourceSection::IntegrityConstraints(vec![Constraint(
-            ConstraintType::Inline(IntegrityConstraint::new(
+        SourceSection::IntegrityConstraints(vec![Constraint(IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
                 SymbolAccess(SymbolAccess::new(
                     Identifier("x".to_string()),
                     AccessType::Default,
@@ -437,12 +443,12 @@ fn ic_comprehension_one_iterable_range() {
                     ))),
                 ),
             )),
-            None,
             Some(vec![(
                 Identifier("x".to_string()),
                 Iterable::Range(Range::new(1, 4)),
             )]),
-        )]),
+            None,
+        ))]),
     ]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -464,8 +470,8 @@ fn ic_comprehension_with_selectors() {
             TraceBinding::new(Identifier("c".to_string()), 0, 4, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 8),
         ]]),
-        SourceSection::IntegrityConstraints(vec![Constraint(
-            ConstraintType::Inline(IntegrityConstraint::new(
+        SourceSection::IntegrityConstraints(vec![Constraint(IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
                 SymbolAccess(SymbolAccess::new(
                     Identifier("x".to_string()),
                     AccessType::Default,
@@ -484,6 +490,10 @@ fn ic_comprehension_with_selectors() {
                     ))),
                 ),
             )),
+            Some(vec![(
+                Identifier("x".to_string()),
+                Iterable::Identifier(Identifier("c".to_string())),
+            )]),
             Some(Mul(
                 Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("s".to_string()),
@@ -496,11 +506,7 @@ fn ic_comprehension_with_selectors() {
                     0,
                 ))),
             )),
-            Some(vec![(
-                Identifier("x".to_string()),
-                Iterable::Identifier(Identifier("c".to_string())),
-            )]),
-        )]),
+        ))]),
     ]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -526,8 +532,8 @@ fn ic_comprehension_with_evaluator_call() {
                 0,
                 1,
             )]],
-            vec![Constraint(
-                ConstraintType::Inline(IntegrityConstraint::new(
+            vec![Constraint(IntegrityConstraint::new(
+                ConstraintExpr::Inline(InlineConstraintExpr::new(
                     Exp(
                         Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
@@ -544,7 +550,7 @@ fn ic_comprehension_with_evaluator_call() {
                 )),
                 None,
                 None,
-            )],
+            ))],
         )),
         SourceSection::Trace(vec![vec![
             TraceBinding::new(Identifier("a".to_string()), 0, 0, 1),
@@ -553,8 +559,8 @@ fn ic_comprehension_with_evaluator_call() {
             TraceBinding::new(Identifier("d".to_string()), 0, 6, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 10),
         ]]),
-        SourceSection::IntegrityConstraints(vec![Constraint(
-            ConstraintType::Evaluator(EvaluatorFunctionCall::new(
+        SourceSection::IntegrityConstraints(vec![Constraint(IntegrityConstraint::new(
+            ConstraintExpr::Evaluator(EvaluatorFunctionCall::new(
                 Identifier("is_binary".to_string()),
                 vec![vec![SymbolAccess::new(
                     Identifier("x".to_string()),
@@ -562,12 +568,12 @@ fn ic_comprehension_with_evaluator_call() {
                     0,
                 )]],
             )),
-            None,
             Some(vec![(
                 Identifier("x".to_string()),
                 Iterable::Identifier(Identifier("c".to_string())),
             )]),
-        )]),
+            None,
+        ))]),
     ]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -593,8 +599,8 @@ fn ic_comprehension_with_evaluator_and_selectors() {
                 0,
                 1,
             )]],
-            vec![Constraint(
-                ConstraintType::Inline(IntegrityConstraint::new(
+            vec![Constraint(IntegrityConstraint::new(
+                ConstraintExpr::Inline(InlineConstraintExpr::new(
                     Exp(
                         Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
@@ -611,7 +617,7 @@ fn ic_comprehension_with_evaluator_and_selectors() {
                 )),
                 None,
                 None,
-            )],
+            ))],
         )),
         SourceSection::Trace(vec![vec![
             TraceBinding::new(Identifier("s".to_string()), 0, 0, 2),
@@ -621,8 +627,8 @@ fn ic_comprehension_with_evaluator_and_selectors() {
             TraceBinding::new(Identifier("d".to_string()), 0, 8, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 12),
         ]]),
-        SourceSection::IntegrityConstraints(vec![Constraint(
-            ConstraintType::Evaluator(EvaluatorFunctionCall::new(
+        SourceSection::IntegrityConstraints(vec![Constraint(IntegrityConstraint::new(
+            ConstraintExpr::Evaluator(EvaluatorFunctionCall::new(
                 Identifier("is_binary".to_string()),
                 vec![vec![SymbolAccess::new(
                     Identifier("x".to_string()),
@@ -630,6 +636,10 @@ fn ic_comprehension_with_evaluator_and_selectors() {
                     0,
                 )]],
             )),
+            Some(vec![(
+                Identifier("x".to_string()),
+                Iterable::Identifier(Identifier("c".to_string())),
+            )]),
             Some(Mul(
                 Box::new(SymbolAccess(SymbolAccess::new(
                     Identifier("s".to_string()),
@@ -642,11 +652,7 @@ fn ic_comprehension_with_evaluator_and_selectors() {
                     0,
                 ))),
             )),
-            Some(vec![(
-                Identifier("x".to_string()),
-                Iterable::Identifier(Identifier("c".to_string())),
-            )]),
-        )]),
+        ))]),
     ]);
 
     build_parse_test!(source).expect_ast(expected);

--- a/parser/src/parser/tests/integrity_constraints.rs
+++ b/parser/src/parser/tests/integrity_constraints.rs
@@ -36,6 +36,7 @@ fn integrity_constraints() {
             ),
         )),
         None,
+        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -71,6 +72,7 @@ fn multiple_integrity_constraints() {
                 ),
             )),
             None,
+            None,
         ),
         Constraint(
             ConstraintType::Inline(IntegrityConstraint::new(
@@ -88,6 +90,7 @@ fn multiple_integrity_constraints() {
                 ),
                 Const(1),
             )),
+            None,
             None,
         ),
     ])]);
@@ -116,6 +119,7 @@ fn integrity_constraint_with_periodic_col() {
             Const(0),
         )),
         None,
+        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -141,6 +145,7 @@ fn integrity_constraint_with_random_value() {
             ),
             Const(0),
         )),
+        None,
         None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
@@ -191,6 +196,7 @@ fn integrity_constraint_with_constants() {
                     ))),
                 ),
             )),
+            None,
             None,
         )]),
     ]);
@@ -291,6 +297,7 @@ fn integrity_constraint_with_variables() {
                 ),
             )),
             None,
+            None,
         ),
     ])]);
     build_parse_test!(source).expect_ast(expected);
@@ -320,6 +327,7 @@ fn integrity_constraint_with_indexed_trace_access() {
                 ),
             )),
             None,
+            None,
         ),
         Constraint(
             ConstraintType::Inline(IntegrityConstraint::new(
@@ -337,6 +345,7 @@ fn integrity_constraint_with_indexed_trace_access() {
                 ),
                 Const(1),
             )),
+            None,
             None,
         ),
     ])]);
@@ -362,7 +371,7 @@ fn ic_comprehension_one_iterable_identifier() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 6),
         ]]),
-        SourceSection::IntegrityConstraints(vec![ConstraintComprehension(
+        SourceSection::IntegrityConstraints(vec![Constraint(
             ConstraintType::Inline(IntegrityConstraint::new(
                 SymbolAccess(SymbolAccess::new(
                     Identifier("x".to_string()),
@@ -383,10 +392,10 @@ fn ic_comprehension_one_iterable_identifier() {
                 ),
             )),
             None,
-            vec![(
+            Some(vec![(
                 Identifier("x".to_string()),
                 Iterable::Identifier(Identifier("c".to_string())),
-            )],
+            )]),
         )]),
     ]);
     build_parse_test!(source).expect_ast(expected);
@@ -408,7 +417,7 @@ fn ic_comprehension_one_iterable_range() {
             TraceBinding::new(Identifier("c".to_string()), 0, 2, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 6),
         ]]),
-        SourceSection::IntegrityConstraints(vec![ConstraintComprehension(
+        SourceSection::IntegrityConstraints(vec![Constraint(
             ConstraintType::Inline(IntegrityConstraint::new(
                 SymbolAccess(SymbolAccess::new(
                     Identifier("x".to_string()),
@@ -429,10 +438,10 @@ fn ic_comprehension_one_iterable_range() {
                 ),
             )),
             None,
-            vec![(
+            Some(vec![(
                 Identifier("x".to_string()),
                 Iterable::Range(Range::new(1, 4)),
-            )],
+            )]),
         )]),
     ]);
     build_parse_test!(source).expect_ast(expected);
@@ -445,7 +454,7 @@ fn ic_comprehension_with_selectors() {
         main: [s[2], a, b, c[4]]
 
     integrity_constraints:
-        enf x = a + b when s[0] & s[1] for x in c";
+        enf x = a + b for x in c when s[0] & s[1]";
 
     let expected = Source(vec![
         SourceSection::Trace(vec![vec![
@@ -455,7 +464,7 @@ fn ic_comprehension_with_selectors() {
             TraceBinding::new(Identifier("c".to_string()), 0, 4, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 8),
         ]]),
-        SourceSection::IntegrityConstraints(vec![ConstraintComprehension(
+        SourceSection::IntegrityConstraints(vec![Constraint(
             ConstraintType::Inline(IntegrityConstraint::new(
                 SymbolAccess(SymbolAccess::new(
                     Identifier("x".to_string()),
@@ -487,10 +496,10 @@ fn ic_comprehension_with_selectors() {
                     0,
                 ))),
             )),
-            vec![(
+            Some(vec![(
                 Identifier("x".to_string()),
                 Iterable::Identifier(Identifier("c".to_string())),
-            )],
+            )]),
         )]),
     ]);
     build_parse_test!(source).expect_ast(expected);
@@ -534,6 +543,7 @@ fn ic_comprehension_with_evaluator_call() {
                     )),
                 )),
                 None,
+                None,
             )],
         )),
         SourceSection::Trace(vec![vec![
@@ -543,7 +553,7 @@ fn ic_comprehension_with_evaluator_call() {
             TraceBinding::new(Identifier("d".to_string()), 0, 6, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 10),
         ]]),
-        SourceSection::IntegrityConstraints(vec![ConstraintComprehension(
+        SourceSection::IntegrityConstraints(vec![Constraint(
             ConstraintType::Evaluator(EvaluatorFunctionCall::new(
                 Identifier("is_binary".to_string()),
                 vec![vec![SymbolAccess::new(
@@ -553,10 +563,10 @@ fn ic_comprehension_with_evaluator_call() {
                 )]],
             )),
             None,
-            vec![(
+            Some(vec![(
                 Identifier("x".to_string()),
                 Iterable::Identifier(Identifier("c".to_string())),
-            )],
+            )]),
         )]),
     ]);
     build_parse_test!(source).expect_ast(expected);
@@ -572,7 +582,7 @@ fn ic_comprehension_with_evaluator_and_selectors() {
         main: [s[2], a, b, c[4], d[4]]
 
     integrity_constraints:
-        enf is_binary([x]) when s[0] & s[1] for x in c";
+        enf is_binary([x]) for x in c when s[0] & s[1]";
 
     let expected = Source(vec![
         SourceSection::EvaluatorFunction(EvaluatorFunction::new(
@@ -600,6 +610,7 @@ fn ic_comprehension_with_evaluator_and_selectors() {
                     )),
                 )),
                 None,
+                None,
             )],
         )),
         SourceSection::Trace(vec![vec![
@@ -610,7 +621,7 @@ fn ic_comprehension_with_evaluator_and_selectors() {
             TraceBinding::new(Identifier("d".to_string()), 0, 8, 4),
             TraceBinding::new(Identifier("$main".to_string()), 0, 0, 12),
         ]]),
-        SourceSection::IntegrityConstraints(vec![ConstraintComprehension(
+        SourceSection::IntegrityConstraints(vec![Constraint(
             ConstraintType::Evaluator(EvaluatorFunctionCall::new(
                 Identifier("is_binary".to_string()),
                 vec![vec![SymbolAccess::new(
@@ -631,10 +642,10 @@ fn ic_comprehension_with_evaluator_and_selectors() {
                     0,
                 ))),
             )),
-            vec![(
+            Some(vec![(
                 Identifier("x".to_string()),
                 Iterable::Identifier(Identifier("c".to_string())),
-            )],
+            )]),
         )]),
     ]);
 

--- a/parser/src/parser/tests/list_comprehension.rs
+++ b/parser/src/parser/tests/list_comprehension.rs
@@ -3,9 +3,9 @@ use air_script_core::{Iterable, ListComprehension, Range};
 use super::{build_parse_test, Identifier, IntegrityConstraint, Source};
 use crate::{
     ast::{
-        AccessType, Boundary, BoundaryConstraint, BoundaryStmt, ConstraintType, Expression::*,
-        IntegrityStmt, SourceSection::*, SymbolAccess, TraceBinding, VariableBinding,
-        VariableValueExpr,
+        AccessType, Boundary, BoundaryConstraint, BoundaryStmt, ConstraintExpr, Expression::*,
+        InlineConstraintExpr, IntegrityStmt, SourceSection::*, SymbolAccess, TraceBinding,
+        VariableBinding, VariableValueExpr,
     },
     error::{Error, ParseError},
 };
@@ -50,39 +50,37 @@ fn bc_one_iterable_identifier_lc() {
                     )],
                 )),
             )),
-            BoundaryStmt::Constraint(
-                BoundaryConstraint::new(
-                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                    Boundary::First,
-                    Add(
+            BoundaryStmt::Constraint(BoundaryConstraint::new(
+                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                Boundary::First,
+                Add(
+                    Box::new(Add(
                         Box::new(Add(
-                            Box::new(Add(
-                                Box::new(SymbolAccess(SymbolAccess::new(
-                                    Identifier("x".to_string()),
-                                    AccessType::Vector(0),
-                                    0,
-                                ))),
-                                Box::new(SymbolAccess(SymbolAccess::new(
-                                    Identifier("x".to_string()),
-                                    AccessType::Vector(1),
-                                    0,
-                                ))),
-                            )),
                             Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
-                                AccessType::Vector(2),
+                                AccessType::Vector(0),
+                                0,
+                            ))),
+                            Box::new(SymbolAccess(SymbolAccess::new(
+                                Identifier("x".to_string()),
+                                AccessType::Vector(1),
                                 0,
                             ))),
                         )),
                         Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
-                            AccessType::Vector(3),
+                            AccessType::Vector(2),
                             0,
                         ))),
-                    ),
+                    )),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("x".to_string()),
+                        AccessType::Vector(3),
+                        0,
+                    ))),
                 ),
                 None,
-            ),
+            )),
         ]),
     ]);
 
@@ -137,39 +135,37 @@ fn bc_identifier_and_range_lc() {
                     ],
                 )),
             )),
-            BoundaryStmt::Constraint(
-                BoundaryConstraint::new(
-                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                    Boundary::First,
-                    Add(
+            BoundaryStmt::Constraint(BoundaryConstraint::new(
+                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                Boundary::First,
+                Add(
+                    Box::new(Add(
                         Box::new(Add(
-                            Box::new(Add(
-                                Box::new(SymbolAccess(SymbolAccess::new(
-                                    Identifier("x".to_string()),
-                                    AccessType::Vector(0),
-                                    0,
-                                ))),
-                                Box::new(SymbolAccess(SymbolAccess::new(
-                                    Identifier("x".to_string()),
-                                    AccessType::Vector(1),
-                                    0,
-                                ))),
-                            )),
                             Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
-                                AccessType::Vector(2),
+                                AccessType::Vector(0),
+                                0,
+                            ))),
+                            Box::new(SymbolAccess(SymbolAccess::new(
+                                Identifier("x".to_string()),
+                                AccessType::Vector(1),
                                 0,
                             ))),
                         )),
                         Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
-                            AccessType::Vector(3),
+                            AccessType::Vector(2),
                             0,
                         ))),
-                    ),
+                    )),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("x".to_string()),
+                        AccessType::Vector(3),
+                        0,
+                    ))),
                 ),
                 None,
-            ),
+            )),
         ]),
     ]);
 
@@ -208,39 +204,37 @@ fn bc_iterable_slice_lc() {
                     )],
                 )),
             )),
-            BoundaryStmt::Constraint(
-                BoundaryConstraint::new(
-                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                    Boundary::First,
-                    Add(
+            BoundaryStmt::Constraint(BoundaryConstraint::new(
+                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                Boundary::First,
+                Add(
+                    Box::new(Add(
                         Box::new(Add(
-                            Box::new(Add(
-                                Box::new(SymbolAccess(SymbolAccess::new(
-                                    Identifier("x".to_string()),
-                                    AccessType::Vector(0),
-                                    0,
-                                ))),
-                                Box::new(SymbolAccess(SymbolAccess::new(
-                                    Identifier("x".to_string()),
-                                    AccessType::Vector(1),
-                                    0,
-                                ))),
-                            )),
                             Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
-                                AccessType::Vector(2),
+                                AccessType::Vector(0),
+                                0,
+                            ))),
+                            Box::new(SymbolAccess(SymbolAccess::new(
+                                Identifier("x".to_string()),
+                                AccessType::Vector(1),
                                 0,
                             ))),
                         )),
                         Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
-                            AccessType::Vector(3),
+                            AccessType::Vector(2),
                             0,
                         ))),
-                    ),
+                    )),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("x".to_string()),
+                        AccessType::Vector(3),
+                        0,
+                    ))),
                 ),
                 None,
-            ),
+            )),
         ]),
     ]);
 
@@ -293,39 +287,37 @@ fn bc_two_iterable_identifier_lc() {
                     ],
                 )),
             )),
-            BoundaryStmt::Constraint(
-                BoundaryConstraint::new(
-                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                    Boundary::First,
-                    Add(
+            BoundaryStmt::Constraint(BoundaryConstraint::new(
+                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                Boundary::First,
+                Add(
+                    Box::new(Add(
                         Box::new(Add(
-                            Box::new(Add(
-                                Box::new(SymbolAccess(SymbolAccess::new(
-                                    Identifier("x".to_string()),
-                                    AccessType::Vector(0),
-                                    0,
-                                ))),
-                                Box::new(SymbolAccess(SymbolAccess::new(
-                                    Identifier("x".to_string()),
-                                    AccessType::Vector(1),
-                                    0,
-                                ))),
-                            )),
                             Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
-                                AccessType::Vector(2),
+                                AccessType::Vector(0),
+                                0,
+                            ))),
+                            Box::new(SymbolAccess(SymbolAccess::new(
+                                Identifier("x".to_string()),
+                                AccessType::Vector(1),
                                 0,
                             ))),
                         )),
                         Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
-                            AccessType::Vector(3),
+                            AccessType::Vector(2),
                             0,
                         ))),
-                    ),
+                    )),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("x".to_string()),
+                        AccessType::Vector(3),
+                        0,
+                    ))),
                 ),
                 None,
-            ),
+            )),
         ]),
     ]);
 
@@ -400,39 +392,37 @@ fn bc_multiple_iterables_lc() {
                     ],
                 )),
             )),
-            BoundaryStmt::Constraint(
-                BoundaryConstraint::new(
-                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                    Boundary::First,
-                    Add(
+            BoundaryStmt::Constraint(BoundaryConstraint::new(
+                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                Boundary::First,
+                Add(
+                    Box::new(Add(
                         Box::new(Add(
-                            Box::new(Add(
-                                Box::new(SymbolAccess(SymbolAccess::new(
-                                    Identifier("x".to_string()),
-                                    AccessType::Vector(0),
-                                    0,
-                                ))),
-                                Box::new(SymbolAccess(SymbolAccess::new(
-                                    Identifier("x".to_string()),
-                                    AccessType::Vector(1),
-                                    0,
-                                ))),
-                            )),
                             Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
-                                AccessType::Vector(2),
+                                AccessType::Vector(0),
+                                0,
+                            ))),
+                            Box::new(SymbolAccess(SymbolAccess::new(
+                                Identifier("x".to_string()),
+                                AccessType::Vector(1),
                                 0,
                             ))),
                         )),
                         Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
-                            AccessType::Vector(3),
+                            AccessType::Vector(2),
                             0,
                         ))),
-                    ),
+                    )),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("x".to_string()),
+                        AccessType::Vector(3),
+                        0,
+                    ))),
                 ),
                 None,
-            ),
+            )),
         ]),
     ]);
 
@@ -495,8 +485,8 @@ fn ic_one_iterable_identifier_lc() {
                     )],
                 )),
             )),
-            IntegrityStmt::Constraint(
-                ConstraintType::Inline(IntegrityConstraint::new(
+            IntegrityStmt::Constraint(IntegrityConstraint::new(
+                ConstraintExpr::Inline(InlineConstraintExpr::new(
                     SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
@@ -531,7 +521,7 @@ fn ic_one_iterable_identifier_lc() {
                 )),
                 None,
                 None,
-            ),
+            )),
         ]),
     ]);
 
@@ -586,8 +576,8 @@ fn ic_iterable_identifier_range_lc() {
                     ],
                 )),
             )),
-            IntegrityStmt::Constraint(
-                ConstraintType::Inline(IntegrityConstraint::new(
+            IntegrityStmt::Constraint(IntegrityConstraint::new(
+                ConstraintExpr::Inline(InlineConstraintExpr::new(
                     SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
@@ -622,7 +612,7 @@ fn ic_iterable_identifier_range_lc() {
                 )),
                 None,
                 None,
-            ),
+            )),
         ]),
     ]);
 
@@ -661,8 +651,8 @@ fn ic_iterable_slice_lc() {
                     )],
                 )),
             )),
-            IntegrityStmt::Constraint(
-                ConstraintType::Inline(IntegrityConstraint::new(
+            IntegrityStmt::Constraint(IntegrityConstraint::new(
+                ConstraintExpr::Inline(InlineConstraintExpr::new(
                     SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
@@ -697,7 +687,7 @@ fn ic_iterable_slice_lc() {
                 )),
                 None,
                 None,
-            ),
+            )),
         ]),
     ]);
 
@@ -750,8 +740,8 @@ fn ic_two_iterable_identifier_lc() {
                     ],
                 )),
             )),
-            IntegrityStmt::Constraint(
-                ConstraintType::Inline(IntegrityConstraint::new(
+            IntegrityStmt::Constraint(IntegrityConstraint::new(
+                ConstraintExpr::Inline(InlineConstraintExpr::new(
                     SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
@@ -786,7 +776,7 @@ fn ic_two_iterable_identifier_lc() {
                 )),
                 None,
                 None,
-            ),
+            )),
         ]),
     ]);
 
@@ -861,8 +851,8 @@ fn ic_multiple_iterables_lc() {
                     ],
                 )),
             )),
-            IntegrityStmt::Constraint(
-                ConstraintType::Inline(IntegrityConstraint::new(
+            IntegrityStmt::Constraint(IntegrityConstraint::new(
+                ConstraintExpr::Inline(InlineConstraintExpr::new(
                     SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
@@ -897,7 +887,7 @@ fn ic_multiple_iterables_lc() {
                 )),
                 None,
                 None,
-            ),
+            )),
         ]),
     ]);
 

--- a/parser/src/parser/tests/list_comprehension.rs
+++ b/parser/src/parser/tests/list_comprehension.rs
@@ -50,36 +50,39 @@ fn bc_one_iterable_identifier_lc() {
                     )],
                 )),
             )),
-            BoundaryStmt::Constraint(BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                Add(
-                    Box::new(Add(
+            BoundaryStmt::Constraint(
+                BoundaryConstraint::new(
+                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                    Boundary::First,
+                    Add(
                         Box::new(Add(
+                            Box::new(Add(
+                                Box::new(SymbolAccess(SymbolAccess::new(
+                                    Identifier("x".to_string()),
+                                    AccessType::Vector(0),
+                                    0,
+                                ))),
+                                Box::new(SymbolAccess(SymbolAccess::new(
+                                    Identifier("x".to_string()),
+                                    AccessType::Vector(1),
+                                    0,
+                                ))),
+                            )),
                             Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
-                                AccessType::Vector(0),
-                                0,
-                            ))),
-                            Box::new(SymbolAccess(SymbolAccess::new(
-                                Identifier("x".to_string()),
-                                AccessType::Vector(1),
+                                AccessType::Vector(2),
                                 0,
                             ))),
                         )),
                         Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
-                            AccessType::Vector(2),
+                            AccessType::Vector(3),
                             0,
                         ))),
-                    )),
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("x".to_string()),
-                        AccessType::Vector(3),
-                        0,
-                    ))),
+                    ),
                 ),
-            )),
+                None,
+            ),
         ]),
     ]);
 
@@ -134,36 +137,39 @@ fn bc_identifier_and_range_lc() {
                     ],
                 )),
             )),
-            BoundaryStmt::Constraint(BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                Add(
-                    Box::new(Add(
+            BoundaryStmt::Constraint(
+                BoundaryConstraint::new(
+                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                    Boundary::First,
+                    Add(
                         Box::new(Add(
+                            Box::new(Add(
+                                Box::new(SymbolAccess(SymbolAccess::new(
+                                    Identifier("x".to_string()),
+                                    AccessType::Vector(0),
+                                    0,
+                                ))),
+                                Box::new(SymbolAccess(SymbolAccess::new(
+                                    Identifier("x".to_string()),
+                                    AccessType::Vector(1),
+                                    0,
+                                ))),
+                            )),
                             Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
-                                AccessType::Vector(0),
-                                0,
-                            ))),
-                            Box::new(SymbolAccess(SymbolAccess::new(
-                                Identifier("x".to_string()),
-                                AccessType::Vector(1),
+                                AccessType::Vector(2),
                                 0,
                             ))),
                         )),
                         Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
-                            AccessType::Vector(2),
+                            AccessType::Vector(3),
                             0,
                         ))),
-                    )),
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("x".to_string()),
-                        AccessType::Vector(3),
-                        0,
-                    ))),
+                    ),
                 ),
-            )),
+                None,
+            ),
         ]),
     ]);
 
@@ -202,36 +208,39 @@ fn bc_iterable_slice_lc() {
                     )],
                 )),
             )),
-            BoundaryStmt::Constraint(BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                Add(
-                    Box::new(Add(
+            BoundaryStmt::Constraint(
+                BoundaryConstraint::new(
+                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                    Boundary::First,
+                    Add(
                         Box::new(Add(
+                            Box::new(Add(
+                                Box::new(SymbolAccess(SymbolAccess::new(
+                                    Identifier("x".to_string()),
+                                    AccessType::Vector(0),
+                                    0,
+                                ))),
+                                Box::new(SymbolAccess(SymbolAccess::new(
+                                    Identifier("x".to_string()),
+                                    AccessType::Vector(1),
+                                    0,
+                                ))),
+                            )),
                             Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
-                                AccessType::Vector(0),
-                                0,
-                            ))),
-                            Box::new(SymbolAccess(SymbolAccess::new(
-                                Identifier("x".to_string()),
-                                AccessType::Vector(1),
+                                AccessType::Vector(2),
                                 0,
                             ))),
                         )),
                         Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
-                            AccessType::Vector(2),
+                            AccessType::Vector(3),
                             0,
                         ))),
-                    )),
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("x".to_string()),
-                        AccessType::Vector(3),
-                        0,
-                    ))),
+                    ),
                 ),
-            )),
+                None,
+            ),
         ]),
     ]);
 
@@ -284,36 +293,39 @@ fn bc_two_iterable_identifier_lc() {
                     ],
                 )),
             )),
-            BoundaryStmt::Constraint(BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                Add(
-                    Box::new(Add(
+            BoundaryStmt::Constraint(
+                BoundaryConstraint::new(
+                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                    Boundary::First,
+                    Add(
                         Box::new(Add(
+                            Box::new(Add(
+                                Box::new(SymbolAccess(SymbolAccess::new(
+                                    Identifier("x".to_string()),
+                                    AccessType::Vector(0),
+                                    0,
+                                ))),
+                                Box::new(SymbolAccess(SymbolAccess::new(
+                                    Identifier("x".to_string()),
+                                    AccessType::Vector(1),
+                                    0,
+                                ))),
+                            )),
                             Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
-                                AccessType::Vector(0),
-                                0,
-                            ))),
-                            Box::new(SymbolAccess(SymbolAccess::new(
-                                Identifier("x".to_string()),
-                                AccessType::Vector(1),
+                                AccessType::Vector(2),
                                 0,
                             ))),
                         )),
                         Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
-                            AccessType::Vector(2),
+                            AccessType::Vector(3),
                             0,
                         ))),
-                    )),
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("x".to_string()),
-                        AccessType::Vector(3),
-                        0,
-                    ))),
+                    ),
                 ),
-            )),
+                None,
+            ),
         ]),
     ]);
 
@@ -388,36 +400,39 @@ fn bc_multiple_iterables_lc() {
                     ],
                 )),
             )),
-            BoundaryStmt::Constraint(BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                Add(
-                    Box::new(Add(
+            BoundaryStmt::Constraint(
+                BoundaryConstraint::new(
+                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                    Boundary::First,
+                    Add(
                         Box::new(Add(
+                            Box::new(Add(
+                                Box::new(SymbolAccess(SymbolAccess::new(
+                                    Identifier("x".to_string()),
+                                    AccessType::Vector(0),
+                                    0,
+                                ))),
+                                Box::new(SymbolAccess(SymbolAccess::new(
+                                    Identifier("x".to_string()),
+                                    AccessType::Vector(1),
+                                    0,
+                                ))),
+                            )),
                             Box::new(SymbolAccess(SymbolAccess::new(
                                 Identifier("x".to_string()),
-                                AccessType::Vector(0),
-                                0,
-                            ))),
-                            Box::new(SymbolAccess(SymbolAccess::new(
-                                Identifier("x".to_string()),
-                                AccessType::Vector(1),
+                                AccessType::Vector(2),
                                 0,
                             ))),
                         )),
                         Box::new(SymbolAccess(SymbolAccess::new(
                             Identifier("x".to_string()),
-                            AccessType::Vector(2),
+                            AccessType::Vector(3),
                             0,
                         ))),
-                    )),
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("x".to_string()),
-                        AccessType::Vector(3),
-                        0,
-                    ))),
+                    ),
                 ),
-            )),
+                None,
+            ),
         ]),
     ]);
 
@@ -515,6 +530,7 @@ fn ic_one_iterable_identifier_lc() {
                     ),
                 )),
                 None,
+                None,
             ),
         ]),
     ]);
@@ -605,6 +621,7 @@ fn ic_iterable_identifier_range_lc() {
                     ),
                 )),
                 None,
+                None,
             ),
         ]),
     ]);
@@ -678,6 +695,7 @@ fn ic_iterable_slice_lc() {
                         ))),
                     ),
                 )),
+                None,
                 None,
             ),
         ]),
@@ -766,6 +784,7 @@ fn ic_two_iterable_identifier_lc() {
                         ))),
                     ),
                 )),
+                None,
                 None,
             ),
         ]),
@@ -876,6 +895,7 @@ fn ic_multiple_iterables_lc() {
                         ))),
                     ),
                 )),
+                None,
                 None,
             ),
         ]),

--- a/parser/src/parser/tests/list_folding.rs
+++ b/parser/src/parser/tests/list_folding.rs
@@ -3,9 +3,9 @@ use air_script_core::{Iterable, ListComprehension, ListFolding, ListFoldingValue
 use super::{build_parse_test, Identifier, IntegrityConstraint, Source};
 use crate::{
     ast::{
-        AccessType, Boundary, BoundaryConstraint, BoundaryStmt, ConstraintType, Expression::*,
-        IntegrityStmt, SourceSection::*, SymbolAccess, TraceBinding, VariableBinding,
-        VariableValueExpr,
+        AccessType, Boundary, BoundaryConstraint, BoundaryStmt, ConstraintExpr, Expression::*,
+        InlineConstraintExpr, IntegrityStmt, SourceSection::*, SymbolAccess, TraceBinding,
+        VariableBinding, VariableValueExpr,
     },
     error::{Error, ParseError},
 };
@@ -43,25 +43,23 @@ fn identifier_lf() {
                     ListFoldingValueExpr::Identifier(Identifier("c".to_string())),
                 ))),
             )),
-            BoundaryStmt::Constraint(
-                BoundaryConstraint::new(
-                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                    Boundary::First,
-                    Add(
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("x".to_string()),
-                            AccessType::Default,
-                            0,
-                        ))),
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("y".to_string()),
-                            AccessType::Default,
-                            0,
-                        ))),
-                    ),
+            BoundaryStmt::Constraint(BoundaryConstraint::new(
+                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                Boundary::First,
+                Add(
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("x".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("y".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
                 ),
                 None,
-            ),
+            )),
         ]),
     ]);
     build_parse_test!(source).expect_ast(expected);
@@ -129,25 +127,23 @@ fn vector_lf() {
                     ]),
                 ))),
             )),
-            BoundaryStmt::Constraint(
-                BoundaryConstraint::new(
-                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                    Boundary::First,
-                    Add(
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("x".to_string()),
-                            AccessType::Default,
-                            0,
-                        ))),
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("y".to_string()),
-                            AccessType::Default,
-                            0,
-                        ))),
-                    ),
+            BoundaryStmt::Constraint(BoundaryConstraint::new(
+                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                Boundary::First,
+                Add(
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("x".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("y".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
                 ),
                 None,
-            ),
+            )),
         ]),
     ]);
 
@@ -210,25 +206,23 @@ fn bc_one_iterable_identifier_lf() {
                     )),
                 ))),
             )),
-            BoundaryStmt::Constraint(
-                BoundaryConstraint::new(
-                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                    Boundary::First,
-                    Add(
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("x".to_string()),
-                            AccessType::Default,
-                            0,
-                        ))),
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("y".to_string()),
-                            AccessType::Default,
-                            0,
-                        ))),
-                    ),
+            BoundaryStmt::Constraint(BoundaryConstraint::new(
+                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                Boundary::First,
+                Add(
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("x".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("y".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
                 ),
                 None,
-            ),
+            )),
         ]),
     ]);
 
@@ -312,25 +306,23 @@ fn bc_two_iterable_identifier_lf() {
                     )),
                 ))),
             )),
-            BoundaryStmt::Constraint(
-                BoundaryConstraint::new(
-                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                    Boundary::First,
-                    Add(
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("x".to_string()),
-                            AccessType::Default,
-                            0,
-                        ))),
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("y".to_string()),
-                            AccessType::Default,
-                            0,
-                        ))),
-                    ),
+            BoundaryStmt::Constraint(BoundaryConstraint::new(
+                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                Boundary::First,
+                Add(
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("x".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("y".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
                 ),
                 None,
-            ),
+            )),
         ]),
     ]);
 
@@ -413,25 +405,23 @@ fn bc_two_iterables_identifier_range_lf() {
                     )),
                 ))),
             )),
-            BoundaryStmt::Constraint(
-                BoundaryConstraint::new(
-                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                    Boundary::First,
-                    Add(
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("x".to_string()),
-                            AccessType::Default,
-                            0,
-                        ))),
-                        Box::new(SymbolAccess(SymbolAccess::new(
-                            Identifier("y".to_string()),
-                            AccessType::Default,
-                            0,
-                        ))),
-                    ),
+            BoundaryStmt::Constraint(BoundaryConstraint::new(
+                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                Boundary::First,
+                Add(
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("x".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("y".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
                 ),
                 None,
-            ),
+            )),
         ]),
     ]);
 
@@ -494,8 +484,8 @@ fn ic_one_iterable_identifier_lf() {
                     )),
                 ))),
             )),
-            IntegrityStmt::Constraint(
-                ConstraintType::Inline(IntegrityConstraint::new(
+            IntegrityStmt::Constraint(IntegrityConstraint::new(
+                ConstraintExpr::Inline(InlineConstraintExpr::new(
                     SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
@@ -516,7 +506,7 @@ fn ic_one_iterable_identifier_lf() {
                 )),
                 None,
                 None,
-            ),
+            )),
         ]),
     ]);
 
@@ -600,8 +590,8 @@ fn ic_two_iterable_identifier_lf() {
                     )),
                 ))),
             )),
-            IntegrityStmt::Constraint(
-                ConstraintType::Inline(IntegrityConstraint::new(
+            IntegrityStmt::Constraint(IntegrityConstraint::new(
+                ConstraintExpr::Inline(InlineConstraintExpr::new(
                     SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
@@ -622,7 +612,7 @@ fn ic_two_iterable_identifier_lf() {
                 )),
                 None,
                 None,
-            ),
+            )),
         ]),
     ]);
 
@@ -705,8 +695,8 @@ fn ic_two_iterables_identifier_range_lf() {
                     )),
                 ))),
             )),
-            IntegrityStmt::Constraint(
-                ConstraintType::Inline(IntegrityConstraint::new(
+            IntegrityStmt::Constraint(IntegrityConstraint::new(
+                ConstraintExpr::Inline(InlineConstraintExpr::new(
                     SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
@@ -727,7 +717,7 @@ fn ic_two_iterables_identifier_range_lf() {
                 )),
                 None,
                 None,
-            ),
+            )),
         ]),
     ]);
 
@@ -832,8 +822,8 @@ fn ic_three_iterables_slice_identifier_range_lf() {
                     )),
                 ))),
             )),
-            IntegrityStmt::Constraint(
-                ConstraintType::Inline(IntegrityConstraint::new(
+            IntegrityStmt::Constraint(IntegrityConstraint::new(
+                ConstraintExpr::Inline(InlineConstraintExpr::new(
                     SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Default,
@@ -854,7 +844,7 @@ fn ic_three_iterables_slice_identifier_range_lf() {
                 )),
                 None,
                 None,
-            ),
+            )),
         ]),
     ]);
 

--- a/parser/src/parser/tests/list_folding.rs
+++ b/parser/src/parser/tests/list_folding.rs
@@ -43,22 +43,25 @@ fn identifier_lf() {
                     ListFoldingValueExpr::Identifier(Identifier("c".to_string())),
                 ))),
             )),
-            BoundaryStmt::Constraint(BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                Add(
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("x".to_string()),
-                        AccessType::Default,
-                        0,
-                    ))),
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("y".to_string()),
-                        AccessType::Default,
-                        0,
-                    ))),
+            BoundaryStmt::Constraint(
+                BoundaryConstraint::new(
+                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                    Boundary::First,
+                    Add(
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("x".to_string()),
+                            AccessType::Default,
+                            0,
+                        ))),
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("y".to_string()),
+                            AccessType::Default,
+                            0,
+                        ))),
+                    ),
                 ),
-            )),
+                None,
+            ),
         ]),
     ]);
     build_parse_test!(source).expect_ast(expected);
@@ -126,22 +129,25 @@ fn vector_lf() {
                     ]),
                 ))),
             )),
-            BoundaryStmt::Constraint(BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                Add(
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("x".to_string()),
-                        AccessType::Default,
-                        0,
-                    ))),
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("y".to_string()),
-                        AccessType::Default,
-                        0,
-                    ))),
+            BoundaryStmt::Constraint(
+                BoundaryConstraint::new(
+                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                    Boundary::First,
+                    Add(
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("x".to_string()),
+                            AccessType::Default,
+                            0,
+                        ))),
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("y".to_string()),
+                            AccessType::Default,
+                            0,
+                        ))),
+                    ),
                 ),
-            )),
+                None,
+            ),
         ]),
     ]);
 
@@ -204,22 +210,25 @@ fn bc_one_iterable_identifier_lf() {
                     )),
                 ))),
             )),
-            BoundaryStmt::Constraint(BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                Add(
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("x".to_string()),
-                        AccessType::Default,
-                        0,
-                    ))),
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("y".to_string()),
-                        AccessType::Default,
-                        0,
-                    ))),
+            BoundaryStmt::Constraint(
+                BoundaryConstraint::new(
+                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                    Boundary::First,
+                    Add(
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("x".to_string()),
+                            AccessType::Default,
+                            0,
+                        ))),
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("y".to_string()),
+                            AccessType::Default,
+                            0,
+                        ))),
+                    ),
                 ),
-            )),
+                None,
+            ),
         ]),
     ]);
 
@@ -303,22 +312,25 @@ fn bc_two_iterable_identifier_lf() {
                     )),
                 ))),
             )),
-            BoundaryStmt::Constraint(BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                Add(
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("x".to_string()),
-                        AccessType::Default,
-                        0,
-                    ))),
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("y".to_string()),
-                        AccessType::Default,
-                        0,
-                    ))),
+            BoundaryStmt::Constraint(
+                BoundaryConstraint::new(
+                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                    Boundary::First,
+                    Add(
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("x".to_string()),
+                            AccessType::Default,
+                            0,
+                        ))),
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("y".to_string()),
+                            AccessType::Default,
+                            0,
+                        ))),
+                    ),
                 ),
-            )),
+                None,
+            ),
         ]),
     ]);
 
@@ -401,22 +413,25 @@ fn bc_two_iterables_identifier_range_lf() {
                     )),
                 ))),
             )),
-            BoundaryStmt::Constraint(BoundaryConstraint::new(
-                SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
-                Boundary::First,
-                Add(
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("x".to_string()),
-                        AccessType::Default,
-                        0,
-                    ))),
-                    Box::new(SymbolAccess(SymbolAccess::new(
-                        Identifier("y".to_string()),
-                        AccessType::Default,
-                        0,
-                    ))),
+            BoundaryStmt::Constraint(
+                BoundaryConstraint::new(
+                    SymbolAccess::new(Identifier("a".to_string()), AccessType::Default, 0),
+                    Boundary::First,
+                    Add(
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("x".to_string()),
+                            AccessType::Default,
+                            0,
+                        ))),
+                        Box::new(SymbolAccess(SymbolAccess::new(
+                            Identifier("y".to_string()),
+                            AccessType::Default,
+                            0,
+                        ))),
+                    ),
                 ),
-            )),
+                None,
+            ),
         ]),
     ]);
 
@@ -499,6 +514,7 @@ fn ic_one_iterable_identifier_lf() {
                         ))),
                     ),
                 )),
+                None,
                 None,
             ),
         ]),
@@ -605,6 +621,7 @@ fn ic_two_iterable_identifier_lf() {
                     ),
                 )),
                 None,
+                None,
             ),
         ]),
     ]);
@@ -708,6 +725,7 @@ fn ic_two_iterables_identifier_range_lf() {
                         ))),
                     ),
                 )),
+                None,
                 None,
             ),
         ]),
@@ -834,6 +852,7 @@ fn ic_three_iterables_slice_identifier_range_lf() {
                         ))),
                     ),
                 )),
+                None,
                 None,
             ),
         ]),

--- a/parser/src/parser/tests/mod.rs
+++ b/parser/src/parser/tests/mod.rs
@@ -63,6 +63,7 @@ fn full_air_file() {
                 ),
             )),
             None,
+            None,
         )]),
         // boundary_constraints:
         //     enf clk.first = 0
@@ -72,6 +73,7 @@ fn full_air_file() {
                 Boundary::First,
                 Expression::Const(0),
             ),
+            None,
         )]),
     ]);
     build_parse_test!(source.as_str()).expect_ast(expected);

--- a/parser/src/parser/tests/mod.rs
+++ b/parser/src/parser/tests/mod.rs
@@ -46,24 +46,26 @@ fn full_air_file() {
         // integrity_constraints:
         //     enf clk' = clk + 1
         SourceSection::IntegrityConstraints(vec![IntegrityStmt::Constraint(
-            ConstraintType::Inline(IntegrityConstraint::new(
-                // clk' = clk + 1
-                Expression::SymbolAccess(SymbolAccess::new(
-                    Identifier("clk".to_string()),
-                    AccessType::Default,
-                    1,
-                )),
-                Expression::Add(
-                    Box::new(Expression::SymbolAccess(SymbolAccess::new(
+            IntegrityConstraint::new(
+                ConstraintExpr::Inline(InlineConstraintExpr::new(
+                    // clk' = clk + 1
+                    Expression::SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
                         AccessType::Default,
-                        0,
-                    ))),
-                    Box::new(Expression::Const(1)),
-                ),
-            )),
-            None,
-            None,
+                        1,
+                    )),
+                    Expression::Add(
+                        Box::new(Expression::SymbolAccess(SymbolAccess::new(
+                            Identifier("clk".to_string()),
+                            AccessType::Default,
+                            0,
+                        ))),
+                        Box::new(Expression::Const(1)),
+                    ),
+                )),
+                None,
+                None,
+            ),
         )]),
         // boundary_constraints:
         //     enf clk.first = 0
@@ -72,8 +74,8 @@ fn full_air_file() {
                 SymbolAccess::new(Identifier("clk".to_string()), AccessType::Default, 0),
                 Boundary::First,
                 Expression::Const(0),
+                None,
             ),
-            None,
         )]),
     ]);
     build_parse_test!(source.as_str()).expect_ast(expected);

--- a/parser/src/parser/tests/random_values.rs
+++ b/parser/src/parser/tests/random_values.rs
@@ -1,9 +1,9 @@
 use super::{
-    build_parse_test, AccessType, Error, Expression::*, Identifier, IntegrityConstraint,
-    IntegrityStmt::*, ParseError, RandBinding, RandomValues, Source, SourceSection,
-    SourceSection::*, SymbolAccess,
+    build_parse_test, AccessType, Error, Expression::*, Identifier, InlineConstraintExpr,
+    IntegrityConstraint, IntegrityStmt::*, ParseError, RandBinding, RandomValues, Source,
+    SourceSection, SourceSection::*, SymbolAccess,
 };
-use crate::ast::ConstraintType;
+use crate::ast::ConstraintExpr;
 
 // RANDOM VALUES
 // ================================================================================================
@@ -78,23 +78,25 @@ fn random_values_index_access() {
     integrity_constraints:
         enf a + $alphas[1] = 0";
     let expected = Source(vec![SourceSection::IntegrityConstraints(vec![Constraint(
-        ConstraintType::Inline(IntegrityConstraint::new(
-            Add(
-                Box::new(SymbolAccess(SymbolAccess::new(
-                    Identifier("a".to_string()),
-                    AccessType::Default,
-                    0,
-                ))),
-                Box::new(SymbolAccess(SymbolAccess::new(
-                    Identifier("$alphas".to_string()),
-                    AccessType::Vector(1),
-                    0,
-                ))),
-            ),
-            Const(0),
-        )),
-        None,
-        None,
+        IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
+                Add(
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("a".to_string()),
+                        AccessType::Default,
+                        0,
+                    ))),
+                    Box::new(SymbolAccess(SymbolAccess::new(
+                        Identifier("$alphas".to_string()),
+                        AccessType::Vector(1),
+                        0,
+                    ))),
+                ),
+                Const(0),
+            )),
+            None,
+            None,
+        ),
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }

--- a/parser/src/parser/tests/random_values.rs
+++ b/parser/src/parser/tests/random_values.rs
@@ -94,6 +94,7 @@ fn random_values_index_access() {
             Const(0),
         )),
         None,
+        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }

--- a/parser/src/parser/tests/selectors.rs
+++ b/parser/src/parser/tests/selectors.rs
@@ -29,6 +29,7 @@ fn single_selector() {
             AccessType::Default,
             0,
         ))),
+        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -105,6 +106,7 @@ fn chained_selectors() {
                 )),
             )),
         )),
+        None,
     )])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -143,6 +145,7 @@ fn multiconstraint_selectors() {
                     ))),
                 )),
             )),
+            None,
         ),
         Constraint(
             ConstraintType::Inline(IntegrityConstraint::new(
@@ -170,6 +173,7 @@ fn multiconstraint_selectors() {
                     0,
                 ))),
             )),
+            None,
         ),
         Constraint(
             ConstraintType::Inline(IntegrityConstraint::new(
@@ -199,6 +203,7 @@ fn multiconstraint_selectors() {
                     ))),
                 )),
             )),
+            None,
         ),
     ])]);
     build_parse_test!(source).expect_ast(expected);

--- a/parser/src/parser/tests/trace_columns.rs
+++ b/parser/src/parser/tests/trace_columns.rs
@@ -1,8 +1,9 @@
 use super::{
-    build_parse_test, AccessType, Error, Expression::*, Identifier, IntegrityConstraint,
-    IntegrityStmt::*, ParseError, Source, SourceSection::*, SymbolAccess, TraceBinding,
+    build_parse_test, AccessType, Error, Expression::*, Identifier, InlineConstraintExpr,
+    IntegrityConstraint, IntegrityStmt::*, ParseError, Source, SourceSection::*, SymbolAccess,
+    TraceBinding,
 };
-use crate::ast::ConstraintType;
+use crate::ast::ConstraintExpr;
 
 // TRACE COLUMNS
 // ================================================================================================
@@ -69,8 +70,8 @@ fn trace_columns_groups() {
             ],
         ]),
         IntegrityConstraints(vec![
-            Constraint(
-                ConstraintType::Inline(IntegrityConstraint::new(
+            Constraint(IntegrityConstraint::new(
+                ConstraintExpr::Inline(InlineConstraintExpr::new(
                     SymbolAccess(SymbolAccess::new(
                         Identifier("a".to_string()),
                         AccessType::Vector(1),
@@ -80,9 +81,9 @@ fn trace_columns_groups() {
                 )),
                 None,
                 None,
-            ),
-            Constraint(
-                ConstraintType::Inline(IntegrityConstraint::new(
+            )),
+            Constraint(IntegrityConstraint::new(
+                ConstraintExpr::Inline(InlineConstraintExpr::new(
                     SymbolAccess(SymbolAccess::new(
                         Identifier("clk".to_string()),
                         AccessType::Default,
@@ -99,7 +100,7 @@ fn trace_columns_groups() {
                 )),
                 None,
                 None,
-            ),
+            )),
         ]),
     ]);
     build_parse_test!(source).expect_ast(expected);

--- a/parser/src/parser/tests/trace_columns.rs
+++ b/parser/src/parser/tests/trace_columns.rs
@@ -79,6 +79,7 @@ fn trace_columns_groups() {
                     Const(1),
                 )),
                 None,
+                None,
             ),
             Constraint(
                 ConstraintType::Inline(IntegrityConstraint::new(
@@ -96,6 +97,7 @@ fn trace_columns_groups() {
                         Box::new(Const(1)),
                     ),
                 )),
+                None,
                 None,
             ),
         ]),

--- a/parser/src/parser/tests/variables.rs
+++ b/parser/src/parser/tests/variables.rs
@@ -52,6 +52,7 @@ fn variables_with_and_operators() {
                 AccessType::Default,
                 0,
             ))),
+            None,
         ),
     ])]);
     build_parse_test!(source).expect_ast(expected);
@@ -120,6 +121,7 @@ fn variables_with_or_operators() {
                 AccessType::Default,
                 0,
             ))),
+            None,
         ),
     ])]);
     build_parse_test!(source).expect_ast(expected);

--- a/parser/src/parser/tests/variables.rs
+++ b/parser/src/parser/tests/variables.rs
@@ -1,7 +1,7 @@
 use super::{build_parse_test, Identifier, IntegrityConstraint, Source, SourceSection};
 use crate::ast::{
-    AccessType, ConstraintType, Expression::*, IntegrityStmt::*, SymbolAccess, VariableBinding,
-    VariableValueExpr,
+    AccessType, ConstraintExpr, Expression::*, InlineConstraintExpr, IntegrityStmt::*,
+    SymbolAccess, VariableBinding, VariableValueExpr,
 };
 
 // VARIABLES
@@ -31,8 +31,8 @@ fn variables_with_and_operators() {
                 )),
             )),
         )),
-        Constraint(
-            ConstraintType::Inline(IntegrityConstraint::new(
+        Constraint(IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
                 SymbolAccess(SymbolAccess::new(
                     Identifier("clk".to_string()),
                     AccessType::Default,
@@ -47,13 +47,13 @@ fn variables_with_and_operators() {
                     Box::new(Const(1)),
                 ),
             )),
+            None,
             Some(SymbolAccess(SymbolAccess::new(
                 Identifier("flag".to_string()),
                 AccessType::Default,
                 0,
             ))),
-            None,
-        ),
+        )),
     ])]);
     build_parse_test!(source).expect_ast(expected);
 }
@@ -100,8 +100,8 @@ fn variables_with_or_operators() {
                 )),
             )),
         )),
-        Constraint(
-            ConstraintType::Inline(IntegrityConstraint::new(
+        Constraint(IntegrityConstraint::new(
+            ConstraintExpr::Inline(InlineConstraintExpr::new(
                 SymbolAccess(SymbolAccess::new(
                     Identifier("clk".to_string()),
                     AccessType::Default,
@@ -116,13 +116,13 @@ fn variables_with_or_operators() {
                     Box::new(Const(1)),
                 ),
             )),
+            None,
             Some(SymbolAccess(SymbolAccess::new(
                 Identifier("flag".to_string()),
                 AccessType::Default,
                 0,
             ))),
-            None,
-        ),
+        )),
     ])]);
     build_parse_test!(source).expect_ast(expected);
 }


### PR DESCRIPTION
Addressing #236.

- Combines `Constraint` and `ConstraintComprehension` variants.
- Re-orders constraint comprehension with selectors statements to place selectors after comprehension (i.e., `enf x = a + b for x in c when s[0] & s[1]`)