### PR TITLE
feat(ir): add support for selectors

### DIFF
--- a/air-script/tests/main.rs
+++ b/air-script/tests/main.rs
@@ -143,3 +143,13 @@ fn list_folding() {
     let expected = expect_file!["list_folding/list_folding.rs"];
     expected.assert_eq(&generated_air);
 }
+
+#[test]
+fn selectors() {
+    let generated_air = Test::new("tests/selectors/selectors.air".to_string())
+        .transpile()
+        .unwrap();
+
+    let expected = expect_file!["selectors/selectors.rs"];
+    expected.assert_eq(&generated_air);
+}

--- a/air-script/tests/selectors/selectors.air
+++ b/air-script/tests/selectors/selectors.air
@@ -1,0 +1,16 @@
+def SelectorsAir
+
+trace_columns:
+        main: [s[3], clk]
+    
+public_inputs:
+    stack_inputs: [16]
+
+boundary_constraints:
+    enf clk.first = 0
+
+integrity_constraints:
+    enf clk' = 0 when s[0] & !s[1]
+    match enf:
+        clk' = clk when s[0] & s[1]
+        clk' = 1 when !s[0] & !s[1]

--- a/air-script/tests/selectors/selectors.rs
+++ b/air-script/tests/selectors/selectors.rs
@@ -1,0 +1,92 @@
+use winter_air::{Air, AirContext, Assertion, AuxTraceRandElements, EvaluationFrame, ProofOptions as WinterProofOptions, TransitionConstraintDegree, TraceInfo};
+use winter_math::fields::f64::BaseElement as Felt;
+use winter_math::{ExtensionOf, FieldElement};
+use winter_utils::collections::Vec;
+use winter_utils::{ByteWriter, Serializable};
+
+pub struct PublicInputs {
+    stack_inputs: [Felt; 16],
+}
+
+impl PublicInputs {
+    pub fn new(stack_inputs: [Felt; 16]) -> Self {
+        Self { stack_inputs }
+    }
+}
+
+impl Serializable for PublicInputs {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write(self.stack_inputs.as_slice());
+    }
+}
+
+pub struct SelectorsAir {
+    context: AirContext<Felt>,
+    stack_inputs: [Felt; 16],
+}
+
+impl SelectorsAir {
+    pub fn last_step(&self) -> usize {
+        self.trace_length() - self.context().num_transition_exemptions()
+    }
+}
+
+impl Air for SelectorsAir {
+    type BaseField = Felt;
+    type PublicInputs = PublicInputs;
+
+    fn context(&self) -> &AirContext<Felt> {
+        &self.context
+    }
+
+    fn new(trace_info: TraceInfo, public_inputs: PublicInputs, options: WinterProofOptions) -> Self {
+        let main_degrees = vec![TransitionConstraintDegree::new(3), TransitionConstraintDegree::new(3), TransitionConstraintDegree::new(3)];
+        let aux_degrees = vec![];
+        let num_main_assertions = 1;
+        let num_aux_assertions = 0;
+
+        let context = AirContext::new_multi_segment(
+            trace_info,
+            main_degrees,
+            aux_degrees,
+            num_main_assertions,
+            num_aux_assertions,
+            options,
+        )
+        .set_num_transition_exemptions(2);
+        Self { context, stack_inputs: public_inputs.stack_inputs }
+    }
+
+    fn get_periodic_column_values(&self) -> Vec<Vec<Felt>> {
+        vec![]
+    }
+
+    fn get_assertions(&self) -> Vec<Assertion<Felt>> {
+        let mut result = Vec::new();
+        result.push(Assertion::single(3, 0, Felt::ZERO));
+        result
+    }
+
+    fn get_aux_assertions<E: FieldElement<BaseField = Felt>>(&self, aux_rand_elements: &AuxTraceRandElements<E>) -> Vec<Assertion<E>> {
+        let mut result = Vec::new();
+        result
+    }
+
+    fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
+        let main_current = frame.current();
+        let main_next = frame.next();
+        result[0] = (main_next[3] - E::ZERO) * main_current[0] * (E::ONE - main_current[1]);
+        result[1] = (main_next[3] - main_current[3]) * main_current[0] * main_current[1];
+        result[2] = (main_next[3] - E::ONE) * (E::ONE - main_current[0]) * (E::ONE - main_current[1]);
+    }
+
+    fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])
+    where F: FieldElement<BaseField = Felt>,
+          E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
+    {
+        let main_current = main_frame.current();
+        let main_next = main_frame.next();
+        let aux_current = aux_frame.current();
+        let aux_next = aux_frame.next();
+    }
+}

--- a/ir/src/constraint_builder/boundary_constraints.rs
+++ b/ir/src/constraint_builder/boundary_constraints.rs
@@ -94,7 +94,7 @@ impl ConstraintBuilder {
                 }
 
                 // merge the two sides of the expression into a constraint.
-                let root = self.merge_equal_exprs(lhs, rhs);
+                let root = self.merge_equal_exprs(lhs, rhs, None);
 
                 // save the constraint information
                 self.insert_constraint(root, lhs_segment.into(), domain)?

--- a/ir/src/constraint_builder/expression.rs
+++ b/ir/src/constraint_builder/expression.rs
@@ -9,8 +9,18 @@ impl ConstraintBuilder {
     ///
     /// TODO: we can optimize this in the future in the case where lhs or rhs equals zero to just
     /// return the other expression.
-    pub(crate) fn merge_equal_exprs(&mut self, lhs: NodeIndex, rhs: NodeIndex) -> NodeIndex {
-        self.insert_graph_node(Operation::Sub(lhs, rhs))
+    pub(crate) fn merge_equal_exprs(
+        &mut self,
+        lhs: NodeIndex,
+        rhs: NodeIndex,
+        selectors: Option<NodeIndex>,
+    ) -> NodeIndex {
+        if let Some(selectors) = selectors {
+            let constraint = self.insert_graph_node(Operation::Sub(lhs, rhs));
+            self.insert_graph_node(Operation::Mul(constraint, selectors))
+        } else {
+            self.insert_graph_node(Operation::Sub(lhs, rhs))
+        }
     }
 
     /// Adds the expression to the graph and returns the [ExprDetails] of the constraint.

--- a/ir/src/constraint_builder/integrity_constraints/mod.rs
+++ b/ir/src/constraint_builder/integrity_constraints/mod.rs
@@ -23,7 +23,7 @@ impl ConstraintBuilder {
     ) -> Result<(), SemanticError> {
         match stmt {
             IntegrityStmt::Constraint(constraint) => {
-                let (constraint_expr, _, _) = constraint.into_parts();
+                let (constraint_expr, _, selectors) = constraint.into_parts();
                 match constraint_expr {
                     ConstraintExpr::Inline(inline_constraint) => {
                         let (lhs, rhs) = inline_constraint.into_parts();
@@ -33,8 +33,15 @@ impl ConstraintBuilder {
                         // add the right hand side expression to the graph.
                         let rhs = self.insert_expr(rhs)?;
 
+                        // add the selectors expression to the graph
+                        let selectors = if let Some(selectors) = selectors {
+                            Some(self.insert_expr(selectors)?)
+                        } else {
+                            None
+                        };
+
                         // merge the two sides of the expression into a constraint.
-                        let root = self.merge_equal_exprs(lhs, rhs);
+                        let root = self.merge_equal_exprs(lhs, rhs, selectors);
 
                         // get the trace segment and domain of the constraint
                         // the default domain for integrity constraints is `EveryRow`

--- a/ir/src/tests/selectors.rs
+++ b/ir/src/tests/selectors.rs
@@ -1,6 +1,5 @@
 use super::{parse, AirIR};
 
-#[ignore]
 #[test]
 fn single_selector() {
     let source = "
@@ -21,7 +20,6 @@ fn single_selector() {
     assert!(result.is_ok());
 }
 
-#[ignore]
 #[test]
 fn chained_selectors() {
     let source = "
@@ -42,7 +40,6 @@ fn chained_selectors() {
     assert!(result.is_ok());
 }
 
-#[ignore]
 #[test]
 fn multiconstraint_selectors() {
     let source = "


### PR DESCRIPTION
Partly addressing #125.
Adds support for selectors to IR.

Note: This doesn't implement selectors with evaluators yet. That will be done in a subsequent PR.