### PR TITLE
fix graph cloning when processing evaluator function calls

### DIFF
--- a/air-script/tests/evaluators/evaluators.air
+++ b/air-script/tests/evaluators/evaluators.air
@@ -1,0 +1,20 @@
+def EvaluatorsAir
+
+ev is_unchanged([x]):
+    enf x' = x
+
+ev is_binary([x]):
+    enf x^2 = x
+
+trace_columns:
+    main: [b]
+
+public_inputs:
+    stack_inputs: [16]
+
+boundary_constraints:
+    enf b.first = 0
+
+integrity_constraints:
+    enf is_unchanged([b])
+    enf is_binary([b])

--- a/air-script/tests/evaluators/evaluators.rs
+++ b/air-script/tests/evaluators/evaluators.rs
@@ -1,0 +1,91 @@
+use winter_air::{Air, AirContext, Assertion, AuxTraceRandElements, EvaluationFrame, ProofOptions as WinterProofOptions, TransitionConstraintDegree, TraceInfo};
+use winter_math::fields::f64::BaseElement as Felt;
+use winter_math::{ExtensionOf, FieldElement};
+use winter_utils::collections::Vec;
+use winter_utils::{ByteWriter, Serializable};
+
+pub struct PublicInputs {
+    stack_inputs: [Felt; 16],
+}
+
+impl PublicInputs {
+    pub fn new(stack_inputs: [Felt; 16]) -> Self {
+        Self { stack_inputs }
+    }
+}
+
+impl Serializable for PublicInputs {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write(self.stack_inputs.as_slice());
+    }
+}
+
+pub struct EvaluatorsAir {
+    context: AirContext<Felt>,
+    stack_inputs: [Felt; 16],
+}
+
+impl EvaluatorsAir {
+    pub fn last_step(&self) -> usize {
+        self.trace_length() - self.context().num_transition_exemptions()
+    }
+}
+
+impl Air for EvaluatorsAir {
+    type BaseField = Felt;
+    type PublicInputs = PublicInputs;
+
+    fn context(&self) -> &AirContext<Felt> {
+        &self.context
+    }
+
+    fn new(trace_info: TraceInfo, public_inputs: PublicInputs, options: WinterProofOptions) -> Self {
+        let main_degrees = vec![TransitionConstraintDegree::new(1), TransitionConstraintDegree::new(2)];
+        let aux_degrees = vec![];
+        let num_main_assertions = 1;
+        let num_aux_assertions = 0;
+
+        let context = AirContext::new_multi_segment(
+            trace_info,
+            main_degrees,
+            aux_degrees,
+            num_main_assertions,
+            num_aux_assertions,
+            options,
+        )
+        .set_num_transition_exemptions(2);
+        Self { context, stack_inputs: public_inputs.stack_inputs }
+    }
+
+    fn get_periodic_column_values(&self) -> Vec<Vec<Felt>> {
+        vec![]
+    }
+
+    fn get_assertions(&self) -> Vec<Assertion<Felt>> {
+        let mut result = Vec::new();
+        result.push(Assertion::single(0, 0, Felt::ZERO));
+        result
+    }
+
+    fn get_aux_assertions<E: FieldElement<BaseField = Felt>>(&self, aux_rand_elements: &AuxTraceRandElements<E>) -> Vec<Assertion<E>> {
+        let mut result = Vec::new();
+        result
+    }
+
+    fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
+        let main_current = frame.current();
+        let main_next = frame.next();
+        result[0] = main_next[0] - main_current[0];
+        result[1] = main_current[0].exp(E::PositiveInteger::from(2_u64)) - main_current[0];
+    }
+
+    fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])
+    where F: FieldElement<BaseField = Felt>,
+          E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
+    {
+        let main_current = main_frame.current();
+        let main_next = main_frame.next();
+        let aux_current = aux_frame.current();
+        let aux_next = aux_frame.next();
+    }
+}

--- a/air-script/tests/main.rs
+++ b/air-script/tests/main.rs
@@ -77,6 +77,16 @@ fn constants() {
 }
 
 #[test]
+fn evaluators() {
+    let generated_air = Test::new("tests/evaluators/evaluators.air".to_string())
+        .transpile()
+        .unwrap();
+
+    let expected = expect_file!["evaluators/evaluators.rs"];
+    expected.assert_eq(&generated_air);
+}
+
+#[test]
 fn variables() {
     let generated_air = Test::new("tests/variables/variables.air".to_string())
         .transpile()

--- a/ir/src/constraint_builder/evaluators.rs
+++ b/ir/src/constraint_builder/evaluators.rs
@@ -136,7 +136,9 @@ impl Evaluator {
         node_idx_offset: usize,
     ) -> (AlgebraicGraph, Vec<Vec<ConstraintRoot>>) {
         // clone the graph, updating the nodes which reference the trace by the offsets.
-        let ev_call_graph = self.graph.clone_with_offsets(trace_offsets);
+        let ev_call_graph = self
+            .graph
+            .clone_with_offsets(trace_offsets, node_idx_offset);
 
         // create a new set of [ConstraintRoot] with updated [NodeIndex] for each constraint
         let constraints = self


### PR DESCRIPTION
This PR addresses #280. When evaluator graphs were being cloned, the node index references weren't being updated to reflect the offset of the node indices.