### PR TITLE
deps: structopt -> clap

### DIFF
--- a/air-script/Cargo.toml
+++ b/air-script/Cargo.toml
@@ -23,7 +23,7 @@ ir = { package = "air-ir", path = "../ir", version = "0.2.0" }
 log = { version = "0.4", default-features = false }
 miden-diagnostics = { git = "https://github.com/0xPolygonMiden/miden-diagnostics" }
 parser = { package = "air-parser", path = "../parser", version = "0.2.0" }
-structopt = "0.3.26"
+clap = {version = "4.2", features = ["derive"]}
 
 [dev-dependencies]
 winter-air = { package = "winter-air", version = "0.5.1", default-features = false }

--- a/air-script/README.md
+++ b/air-script/README.md
@@ -42,10 +42,10 @@ To use the CLI, first run:
 cargo build --release
 ```
 
-Then, run the `airc` target with the `transpile` option and specify your input file with `-i`. For example:
+Then, run the `airc` target with the `transpile`. For example:
 
 ```
-./target/release/airc transpile -i examples/example.air
+./target/release/airc transpile examples/example.air
 ```
 
 When no output destination is specified, the output file will use the path and name of the input file, replacing the `.air` extension with `.rs`. For the above example, `examples/example.rs` will contain the generated output.

--- a/air-script/src/cli/mod.rs
+++ b/air-script/src/cli/mod.rs
@@ -1,2 +1,2 @@
 mod transpile;
-pub use transpile::TranspileCmd;
+pub use transpile::Transpile;

--- a/air-script/src/cli/transpile.rs
+++ b/air-script/src/cli/transpile.rs
@@ -1,3 +1,4 @@
+use clap::Args;
 use std::{fs, path::PathBuf, sync::Arc};
 
 use codegen_winter::CodeGenerator;
@@ -6,37 +7,27 @@ use miden_diagnostics::{
     term::termcolor::ColorChoice, CodeMap, DefaultEmitter, DiagnosticsHandler,
 };
 use parser::{ast::Source, Parser};
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
-#[structopt(
-    name = "Transpile",
-    about = "Transpile AirScript source code to Rust targeting Winterfell"
-)]
-pub struct TranspileCmd {
+#[derive(Args)]
+pub struct Transpile {
     /// Path to input file
-    #[structopt(short = "i", long = "input", parse(from_os_str))]
-    input_file: Option<PathBuf>,
-    /// Path to output file
-    #[structopt(short = "o", long = "output", parse(from_os_str))]
-    output_file: Option<PathBuf>,
+    input: PathBuf,
+
+    #[arg(
+        short,
+        long,
+        help = "Output filename, default to the input file with the .rs extension"
+    )]
+    output: Option<PathBuf>,
 }
 
-impl TranspileCmd {
+impl Transpile {
     pub fn execute(&self) -> Result<(), String> {
         println!("============================================================");
         println!("Transpiling...");
 
-        // get the input path
-        let input_path = match &self.input_file {
-            Some(path) => path.clone(),
-            None => {
-                return Err("No input file specified".to_string());
-            }
-        };
-
-        // get the output path
-        let output_path = match &self.output_file {
+        let input_path = &self.input;
+        let output_path = match &self.output {
             Some(path) => path.clone(),
             None => {
                 let mut path = input_path.clone();

--- a/air-script/src/main.rs
+++ b/air-script/src/main.rs
@@ -1,42 +1,35 @@
+use clap::{Parser, Subcommand};
 use std::io::Write;
-use structopt::StructOpt;
 
 mod cli;
 
-/// Root CLI struct
-#[derive(StructOpt, Debug)]
-#[structopt(name = "AirScript", about = "AirScript CLI")]
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+#[command(propagate_version = true)]
 pub struct Cli {
-    #[structopt(subcommand)]
-    action: Actions,
+    #[command(subcommand)]
+    command: Command,
 }
 
-/// CLI actions
-#[derive(StructOpt, Debug)]
-pub enum Actions {
-    Transpile(cli::TranspileCmd),
-}
-
-impl Cli {
-    pub fn execute(&self) -> Result<(), String> {
-        match &self.action {
-            Actions::Transpile(transpile) => transpile.execute(),
-        }
-    }
+#[derive(Subcommand)]
+pub enum Command {
+    /// Transpile AirScript source code to Rust targeting Winterfell
+    Transpile(cli::Transpile),
 }
 
 pub fn main() {
-    // configure logging
     env_logger::Builder::new()
         .format(|buf, record| writeln!(buf, "{}", record.args()))
         .filter_level(log::LevelFilter::Debug)
         .init();
 
-    // read command-line args
-    let cli = Cli::from_args();
+    let cli = Cli::parse();
 
-    // execute cli action
-    if let Err(error) = cli.execute() {
+    let res = match cli.command {
+        Command::Transpile(transpile) => transpile.execute(),
+    };
+
+    if let Err(error) = res {
         println!("{error}");
     }
 }

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -42,10 +42,10 @@ To use the CLI, first run:
 cargo build --release
 ```
 
-Then, run the `airc` target with the `transpile` option and specify your input file with `-i`. For example:
+Then, run the `airc` target with the `transpile` option. For example:
 
 ```
-./target/release/airc transpile -i examples/example.air
+./target/release/airc transpile examples/example.air
 ```
 
 You can use the `help` option to see other available options.


### PR DESCRIPTION
`structopt` is no longer in active development and is in maintenance mode. The recommendation is to use `clap` instead [ref](https://github.com/TeXitoi/structopt#maintenance)