### PR TITLE
Enum for section exhaustive check

### DIFF
--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -25,7 +25,7 @@ pub use symbol_table::Value;
 use symbol_table::{Symbol, SymbolBinding, SymbolTable};
 
 mod validation;
-use validation::{SemanticError, SourceValidator};
+use validation::{Section, SemanticError, SourceValidator};
 
 #[cfg(test)]
 mod tests;
@@ -80,16 +80,16 @@ impl AirIR {
                 }
                 ast::SourceSection::Trace(trace_bindings) => {
                     if !trace_bindings.is_empty() {
-                        validator.exists("main_trace_columns");
+                        validator.exists(Section::MainTraceColumns);
                     }
                     if trace_bindings.len() > 1 {
-                        validator.exists("aux_trace_columns");
+                        validator.exists(Section::AuxTraceColumns);
                     }
                     // accumulate and save the trace bindings for later processing.
                     trace_decls.push(trace_bindings);
                 }
                 ast::SourceSection::PublicInputs(inputs) => {
-                    validator.exists("public_inputs");
+                    validator.exists(Section::PublicInputs);
                     // accumulate and save the public input bindings for later processing.
                     pub_input_decls.extend(inputs);
                 }
@@ -98,17 +98,17 @@ impl AirIR {
                     symbol_table.insert_periodic_columns(columns)?;
                 }
                 ast::SourceSection::RandomValues(values) => {
-                    validator.exists("random_values");
+                    validator.exists(Section::RandomValues);
                     // process & validate the random value declarations
                     symbol_table.insert_random_values(values)?;
                 }
                 ast::SourceSection::BoundaryConstraints(stmts) => {
-                    validator.exists("boundary_constraints");
+                    validator.exists(Section::BoundaryConstraints);
                     // save the boundary statements for processing after the SymbolTable is built.
                     boundary_stmts.extend(stmts);
                 }
                 ast::SourceSection::IntegrityConstraints(stmts) => {
-                    validator.exists("integrity_constraints");
+                    validator.exists(Section::IntegrityConstraints);
                     // save the integrity statements for processing after the SymbolTable is built.
                     integrity_stmts.extend(stmts);
                 }

--- a/ir/src/validation/mod.rs
+++ b/ir/src/validation/mod.rs
@@ -7,4 +7,4 @@ mod error;
 pub(super) use error::SemanticError;
 
 mod validator;
-pub(super) use validator::SourceValidator;
+pub(super) use validator::{Section, SourceValidator};

--- a/ir/src/validation/validator.rs
+++ b/ir/src/validation/validator.rs
@@ -10,6 +10,15 @@ pub(crate) struct SourceValidator {
     random_values_exists: bool,
 }
 
+pub enum Section {
+    MainTraceColumns,
+    AuxTraceColumns,
+    PublicInputs,
+    BoundaryConstraints,
+    IntegrityConstraints,
+    RandomValues,
+}
+
 impl SourceValidator {
     pub fn new() -> Self {
         SourceValidator {
@@ -23,15 +32,14 @@ impl SourceValidator {
     }
 
     /// If the declaration exists, sets corresponding boolean flag to true.
-    pub fn exists(&mut self, section: &str) {
+    pub fn exists(&mut self, section: Section) {
         match section {
-            "main_trace_columns" => self.main_trace_columns_exists = true,
-            "aux_trace_columns" => self.aux_trace_columns_exists = true,
-            "public_inputs" => self.public_inputs_exists = true,
-            "boundary_constraints" => self.boundary_constraints_exists = true,
-            "integrity_constraints" => self.integrity_constraints_exists = true,
-            "random_values" => self.random_values_exists = true,
-            _ => unreachable!(),
+            Section::MainTraceColumns => self.main_trace_columns_exists = true,
+            Section::AuxTraceColumns => self.aux_trace_columns_exists = true,
+            Section::PublicInputs => self.public_inputs_exists = true,
+            Section::BoundaryConstraints => self.boundary_constraints_exists = true,
+            Section::IntegrityConstraints => self.integrity_constraints_exists = true,
+            Section::RandomValues => self.random_values_exists = true,
         }
     }
 


### PR DESCRIPTION
An enum has a few advantages:

- it auto completes
- the compiler checks the pattern is exhaustive
- is more efficient (matching on a string does a `bcmp` for each arm, not super important here though)