### PR TITLE
Fix conversion of `SymbolAccess` to `TraceAccess` for multi-column references

### DIFF
--- a/ir/src/symbol_table/mod.rs
+++ b/ir/src/symbol_table/mod.rs
@@ -243,10 +243,11 @@ impl SymbolTable {
                 ));
             }
         };
+
         Ok(TraceAccess::new(
             columns.trace_segment(),
             col_offset,
-            1,
+            columns.size(),
             symbol_access.offset(),
         ))
     }

--- a/ir/src/tests/evaluators.rs
+++ b/ir/src/tests/evaluators.rs
@@ -154,3 +154,26 @@ fn ev_call_inside_evaluator_with_aux() {
     let result = AirIR::new(parsed);
     assert!(result.is_ok());
 }
+
+#[test]
+fn ev_fn_call_with_column_group() {
+    let source = "
+    ev clk_selectors([selectors[3], clk]):
+        enf (clk' - clk) * selectors[0] * selectors[1] * selectors[2] = 0
+    
+    trace_columns:
+        main: [s[3], clk]
+        
+    public_inputs:
+        stack_inputs: [16]
+        
+    boundary_constraints:
+        enf clk.first = 0
+        
+    integrity_constraints:
+        enf clk_selectors([s, clk])";
+
+    let parsed = parse(source).expect("Parsing failed");
+    let result = AirIR::new(parsed);
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
This addresses #281. It adds a new test and fixes the issue with converting column group `SymbolAccess` references to `TraceAccess`