### PR TITLE
masm codegen: optimized codegen for numerator aggregation

### DIFF
--- a/air-script/tests/aux_trace/aux_trace.masm
+++ b/air-script/tests/aux_trace/aux_trace.masm
@@ -1,40 +1,30 @@
 proc.compute_evaluate_transitions
     # constraint 0 for main
     padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
     # constraint 1 for main
     padw mem_loadw.4294965001 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 drop drop ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
     # constraint 2 for main
     padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2add ext2sub
-    # constraint 0 for aux
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
+    # constraint 3 for aux
     padw mem_loadw.4294965072 drop drop padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965000 drop drop ext2add ext2mul ext2sub
-    # constraint 1 for aux
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 drop drop ext2mul
+    # constraint 4 for aux
     padw mem_loadw.4294965073 movdn.3 movdn.3 drop drop padw mem_loadw.4294965073 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2add ext2mul ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 4 into the numerator
-    padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 3 into the numerator
-    padw mem_loadw.4294966017 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 2 into the numerator
-    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 1 into the numerator
-    padw mem_loadw.4294966016 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add ext2add ext2add ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/binary/binary.masm
+++ b/air-script/tests/binary/binary.masm
@@ -15,6 +15,8 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
     # constraint 1 for main
     padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
@@ -31,20 +33,14 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 1 into the numerator
-    padw mem_loadw.4294966016 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/bitwise/bitwise.masm
+++ b/air-script/tests/bitwise/bitwise.masm
@@ -142,8 +142,12 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
     # constraint 1 for main
     padw mem_loadw.500000001 drop drop padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub ext2mul push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
     # constraint 2 for main
     padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
@@ -160,6 +164,8 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
     # constraint 3 for main
     padw mem_loadw.4294965004 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
@@ -176,6 +182,8 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965004 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 drop drop ext2mul
     # constraint 4 for main
     padw mem_loadw.4294965005 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
@@ -192,6 +200,8 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965005 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul
     # constraint 5 for main
     padw mem_loadw.4294965006 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
@@ -208,6 +218,8 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965006 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966018 drop drop ext2mul
     # constraint 6 for main
     padw mem_loadw.4294965007 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
@@ -224,6 +236,8 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965007 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966019 movdn.3 movdn.3 drop drop ext2mul
     # constraint 7 for main
     padw mem_loadw.4294965008 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
@@ -240,6 +254,8 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965008 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966019 drop drop ext2mul
     # constraint 8 for main
     padw mem_loadw.4294965009 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
@@ -256,6 +272,8 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965009 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966020 movdn.3 movdn.3 drop drop ext2mul
     # constraint 9 for main
     padw mem_loadw.4294965010 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
@@ -272,6 +290,8 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965010 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966020 drop drop ext2mul
     # constraint 10 for main
     padw mem_loadw.500000000 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop push.2 push.0
     # push the accumulator to the stack
@@ -328,6 +348,8 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965006 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub ext2mul push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966021 movdn.3 movdn.3 drop drop ext2mul
     # constraint 11 for main
     padw mem_loadw.500000000 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop push.2 push.0
     # push the accumulator to the stack
@@ -384,6 +406,8 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965010 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub ext2mul push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966021 drop drop ext2mul
     # constraint 12 for main
     padw mem_loadw.500000001 drop drop padw mem_loadw.4294965001 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop push.16 push.0 ext2mul push.2 push.0
     # push the accumulator to the stack
@@ -440,6 +464,8 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965006 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub ext2mul push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966022 movdn.3 movdn.3 drop drop ext2mul
     # constraint 13 for main
     padw mem_loadw.500000001 drop drop padw mem_loadw.4294965002 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop push.16 push.0 ext2mul push.2 push.0
     # push the accumulator to the stack
@@ -496,10 +522,16 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965010 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub ext2mul push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966022 drop drop ext2mul
     # constraint 14 for main
     padw mem_loadw.500000000 drop drop padw mem_loadw.4294965011 movdn.3 movdn.3 drop drop ext2mul push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966023 movdn.3 movdn.3 drop drop ext2mul
     # constraint 15 for main
     padw mem_loadw.500000001 drop drop padw mem_loadw.4294965012 movdn.3 movdn.3 drop drop padw mem_loadw.4294965011 drop drop ext2sub ext2mul push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966023 drop drop ext2mul
     # constraint 16 for main
     push.1 push.0 padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965012 movdn.3 movdn.3 drop drop padw mem_loadw.4294965011 movdn.3 movdn.3 drop drop push.16 push.0 ext2mul push.2 push.0
     # push the accumulator to the stack
@@ -610,81 +642,15 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965006 movdn.3 movdn.3 drop drop padw mem_loadw.4294965010 movdn.3 movdn.3 drop drop ext2add push.2 push.0 padw mem_loadw.4294965006 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965010 movdn.3 movdn.3 drop drop ext2mul ext2sub ext2mul ext2add ext2sub ext2mul ext2add push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966024 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.cache_periodic_polys
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 16 into the numerator
-    padw mem_loadw.4294966024 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 15 into the numerator
-    padw mem_loadw.4294966023 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 14 into the numerator
-    padw mem_loadw.4294966023 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 13 into the numerator
-    padw mem_loadw.4294966022 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 12 into the numerator
-    padw mem_loadw.4294966022 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 11 into the numerator
-    padw mem_loadw.4294966021 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 10 into the numerator
-    padw mem_loadw.4294966021 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 9 into the numerator
-    padw mem_loadw.4294966020 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 8 into the numerator
-    padw mem_loadw.4294966020 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 7 into the numerator
-    padw mem_loadw.4294966019 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 6 into the numerator
-    padw mem_loadw.4294966019 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 5 into the numerator
-    padw mem_loadw.4294966018 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 4 into the numerator
-    padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 3 into the numerator
-    padw mem_loadw.4294966017 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 2 into the numerator
-    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 1 into the numerator
-    padw mem_loadw.4294966016 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/constants/constants.masm
+++ b/air-script/tests/constants/constants.masm
@@ -1,40 +1,30 @@
 proc.compute_evaluate_transitions
     # constraint 0 for main
     padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
     # constraint 1 for main
     padw mem_loadw.4294965001 drop drop push.0 push.0 padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2mul ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
     # constraint 2 for main
     padw mem_loadw.4294965002 drop drop push.1 push.0 push.0 push.0 ext2add padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2mul ext2sub
-    # constraint 0 for aux
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
+    # constraint 3 for aux
     padw mem_loadw.4294965072 drop drop padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop push.1 push.0 ext2add push.0 push.0 push.2 push.0 ext2mul ext2add ext2sub
-    # constraint 1 for aux
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 drop drop ext2mul
+    # constraint 4 for aux
     padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop push.1 push.0 push.1 push.0 push.0 push.0 ext2mul ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 4 into the numerator
-    padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 3 into the numerator
-    padw mem_loadw.4294966017 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 2 into the numerator
-    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 1 into the numerator
-    padw mem_loadw.4294966016 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add ext2add ext2add ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
+++ b/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
@@ -1,34 +1,26 @@
 proc.compute_evaluate_transitions
     # constraint 0 for aux
     padw mem_loadw.4294965074 movdn.3 movdn.3 drop drop padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
     # constraint 1 for aux
     padw mem_loadw.4294965075 movdn.3 movdn.3 drop drop padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
     # constraint 2 for aux
     padw mem_loadw.4294965076 movdn.3 movdn.3 drop drop padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
     # constraint 3 for aux
     padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 3 into the numerator
-    padw mem_loadw.4294966017 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 2 into the numerator
-    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 1 into the numerator
-    padw mem_loadw.4294966016 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add ext2add ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/constraint_comprehension/constraint_comprehension.masm
+++ b/air-script/tests/constraint_comprehension/constraint_comprehension.masm
@@ -1,34 +1,26 @@
 proc.compute_evaluate_transitions
     # constraint 0 for aux
     padw mem_loadw.4294965074 movdn.3 movdn.3 drop drop padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
     # constraint 1 for aux
     padw mem_loadw.4294965075 movdn.3 movdn.3 drop drop padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
     # constraint 2 for aux
     padw mem_loadw.4294965076 movdn.3 movdn.3 drop drop padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
     # constraint 3 for aux
     padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 3 into the numerator
-    padw mem_loadw.4294966017 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 2 into the numerator
-    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 1 into the numerator
-    padw mem_loadw.4294966016 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add ext2add ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/evaluators/evaluators.masm
+++ b/air-script/tests/evaluators/evaluators.masm
@@ -1,10 +1,16 @@
 proc.compute_evaluate_transitions
     # constraint 0 for main
     padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
     # constraint 1 for main
     padw mem_loadw.4294965002 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
     # constraint 2 for main
     padw mem_loadw.4294965006 drop drop padw mem_loadw.4294965006 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
     # constraint 3 for main
     padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
@@ -21,6 +27,8 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 drop drop ext2mul
     # constraint 4 for main
     padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
@@ -37,6 +45,8 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul
     # constraint 5 for main
     padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
@@ -53,6 +63,8 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966018 drop drop ext2mul
     # constraint 6 for main
     padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
@@ -69,40 +81,14 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966019 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 6 into the numerator
-    padw mem_loadw.4294966019 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 5 into the numerator
-    padw mem_loadw.4294966018 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 4 into the numerator
-    padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 3 into the numerator
-    padw mem_loadw.4294966017 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 2 into the numerator
-    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 1 into the numerator
-    padw mem_loadw.4294966016 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add ext2add ext2add ext2add ext2add ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/indexed_trace_access/indexed_trace_access.masm
+++ b/air-script/tests/indexed_trace_access/indexed_trace_access.masm
@@ -1,22 +1,18 @@
 proc.compute_evaluate_transitions
     # constraint 0 for main
     padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
-    # constraint 0 for aux
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
+    # constraint 1 for aux
     padw mem_loadw.4294965072 drop drop padw mem_loadw.4294965073 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 1 into the numerator
-    padw mem_loadw.4294966016 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/list_comprehension/list_comprehension.masm
+++ b/air-script/tests/list_comprehension/list_comprehension.masm
@@ -1,7 +1,9 @@
 proc.compute_evaluate_transitions
     # constraint 0 for main
     padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2sub
-    # constraint 0 for aux
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
+    # constraint 1 for aux
     padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop push.2 push.0
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -23,38 +25,26 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop ext2mul ext2mul ext2sub
-    # constraint 1 for aux
-    padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965076 drop drop padw mem_loadw.4294965080 drop drop ext2sub ext2mul ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
     # constraint 2 for aux
-    padw mem_loadw.4294965074 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965082 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2sub
+    padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965076 drop drop padw mem_loadw.4294965080 drop drop ext2sub ext2mul ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
     # constraint 3 for aux
+    padw mem_loadw.4294965074 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965082 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 drop drop ext2mul
+    # constraint 4 for aux
     padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop push.0 push.0 padw mem_loadw.4294965073 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965076 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop ext2sub push.1 push.0 padw mem_loadw.4294965074 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop ext2sub ext2add push.2 push.0 padw mem_loadw.4294965075 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965082 movdn.3 movdn.3 drop drop ext2sub ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 4 into the numerator
-    padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 3 into the numerator
-    padw mem_loadw.4294966017 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 2 into the numerator
-    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 1 into the numerator
-    padw mem_loadw.4294966016 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add ext2add ext2add ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/list_folding/list_folding.masm
+++ b/air-script/tests/list_folding/list_folding.masm
@@ -1,34 +1,26 @@
 proc.compute_evaluate_transitions
     # constraint 0 for aux
     padw mem_loadw.4294965073 drop drop padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop padw mem_loadw.4294965082 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965083 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965084 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
     # constraint 1 for aux
     padw mem_loadw.4294965074 drop drop padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop padw mem_loadw.4294965082 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965083 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965084 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
     # constraint 2 for aux
     padw mem_loadw.4294965075 drop drop padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop padw mem_loadw.4294965082 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop padw mem_loadw.4294965083 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop padw mem_loadw.4294965084 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop padw mem_loadw.4294965082 movdn.3 movdn.3 drop drop ext2add ext2mul padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop padw mem_loadw.4294965083 movdn.3 movdn.3 drop drop ext2add ext2mul padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop padw mem_loadw.4294965084 movdn.3 movdn.3 drop drop ext2add ext2mul ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
     # constraint 3 for aux
     padw mem_loadw.4294965076 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop padw mem_loadw.4294965082 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop padw mem_loadw.4294965083 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop padw mem_loadw.4294965084 movdn.3 movdn.3 drop drop ext2mul ext2add ext2add padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop padw mem_loadw.4294965082 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop padw mem_loadw.4294965083 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop padw mem_loadw.4294965084 movdn.3 movdn.3 drop drop ext2mul ext2add ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 3 into the numerator
-    padw mem_loadw.4294966017 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 2 into the numerator
-    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 1 into the numerator
-    padw mem_loadw.4294966016 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add ext2add ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/periodic_columns/periodic_columns.masm
+++ b/air-script/tests/periodic_columns/periodic_columns.masm
@@ -125,23 +125,19 @@ end # END PROC cache_periodic_polys
 proc.compute_evaluate_transitions
     # constraint 0 for main
     padw mem_loadw.500000000 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2add ext2mul push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
     # constraint 1 for main
     padw mem_loadw.500000001 drop drop padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub ext2mul push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.cache_periodic_polys
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 1 into the numerator
-    padw mem_loadw.4294966016 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/pub_inputs/pub_inputs.masm
+++ b/air-script/tests/pub_inputs/pub_inputs.masm
@@ -1,16 +1,14 @@
 proc.compute_evaluate_transitions
     # constraint 0 for main
     padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/random_values/random_values_bindings.masm
+++ b/air-script/tests/random_values/random_values_bindings.masm
@@ -1,16 +1,14 @@
 proc.compute_evaluate_transitions
     # constraint 0 for aux
     padw mem_loadw.4294965072 drop drop padw mem_loadw.4294965007 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965001 drop drop ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/random_values/random_values_simple.masm
+++ b/air-script/tests/random_values/random_values_simple.masm
@@ -1,16 +1,14 @@
 proc.compute_evaluate_transitions
     # constraint 0 for aux
     padw mem_loadw.4294965072 drop drop padw mem_loadw.4294965007 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965001 drop drop ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/selectors/selectors.masm
+++ b/air-script/tests/selectors/selectors.masm
@@ -1,28 +1,22 @@
 proc.compute_evaluate_transitions
     # constraint 0 for main
     padw mem_loadw.4294965003 drop drop push.0 push.0 ext2sub padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop push.1 push.0 padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
     # constraint 1 for main
     padw mem_loadw.4294965003 drop drop padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2mul ext2mul
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
     # constraint 2 for main
     padw mem_loadw.4294965003 drop drop push.1 push.0 ext2sub push.1 push.0 padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2sub push.1 push.0 padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 2 into the numerator
-    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 1 into the numerator
-    padw mem_loadw.4294966016 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/selectors/selectors_with_evaluators.masm
+++ b/air-script/tests/selectors/selectors_with_evaluators.masm
@@ -1,28 +1,22 @@
 proc.compute_evaluate_transitions
     # constraint 0 for main
     padw mem_loadw.4294965003 drop drop push.0 push.0 ext2sub padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop push.1 push.0 padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
     # constraint 1 for main
     padw mem_loadw.4294965003 drop drop padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2mul ext2mul
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
     # constraint 2 for main
     padw mem_loadw.4294965003 drop drop push.1 push.0 ext2sub push.1 push.0 padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2sub push.1 push.0 padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 2 into the numerator
-    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 1 into the numerator
-    padw mem_loadw.4294966016 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/system/system.masm
+++ b/air-script/tests/system/system.masm
@@ -1,16 +1,14 @@
 proc.compute_evaluate_transitions
     # constraint 0 for main
     padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/trace_col_groups/trace_col_groups.masm
+++ b/air-script/tests/trace_col_groups/trace_col_groups.masm
@@ -1,22 +1,18 @@
 proc.compute_evaluate_transitions
     # constraint 0 for main
     padw mem_loadw.4294965002 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
     # constraint 1 for main
     padw mem_loadw.4294965001 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 1 into the numerator
-    padw mem_loadw.4294966016 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/air-script/tests/variables/variables.masm
+++ b/air-script/tests/variables/variables.masm
@@ -97,41 +97,31 @@ proc.compute_evaluate_transitions
     drop drop
     # => [r1, r0, ...] (2 cycles)
     padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
     # constraint 1 for main
     padw mem_loadw.500000000 drop drop padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub ext2mul push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
     # constraint 2 for main
     push.1 push.0 padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2sub ext2mul push.2 push.0 push.3 push.0 ext2mul padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
     # constraint 3 for main
     padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2mul ext2sub ext2mul padw mem_loadw.4294965000 drop drop push.3 push.0 ext2sub push.4 push.0 push.2 push.0 ext2sub ext2sub ext2sub
-    # constraint 0 for aux
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 drop drop ext2mul
+    # constraint 4 for aux
     padw mem_loadw.4294965072 drop drop padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2add ext2mul ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_transitions
 
 proc.evaluate_transitions
     exec.cache_periodic_polys
     exec.compute_evaluate_transitions
-    # Compute the numerator of the constraint polynomial
-    push.0 push.0
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 4 into the numerator
-    padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 3 into the numerator
-    padw mem_loadw.4294966017 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 2 into the numerator
-    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 1 into the numerator
-    padw mem_loadw.4294966016 drop drop ext2mul ext2add # accumulate the contraint into the numerator
-    # Save the accumulator
-    movdn.2 movdn.2
-    # Accumulate constraint 0 into the numerator
-    padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul ext2add # accumulate the contraint into the numerator
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add ext2add ext2add ext2add
 end # END PROC evaluate_transitions
 
 proc.evaluate_boundary

--- a/codegen/masm/tests/test_aux.rs
+++ b/codegen/masm/tests/test_aux.rs
@@ -1,4 +1,4 @@
-use air_codegen_masm::code_gen;
+use air_codegen_masm::{code_gen, constants};
 use assembly::Assembler;
 use ir::AirIR;
 use processor::{
@@ -7,7 +7,7 @@ use processor::{
 };
 
 mod utils;
-use utils::{parse, test_code, to_stack_order};
+use utils::{parse, test_code, to_stack_order, Data};
 
 static SIMPLE_AUX_AIR: &str = "
 def SimpleAux
@@ -37,19 +37,34 @@ fn test_simple_aux() {
     let ast = parse(SIMPLE_AUX_AIR);
     let ir = AirIR::new(ast).expect("build AirIR failed");
     let code = code_gen(&ir).expect("codegen failed");
-    let trace_len = 2u64.pow(4);
-    let z = QuadExtension::new(Felt::new(1), Felt::ZERO);
 
+    let trace_len = 2u64.pow(4);
+    let one = QuadExtension::new(Felt::new(1), Felt::ZERO);
+    let z = one.clone();
     let a = QuadExtension::new(Felt::new(3), Felt::ZERO);
     let b = QuadExtension::new(Felt::new(7), Felt::ZERO);
     let a_prime = a;
     let b_prime = b;
-    let main_frame = to_stack_order(&[a, a_prime]);
-    let aux_frame = to_stack_order(&[b, b_prime]);
+
     let code = test_code(
         code,
-        main_frame,
-        aux_frame,
+        vec![
+            Data {
+                data: to_stack_order(&[a, a_prime]),
+                address: constants::OOD_FRAME_ADDRESS,
+                descriptor: "main_trace",
+            },
+            Data {
+                data: to_stack_order(&[b, b_prime]),
+                address: constants::OOD_AUX_FRAME_ADDRESS,
+                descriptor: "aux_trace",
+            },
+            Data {
+                data: to_stack_order(&vec![one; 6]),
+                address: constants::COMPOSITION_COEF_ADDRESS,
+                descriptor: "composition_coefficients",
+            },
+        ],
         trace_len,
         z,
         &["compute_evaluate_transitions"],
@@ -67,12 +82,12 @@ fn test_simple_aux() {
     // results are in stack-order
     #[rustfmt::skip]
     let expected = to_stack_order(&[
-        b * a,
-        b - a,
-        b + a,
-        a * a,
-        a - a,
-        a + a,
+        b * a, // result: 21
+        b - a, // result: 4
+        b + a, // result: 10
+        a * a, // result: 9
+        a - a, // result: 0
+        a + a, // result: 6
     ]);
 
     assert!(

--- a/codegen/masm/tests/test_basic_arithmetic.rs
+++ b/codegen/masm/tests/test_basic_arithmetic.rs
@@ -1,4 +1,4 @@
-use air_codegen_masm::code_gen;
+use air_codegen_masm::{code_gen, constants};
 use assembly::Assembler;
 use ir::AirIR;
 use processor::{
@@ -7,7 +7,7 @@ use processor::{
 };
 
 mod utils;
-use utils::{parse, test_code, to_stack_order};
+use utils::{parse, test_code, to_stack_order, Data};
 
 static ARITH_AIR: &str = "
 def SimpleArithmetic
@@ -36,19 +36,34 @@ fn test_simple_arithmetic() {
     let ast = parse(ARITH_AIR);
     let ir = AirIR::new(ast).expect("build AirIR failed");
     let code = code_gen(&ir).expect("codegen failed");
-    let trace_len = 2u64.pow(4);
-    let z = QuadExtension::new(Felt::new(1), Felt::ZERO);
 
+    let trace_len = 2u64.pow(4);
+    let one = QuadExtension::new(Felt::new(1), Felt::ZERO);
+    let z = one;
     let a = QuadExtension::new(Felt::new(3), Felt::ZERO);
     let b = QuadExtension::new(Felt::new(7), Felt::ZERO);
     let a_prime = a;
     let b_prime = b;
-    let main_frame = to_stack_order(&[a, a_prime, b, b_prime]);
-    let aux_frame = to_stack_order(&[]);
+
     let code = test_code(
         code,
-        main_frame,
-        aux_frame,
+        vec![
+            Data {
+                data: to_stack_order(&[a, a_prime, b, b_prime]),
+                address: constants::OOD_FRAME_ADDRESS,
+                descriptor: "main_trace",
+            },
+            Data {
+                data: to_stack_order(&[]),
+                address: constants::OOD_AUX_FRAME_ADDRESS,
+                descriptor: "aux_trace",
+            },
+            Data {
+                data: to_stack_order(&vec![one; 6]),
+                address: constants::COMPOSITION_COEF_ADDRESS,
+                descriptor: "composition_coefficients",
+            },
+        ],
         trace_len,
         z,
         &["compute_evaluate_transitions"],
@@ -110,19 +125,34 @@ fn test_exp() {
     let ast = parse(EXP_AIR);
     let ir = AirIR::new(ast).expect("build AirIR failed");
     let code = code_gen(&ir).expect("codegen failed");
-    let trace_len = 2u64.pow(4);
-    let z = QuadExtension::new(Felt::new(1), Felt::ZERO);
 
+    let trace_len = 2u64.pow(4);
+    let one = QuadExtension::new(Felt::new(1), Felt::ZERO);
+    let z = one;
     let a = QuadExtension::<Felt>::ZERO;
     let b = QuadExtension::new(Felt::new(3), Felt::ZERO);
     let a_prime = a;
     let b_prime = b;
-    let main_frame = to_stack_order(&[a, a_prime, b, b_prime]);
-    let aux_frame = to_stack_order(&[]);
+
     let code = test_code(
         code,
-        main_frame,
-        aux_frame,
+        vec![
+            Data {
+                data: to_stack_order(&[a, a_prime, b, b_prime]),
+                address: constants::OOD_FRAME_ADDRESS,
+                descriptor: "main_trace",
+            },
+            Data {
+                data: to_stack_order(&[]),
+                address: constants::OOD_AUX_FRAME_ADDRESS,
+                descriptor: "aux_trace",
+            },
+            Data {
+                data: to_stack_order(&vec![one; 5]),
+                address: constants::COMPOSITION_COEF_ADDRESS,
+                descriptor: "composition_coefficients",
+            },
+        ],
         trace_len,
         z,
         &["compute_evaluate_transitions"],
@@ -179,9 +209,10 @@ fn test_long_trace() {
     let ast = parse(LONG_TRACE);
     let ir = AirIR::new(ast).expect("build AirIR failed");
     let code = code_gen(&ir).expect("codegen failed");
-    let trace_len = 2u64.pow(4);
-    let z = QuadExtension::new(Felt::new(1), Felt::ZERO);
 
+    let trace_len = 2u64.pow(4);
+    let one = QuadExtension::new(Felt::new(1), Felt::ZERO);
+    let z = one;
     let a = QuadExtension::new(Felt::new(2), Felt::ZERO);
     let b = QuadExtension::new(Felt::new(3), Felt::ZERO);
     let c = QuadExtension::new(Felt::new(5), Felt::ZERO);
@@ -192,12 +223,26 @@ fn test_long_trace() {
     let c_prime = c;
     let d_prime = d;
     let e_prime = e;
-    let main_frame = to_stack_order(&[a, a_prime, b, b_prime, c, c_prime, d, d_prime, e, e_prime]);
-    let aux_frame = to_stack_order(&[]);
+
     let code = test_code(
         code,
-        main_frame,
-        aux_frame,
+        vec![
+            Data {
+                data: to_stack_order(&[a, a_prime, b, b_prime, c, c_prime, d, d_prime, e, e_prime]),
+                address: constants::OOD_FRAME_ADDRESS,
+                descriptor: "main_trace",
+            },
+            Data {
+                data: to_stack_order(&[]),
+                address: constants::OOD_AUX_FRAME_ADDRESS,
+                descriptor: "aux_trace",
+            },
+            Data {
+                data: to_stack_order(&vec![one; 1]),
+                address: constants::COMPOSITION_COEF_ADDRESS,
+                descriptor: "composition_coefficients",
+            },
+        ],
         trace_len,
         z,
         &["compute_evaluate_transitions"],
@@ -245,9 +290,10 @@ fn test_vector() {
     let ast = parse(VECTOR);
     let ir = AirIR::new(ast).expect("build AirIR failed");
     let code = code_gen(&ir).expect("codegen failed");
-    let trace_len = 2u64.pow(4);
-    let z = QuadExtension::new(Felt::new(1), Felt::ZERO);
 
+    let trace_len = 2u64.pow(4);
+    let one = QuadExtension::new(Felt::new(1), Felt::ZERO);
+    let z = one;
     let clk = QuadExtension::new(Felt::new(2), Felt::ZERO);
     let fmp_0 = QuadExtension::new(Felt::new(3), Felt::ZERO);
     let fmp_1 = QuadExtension::new(Felt::new(5), Felt::ZERO);
@@ -256,10 +302,26 @@ fn test_vector() {
     let fmp_1_prime = fmp_1;
     let main_frame = to_stack_order(&[clk, clk_prime, fmp_0, fmp_0_prime, fmp_1, fmp_1_prime]);
     let aux_frame = to_stack_order(&[]);
+
     let code = test_code(
         code,
-        main_frame,
-        aux_frame,
+        vec![
+            Data {
+                data: main_frame,
+                address: constants::OOD_FRAME_ADDRESS,
+                descriptor: "main_trace",
+            },
+            Data {
+                data: aux_frame,
+                address: constants::OOD_AUX_FRAME_ADDRESS,
+                descriptor: "aux_trace",
+            },
+            Data {
+                data: to_stack_order(&vec![one; 1]),
+                address: constants::COMPOSITION_COEF_ADDRESS,
+                descriptor: "composition_coefficients",
+            },
+        ],
         trace_len,
         z,
         &["compute_evaluate_transitions"],
@@ -308,21 +370,35 @@ fn test_multiple_rows() {
     let ast = parse(MULTIPLE_ROWS_AIR);
     let ir = AirIR::new(ast).expect("build AirIR failed");
     let code = code_gen(&ir).expect("codegen failed");
-    let trace_len = 2u64.pow(4);
-    let z = QuadExtension::new(Felt::new(1), Felt::ZERO);
 
+    let trace_len = 2u64.pow(4);
+    let one = QuadExtension::new(Felt::new(1), Felt::ZERO);
+    let z = one;
     let two = QuadExtension::new(Felt::new(2), Felt::ZERO);
     let a = QuadExtension::new(Felt::new(3), Felt::ZERO);
     let b = QuadExtension::new(Felt::new(7), Felt::ZERO);
     let a_prime = a * two;
     let b_prime = a + b;
 
-    let main_frame = to_stack_order(&[a, a_prime, b, b_prime]);
-    let aux_frame = to_stack_order(&[]);
     let code = test_code(
         code,
-        main_frame,
-        aux_frame,
+        vec![
+            Data {
+                data: to_stack_order(&[a, a_prime, b, b_prime]),
+                address: constants::OOD_FRAME_ADDRESS,
+                descriptor: "main_trace",
+            },
+            Data {
+                data: to_stack_order(&[]),
+                address: constants::OOD_AUX_FRAME_ADDRESS,
+                descriptor: "aux_trace",
+            },
+            Data {
+                data: to_stack_order(&vec![one; 2]),
+                address: constants::COMPOSITION_COEF_ADDRESS,
+                descriptor: "composition_coefficients",
+            },
+        ],
         trace_len,
         z,
         &["compute_evaluate_transitions"],


### PR DESCRIPTION
instead of multiplying the coefficients on `evaluate_transitions`, this performs the multiplications on `compute_evaluate_transitions`, which means there is no longer a need to manipulate the accumulator on the stack, saving a few cycles.

requested here: https://github.com/0xPolygonMiden/air-script/pull/299#discussion_r1207190470