### PR TITLE
masm codegen: added boundary constraint evaluations

### DIFF
--- a/air-script/tests/aux_trace/aux_trace.masm
+++ b/air-script/tests/aux_trace/aux_trace.masm
@@ -1,32 +1,62 @@
-proc.compute_evaluate_transitions
-    # constraint 0 for main
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for main
     padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 1 for main
+    # integrity constraint 1 for main
     padw mem_loadw.4294965001 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 drop drop ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 drop drop ext2mul
-    # constraint 2 for main
+    # integrity constraint 2 for main
     padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 3 for aux
-    padw mem_loadw.4294965072 drop drop padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965000 drop drop ext2add ext2mul ext2sub
+    # integrity constraint 0 for aux
+    padw mem_loadw.4294965072 drop drop padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294966000 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294966000 drop drop ext2add ext2mul ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 drop drop ext2mul
-    # constraint 4 for aux
-    padw mem_loadw.4294965073 movdn.3 movdn.3 drop drop padw mem_loadw.4294965073 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2add ext2mul ext2sub
+    # integrity constraint 1 for aux
+    padw mem_loadw.4294965073 movdn.3 movdn.3 drop drop padw mem_loadw.4294965073 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop padw mem_loadw.4294966000 movdn.3 movdn.3 drop drop ext2add ext2mul ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
-    exec.compute_evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for main
+    padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966018 drop drop ext2mul
+    # boundary constraint 1 for main
+    padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966019 movdn.3 movdn.3 drop drop ext2mul
+    # boundary constraint 0 for aux
+    padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966019 drop drop ext2mul
+    # boundary constraint 1 for aux
+    padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966020 movdn.3 movdn.3 drop drop ext2mul
+    # boundary constraint 2 for aux
+    padw mem_loadw.4294965073 movdn.3 movdn.3 drop drop padw mem_loadw.4294966000 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966020 drop drop ext2mul
+    # boundary constraint 3 for aux
+    padw mem_loadw.4294965073 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966021 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add ext2add ext2add ext2add ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add ext2add ext2add ext2add ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/binary/binary.masm
+++ b/air-script/tests/binary/binary.masm
@@ -1,5 +1,5 @@
-proc.compute_evaluate_transitions
-    # constraint 0 for main
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for main
     padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -17,7 +17,7 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 1 for main
+    # integrity constraint 1 for main
     padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -35,14 +35,24 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
-    exec.compute_evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for main
+    padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/bitwise/bitwise.masm
+++ b/air-script/tests/bitwise/bitwise.masm
@@ -1,6 +1,6 @@
 proc.cache_z_exp
     # Load trace length
-    mem_load.3294967296
+    mem_load.4294959999
     # => [trace_len, ...]
     # Push initial num_of_cycles
     push.1
@@ -22,8 +22,7 @@ proc.cache_z_exp
         movup.2 div.2 dup.0 neq.1
         # => [b, i+1, z_1^2, z_0^2, num_of_cycles', trace_len, ...]
     end # END while
-    drop push.0 push.0
-    mem_storew.500000100 # Save the exponentiation of z for column 0
+    drop push.0 push.0 mem_storew.500000100 # Save the exponentiation of z for column 0
     mem_storew.500000101 # Save the exponentiation of z for column 1
     # => [0, 0, z_1^2, z_0^2, num_of_cycles', trace_len, ...]
     drop drop
@@ -125,8 +124,8 @@ proc.cache_periodic_polys
     push.0 push.0 mem_storew.500000001 dropw
 end # END PROC cache_periodic_polys
 
-proc.compute_evaluate_transitions
-    # constraint 0 for main
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for main
     padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -144,11 +143,11 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 1 for main
+    # integrity constraint 1 for main
     padw mem_loadw.500000001 drop drop padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub ext2mul push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 drop drop ext2mul
-    # constraint 2 for main
+    # integrity constraint 2 for main
     padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -166,7 +165,7 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 3 for main
+    # integrity constraint 3 for main
     padw mem_loadw.4294965004 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -184,7 +183,7 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965004 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 drop drop ext2mul
-    # constraint 4 for main
+    # integrity constraint 4 for main
     padw mem_loadw.4294965005 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -202,7 +201,7 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965005 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 5 for main
+    # integrity constraint 5 for main
     padw mem_loadw.4294965006 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -220,7 +219,7 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965006 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966018 drop drop ext2mul
-    # constraint 6 for main
+    # integrity constraint 6 for main
     padw mem_loadw.4294965007 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -238,7 +237,7 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965007 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966019 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 7 for main
+    # integrity constraint 7 for main
     padw mem_loadw.4294965008 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -256,7 +255,7 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965008 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966019 drop drop ext2mul
-    # constraint 8 for main
+    # integrity constraint 8 for main
     padw mem_loadw.4294965009 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -274,7 +273,7 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965009 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966020 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 9 for main
+    # integrity constraint 9 for main
     padw mem_loadw.4294965010 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -292,7 +291,7 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965010 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966020 drop drop ext2mul
-    # constraint 10 for main
+    # integrity constraint 10 for main
     padw mem_loadw.500000000 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop push.2 push.0
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -350,7 +349,7 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965006 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub ext2mul push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966021 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 11 for main
+    # integrity constraint 11 for main
     padw mem_loadw.500000000 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop push.2 push.0
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -408,7 +407,7 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965010 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub ext2mul push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966021 drop drop ext2mul
-    # constraint 12 for main
+    # integrity constraint 12 for main
     padw mem_loadw.500000001 drop drop padw mem_loadw.4294965001 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop push.16 push.0 ext2mul push.2 push.0
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -466,7 +465,7 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965006 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub ext2mul push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966022 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 13 for main
+    # integrity constraint 13 for main
     padw mem_loadw.500000001 drop drop padw mem_loadw.4294965002 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop push.16 push.0 ext2mul push.2 push.0
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -524,15 +523,15 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965010 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub ext2mul push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966022 drop drop ext2mul
-    # constraint 14 for main
+    # integrity constraint 14 for main
     padw mem_loadw.500000000 drop drop padw mem_loadw.4294965011 movdn.3 movdn.3 drop drop ext2mul push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966023 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 15 for main
+    # integrity constraint 15 for main
     padw mem_loadw.500000001 drop drop padw mem_loadw.4294965012 movdn.3 movdn.3 drop drop padw mem_loadw.4294965011 drop drop ext2sub ext2mul push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966023 drop drop ext2mul
-    # constraint 16 for main
+    # integrity constraint 16 for main
     push.1 push.0 padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965012 movdn.3 movdn.3 drop drop padw mem_loadw.4294965011 movdn.3 movdn.3 drop drop push.16 push.0 ext2mul push.2 push.0
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -644,15 +643,25 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965006 movdn.3 movdn.3 drop drop padw mem_loadw.4294965010 movdn.3 movdn.3 drop drop ext2add push.2 push.0 padw mem_loadw.4294965006 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965010 movdn.3 movdn.3 drop drop ext2mul ext2sub ext2mul ext2add ext2sub ext2mul ext2add push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966024 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for main
+    padw mem_loadw.4294965013 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966024 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
     exec.cache_periodic_polys
-    exec.compute_evaluate_transitions
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/constants/constants.masm
+++ b/air-script/tests/constants/constants.masm
@@ -1,32 +1,62 @@
-proc.compute_evaluate_transitions
-    # constraint 0 for main
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for main
     padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 1 for main
+    # integrity constraint 1 for main
     padw mem_loadw.4294965001 drop drop push.0 push.0 padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2mul ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 drop drop ext2mul
-    # constraint 2 for main
+    # integrity constraint 2 for main
     padw mem_loadw.4294965002 drop drop push.1 push.0 push.0 push.0 ext2add padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2mul ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 3 for aux
+    # integrity constraint 0 for aux
     padw mem_loadw.4294965072 drop drop padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop push.1 push.0 ext2add push.0 push.0 push.2 push.0 ext2mul ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 drop drop ext2mul
-    # constraint 4 for aux
+    # integrity constraint 1 for aux
     padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop push.1 push.0 push.1 push.0 push.0 push.0 ext2mul ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
-    exec.compute_evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for main
+    padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966018 drop drop ext2mul
+    # boundary constraint 1 for main
+    padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop push.1 push.0 push.0 push.0 push.2 push.0 ext2mul ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966019 movdn.3 movdn.3 drop drop ext2mul
+    # boundary constraint 2 for main
+    padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop push.0 push.0 push.0 push.0 ext2sub push.1 push.0 ext2mul ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966019 drop drop ext2mul
+    # boundary constraint 3 for main
+    padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop push.1 push.0 push.0 push.0 ext2add push.1 push.0 ext2sub push.1 push.0 ext2add push.2 push.0 ext2sub push.2 push.0 ext2add push.0 push.0 ext2sub ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966020 movdn.3 movdn.3 drop drop ext2mul
+    # boundary constraint 0 for aux
+    padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop push.1 push.0 push.0 push.0 push.2 push.0 ext2mul ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966020 drop drop ext2mul
+    # boundary constraint 1 for aux
+    padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop push.1 push.0 push.1 push.0 push.1 push.0 ext2mul ext2sub ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966021 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add ext2add ext2add ext2add ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add ext2add ext2add ext2add ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
+++ b/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
@@ -1,28 +1,38 @@
-proc.compute_evaluate_transitions
-    # constraint 0 for aux
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for aux
     padw mem_loadw.4294965074 movdn.3 movdn.3 drop drop padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 1 for aux
+    # integrity constraint 1 for aux
     padw mem_loadw.4294965075 movdn.3 movdn.3 drop drop padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 drop drop ext2mul
-    # constraint 2 for aux
+    # integrity constraint 2 for aux
     padw mem_loadw.4294965076 movdn.3 movdn.3 drop drop padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 3 for aux
+    # integrity constraint 3 for aux
     padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
-    exec.compute_evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for aux
+    padw mem_loadw.4294965076 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add ext2add ext2add ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/constraint_comprehension/constraint_comprehension.masm
+++ b/air-script/tests/constraint_comprehension/constraint_comprehension.masm
@@ -1,28 +1,38 @@
-proc.compute_evaluate_transitions
-    # constraint 0 for aux
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for aux
     padw mem_loadw.4294965074 movdn.3 movdn.3 drop drop padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 1 for aux
+    # integrity constraint 1 for aux
     padw mem_loadw.4294965075 movdn.3 movdn.3 drop drop padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 drop drop ext2mul
-    # constraint 2 for aux
+    # integrity constraint 2 for aux
     padw mem_loadw.4294965076 movdn.3 movdn.3 drop drop padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 3 for aux
+    # integrity constraint 3 for aux
     padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
-    exec.compute_evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for aux
+    padw mem_loadw.4294965076 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add ext2add ext2add ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/evaluators/evaluators.masm
+++ b/air-script/tests/evaluators/evaluators.masm
@@ -1,17 +1,17 @@
-proc.compute_evaluate_transitions
-    # constraint 0 for main
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for main
     padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 1 for main
+    # integrity constraint 1 for main
     padw mem_loadw.4294965002 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 drop drop ext2mul
-    # constraint 2 for main
+    # integrity constraint 2 for main
     padw mem_loadw.4294965006 drop drop padw mem_loadw.4294965006 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 3 for main
+    # integrity constraint 3 for main
     padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -29,7 +29,7 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 drop drop ext2mul
-    # constraint 4 for main
+    # integrity constraint 4 for main
     padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -47,7 +47,7 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 5 for main
+    # integrity constraint 5 for main
     padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -65,7 +65,7 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966018 drop drop ext2mul
-    # constraint 6 for main
+    # integrity constraint 6 for main
     padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -83,14 +83,24 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966019 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
-    exec.compute_evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for main
+    padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966019 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add ext2add ext2add ext2add ext2add ext2add ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/indexed_trace_access/indexed_trace_access.masm
+++ b/air-script/tests/indexed_trace_access/indexed_trace_access.masm
@@ -1,20 +1,30 @@
-proc.compute_evaluate_transitions
-    # constraint 0 for main
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for main
     padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 1 for aux
+    # integrity constraint 0 for aux
     padw mem_loadw.4294965072 drop drop padw mem_loadw.4294965073 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
-    exec.compute_evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for main
+    padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/list_comprehension/list_comprehension.masm
+++ b/air-script/tests/list_comprehension/list_comprehension.masm
@@ -1,9 +1,9 @@
-proc.compute_evaluate_transitions
-    # constraint 0 for main
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for main
     padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 1 for aux
+    # integrity constraint 0 for aux
     padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop push.2 push.0
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -27,26 +27,36 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop ext2mul ext2mul ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 drop drop ext2mul
-    # constraint 2 for aux
+    # integrity constraint 1 for aux
     padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965076 drop drop padw mem_loadw.4294965080 drop drop ext2sub ext2mul ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 3 for aux
+    # integrity constraint 2 for aux
     padw mem_loadw.4294965074 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965082 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 drop drop ext2mul
-    # constraint 4 for aux
+    # integrity constraint 3 for aux
     padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop push.0 push.0 padw mem_loadw.4294965073 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965076 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop ext2sub push.1 push.0 padw mem_loadw.4294965074 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop ext2sub ext2add push.2 push.0 padw mem_loadw.4294965075 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965082 movdn.3 movdn.3 drop drop ext2sub ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
-    exec.compute_evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for aux
+    padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966018 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add ext2add ext2add ext2add ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/list_folding/list_folding.masm
+++ b/air-script/tests/list_folding/list_folding.masm
@@ -1,28 +1,38 @@
-proc.compute_evaluate_transitions
-    # constraint 0 for aux
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for aux
     padw mem_loadw.4294965073 drop drop padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop padw mem_loadw.4294965082 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965083 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965084 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 1 for aux
+    # integrity constraint 1 for aux
     padw mem_loadw.4294965074 drop drop padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop padw mem_loadw.4294965082 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965083 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965084 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 drop drop ext2mul
-    # constraint 2 for aux
+    # integrity constraint 2 for aux
     padw mem_loadw.4294965075 drop drop padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop padw mem_loadw.4294965082 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop padw mem_loadw.4294965083 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop padw mem_loadw.4294965084 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop padw mem_loadw.4294965082 movdn.3 movdn.3 drop drop ext2add ext2mul padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop padw mem_loadw.4294965083 movdn.3 movdn.3 drop drop ext2add ext2mul padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop padw mem_loadw.4294965084 movdn.3 movdn.3 drop drop ext2add ext2mul ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 3 for aux
+    # integrity constraint 3 for aux
     padw mem_loadw.4294965076 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop padw mem_loadw.4294965082 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop padw mem_loadw.4294965083 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop padw mem_loadw.4294965084 movdn.3 movdn.3 drop drop ext2mul ext2add ext2add padw mem_loadw.4294965077 movdn.3 movdn.3 drop drop padw mem_loadw.4294965081 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965078 movdn.3 movdn.3 drop drop padw mem_loadw.4294965082 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop padw mem_loadw.4294965083 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294965080 movdn.3 movdn.3 drop drop padw mem_loadw.4294965084 movdn.3 movdn.3 drop drop ext2mul ext2add ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
-    exec.compute_evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for aux
+    padw mem_loadw.4294965079 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add ext2add ext2add ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/periodic_columns/periodic_columns.masm
+++ b/air-script/tests/periodic_columns/periodic_columns.masm
@@ -1,6 +1,6 @@
 proc.cache_z_exp
     # Load trace length
-    mem_load.3294967296
+    mem_load.4294959999
     # => [trace_len, ...]
     # Push initial num_of_cycles
     push.1
@@ -22,8 +22,7 @@ proc.cache_z_exp
         movup.2 div.2 dup.0 neq.1
         # => [b, i+1, z_1^2, z_0^2, num_of_cycles', trace_len, ...]
     end # END while
-    drop push.0 push.0
-    mem_storew.500000101 # Save the exponentiation of z for column 1
+    drop push.0 push.0 mem_storew.500000101 # Save the exponentiation of z for column 1
     # => [0, 0, z_1^2, z_0^2, num_of_cycles', trace_len, ...]
     drop drop
     # Compute exponentiations based on the number of cycles for a period of 4
@@ -40,8 +39,7 @@ proc.cache_z_exp
         movup.2 div.2 dup.0 neq.1
         # => [b, i+1, z_1^2, z_0^2, num_of_cycles', trace_len, ...]
     end # END while
-    drop push.0 push.0
-    mem_storew.500000100 # Save the exponentiation of z for column 0
+    drop push.0 push.0 mem_storew.500000100 # Save the exponentiation of z for column 0
     # => [0, 0, z_1^2, z_0^2, num_of_cycles', trace_len, ...]
     drop drop
     # => [z_1^2, z_0^2, num_of_cycles', trace_len, ...]
@@ -122,24 +120,34 @@ proc.cache_periodic_polys
     push.0 push.0 mem_storew.500000001 dropw
 end # END PROC cache_periodic_polys
 
-proc.compute_evaluate_transitions
-    # constraint 0 for main
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for main
     padw mem_loadw.500000000 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2add ext2mul push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 1 for main
+    # integrity constraint 1 for main
     padw mem_loadw.500000001 drop drop padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub ext2mul push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for main
+    padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
     exec.cache_periodic_polys
-    exec.compute_evaluate_transitions
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/pub_inputs/pub_inputs.masm
+++ b/air-script/tests/pub_inputs/pub_inputs.masm
@@ -1,16 +1,70 @@
-proc.compute_evaluate_transitions
-    # constraint 0 for main
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for main
     padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
-    exec.compute_evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for main
+    padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop
+    # Load public input stack_inputs pos 0 with final offset 4
+    padw mem_loadw.4294960002 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
+    # boundary constraint 1 for main
+    padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop
+    # Load public input stack_inputs pos 1 with final offset 4
+    padw mem_loadw.4294960002 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
+    # boundary constraint 2 for main
+    padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop
+    # Load public input stack_inputs pos 2 with final offset 4
+    padw mem_loadw.4294960003 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 drop drop ext2mul
+    # boundary constraint 3 for main
+    padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop
+    # Load public input stack_inputs pos 3 with final offset 4
+    padw mem_loadw.4294960003 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul
+    # boundary constraint 4 for main
+    padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop
+    # Load public input stack_outputs pos 0 with final offset 8
+    padw mem_loadw.4294960004 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966018 drop drop ext2mul
+    # boundary constraint 5 for main
+    padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop
+    # Load public input stack_outputs pos 1 with final offset 8
+    padw mem_loadw.4294960004 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966019 movdn.3 movdn.3 drop drop ext2mul
+    # boundary constraint 6 for main
+    padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop
+    # Load public input stack_outputs pos 2 with final offset 8
+    padw mem_loadw.4294960005 movdn.3 movdn.3 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966019 drop drop ext2mul
+    # boundary constraint 7 for main
+    padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop
+    # Load public input stack_outputs pos 3 with final offset 8
+    padw mem_loadw.4294960005 drop drop ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966020 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/random_values/random_values_bindings.masm
+++ b/air-script/tests/random_values/random_values_bindings.masm
@@ -1,16 +1,30 @@
-proc.compute_evaluate_transitions
-    # constraint 0 for aux
-    padw mem_loadw.4294965072 drop drop padw mem_loadw.4294965007 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965001 drop drop ext2add ext2sub
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for aux
+    padw mem_loadw.4294965072 drop drop padw mem_loadw.4294966007 drop drop padw mem_loadw.4294966000 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294966001 drop drop ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
-    exec.compute_evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for aux
+    padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop padw mem_loadw.4294966002 drop drop padw mem_loadw.4294966001 drop drop ext2add padw mem_loadw.4294966007 drop drop ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
+    # boundary constraint 1 for aux
+    padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop padw mem_loadw.4294966000 movdn.3 movdn.3 drop drop padw mem_loadw.4294966007 drop drop ext2add padw mem_loadw.4294966005 drop drop ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/random_values/random_values_simple.masm
+++ b/air-script/tests/random_values/random_values_simple.masm
@@ -1,16 +1,30 @@
-proc.compute_evaluate_transitions
-    # constraint 0 for aux
-    padw mem_loadw.4294965072 drop drop padw mem_loadw.4294965007 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965001 drop drop ext2add ext2sub
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for aux
+    padw mem_loadw.4294965072 drop drop padw mem_loadw.4294966007 drop drop padw mem_loadw.4294966000 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294966001 drop drop ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
-    exec.compute_evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for aux
+    padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop padw mem_loadw.4294966002 drop drop padw mem_loadw.4294966001 drop drop ext2add padw mem_loadw.4294966007 drop drop ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
+    # boundary constraint 1 for aux
+    padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop padw mem_loadw.4294966000 movdn.3 movdn.3 drop drop padw mem_loadw.4294966007 drop drop ext2add padw mem_loadw.4294966005 drop drop ext2add ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/selectors/selectors.masm
+++ b/air-script/tests/selectors/selectors.masm
@@ -1,24 +1,34 @@
-proc.compute_evaluate_transitions
-    # constraint 0 for main
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for main
     padw mem_loadw.4294965003 drop drop push.0 push.0 ext2sub padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop push.1 push.0 padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 1 for main
+    # integrity constraint 1 for main
     padw mem_loadw.4294965003 drop drop padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2mul ext2mul
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 drop drop ext2mul
-    # constraint 2 for main
+    # integrity constraint 2 for main
     padw mem_loadw.4294965003 drop drop push.1 push.0 ext2sub push.1 push.0 padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2sub push.1 push.0 padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
-    exec.compute_evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for main
+    padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add ext2add ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/selectors/selectors_with_evaluators.masm
+++ b/air-script/tests/selectors/selectors_with_evaluators.masm
@@ -1,24 +1,34 @@
-proc.compute_evaluate_transitions
-    # constraint 0 for main
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for main
     padw mem_loadw.4294965003 drop drop push.0 push.0 ext2sub padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop push.1 push.0 padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 1 for main
+    # integrity constraint 1 for main
     padw mem_loadw.4294965003 drop drop padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2mul ext2mul
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 drop drop ext2mul
-    # constraint 2 for main
+    # integrity constraint 2 for main
     padw mem_loadw.4294965003 drop drop push.1 push.0 ext2sub push.1 push.0 padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2sub push.1 push.0 padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
-    exec.compute_evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for main
+    padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add ext2add ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/system/system.masm
+++ b/air-script/tests/system/system.masm
@@ -1,16 +1,26 @@
-proc.compute_evaluate_transitions
-    # constraint 0 for main
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for main
     padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
-    exec.compute_evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for main
+    padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966016 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/trace_col_groups/trace_col_groups.masm
+++ b/air-script/tests/trace_col_groups/trace_col_groups.masm
@@ -1,20 +1,30 @@
-proc.compute_evaluate_transitions
-    # constraint 0 for main
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for main
     padw mem_loadw.4294965002 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 1 for main
+    # integrity constraint 1 for main
     padw mem_loadw.4294965001 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
-    exec.compute_evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for aux
+    padw mem_loadw.4294965076 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/variables/variables.masm
+++ b/air-script/tests/variables/variables.masm
@@ -1,6 +1,6 @@
 proc.cache_z_exp
     # Load trace length
-    mem_load.3294967296
+    mem_load.4294959999
     # => [trace_len, ...]
     # Push initial num_of_cycles
     push.1
@@ -22,8 +22,7 @@ proc.cache_z_exp
         movup.2 div.2 dup.0 neq.1
         # => [b, i+1, z_1^2, z_0^2, num_of_cycles', trace_len, ...]
     end # END while
-    drop push.0 push.0
-    mem_storew.500000100 # Save the exponentiation of z for column 0
+    drop push.0 push.0 mem_storew.500000100 # Save the exponentiation of z for column 0
     # => [0, 0, z_1^2, z_0^2, num_of_cycles', trace_len, ...]
     drop drop
     # => [z_1^2, z_0^2, num_of_cycles', trace_len, ...]
@@ -80,8 +79,8 @@ proc.cache_periodic_polys
     push.0 push.0 mem_storew.500000000 dropw
 end # END PROC cache_periodic_polys
 
-proc.compute_evaluate_transitions
-    # constraint 0 for main
+proc.compute_evaluate_integrity_constraints
+    # integrity constraint 0 for main
     padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
@@ -99,31 +98,45 @@ proc.compute_evaluate_transitions
     padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 1 for main
+    # integrity constraint 1 for main
     padw mem_loadw.500000000 drop drop padw mem_loadw.4294965000 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub ext2mul push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966016 drop drop ext2mul
-    # constraint 2 for main
+    # integrity constraint 2 for main
     push.1 push.0 padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2sub ext2mul push.2 push.0 push.3 push.0 ext2mul padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2sub ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 movdn.3 movdn.3 drop drop ext2mul
-    # constraint 3 for main
+    # integrity constraint 3 for main
     padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop padw mem_loadw.4294965002 movdn.3 movdn.3 drop drop ext2mul ext2sub ext2mul padw mem_loadw.4294965000 drop drop push.3 push.0 ext2sub push.4 push.0 push.2 push.0 ext2sub ext2sub ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966017 drop drop ext2mul
-    # constraint 4 for aux
-    padw mem_loadw.4294965072 drop drop padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop padw mem_loadw.4294965000 movdn.3 movdn.3 drop drop ext2add ext2mul ext2sub
+    # integrity constraint 0 for aux
+    padw mem_loadw.4294965072 drop drop padw mem_loadw.4294965072 movdn.3 movdn.3 drop drop padw mem_loadw.4294965003 movdn.3 movdn.3 drop drop padw mem_loadw.4294966000 movdn.3 movdn.3 drop drop ext2add ext2mul ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294966018 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_transitions
+end # END PROC compute_evaluate_integrity_constraints
 
-proc.evaluate_transitions
+proc.compute_evaluate_boundary_constraints
+    # boundary constraint 0 for main
+    padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966018 drop drop ext2mul
+    # boundary constraint 1 for main
+    padw mem_loadw.4294965001 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294966019 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_evaluate_boundary_constraints
+
+proc.evaluate_integrity_constraints
     exec.cache_periodic_polys
-    exec.compute_evaluate_transitions
+    exec.compute_evaluate_integrity_constraints
     # Accumulate the numerator of the constraint polynomial
     ext2add ext2add ext2add ext2add ext2add
-end # END PROC evaluate_transitions
+end # END PROC evaluate_integrity_constraints
 
-proc.evaluate_boundary
-end # END PROC evaluate_boundary
+proc.evaluate_boundary_constraints
+    exec.compute_evaluate_boundary_constraints
+    # Accumulate the numerator of the constraint polynomial
+    ext2add ext2add
+end # END PROC evaluate_boundary_constraints
 

--- a/codegen/masm/src/codegen.rs
+++ b/codegen/masm/src/codegen.rs
@@ -28,9 +28,23 @@ pub struct CodeGenerator<'ast> {
     /// Periodic columns are visited in order, and the counter is the same as the columns ID.
     periodic_column: u32,
 
-    /// Counts how many transition constraint roots have been visited so far. Used for
-    /// documentation and to load the composition coefficients.
-    transition_contraint: u32,
+    /// Counts how many composition coefficients have been used so far, used to compute the correct
+    /// offset in memory.
+    composition_coefficient_count: u32,
+
+    /// Counts how many integrity constraint roots have been visited so far, used for
+    /// emitting documentation.
+    integrity_contraints: usize,
+
+    /// Counts how many boundary constraint roots have been visited so far, used for
+    /// emitting documentation.
+    boundary_contraints: usize,
+
+    /// Maps the public input to their start offset.
+    public_input_to_offset: BTreeMap<String, usize>,
+
+    /// Holds the count of public inputs seen so far, this is used to compute the offset.
+    public_input_count: usize,
 
     /// Map of the constants found while visitint the [AirIR].
     ///
@@ -102,9 +116,13 @@ impl<'ast> CodeGenerator<'ast> {
     pub fn new(ir: &'ast AirIR, config: CodegenConfig) -> CodeGenerator<'ast> {
         CodeGenerator {
             writer: Writer::new(),
-            constants: BTreeMap::new(),
-            transition_contraint: 0,
             periodic_column: 0,
+            composition_coefficient_count: 0,
+            integrity_contraints: 0,
+            boundary_contraints: 0,
+            public_input_to_offset: BTreeMap::new(),
+            public_input_count: 0,
+            constants: BTreeMap::new(),
             ir,
             config,
         }
@@ -160,7 +178,6 @@ impl<'ast> CodeGenerator<'ast> {
         self.writer.mem_loadw(self.config.z_address);
         self.writer.drop();
         self.writer.drop();
-        self.writer.new_line();
         self.writer
             .header("=> [z_1, z_0, num_of_cycles, trace_len, ...]");
 
@@ -171,7 +188,6 @@ impl<'ast> CodeGenerator<'ast> {
             ));
             self.writer.dup(3);
             self.writer.div(Some(*divisor));
-            self.writer.new_line();
             self.writer
                 .header("=> [num_of_cycles', z_1, z_0, num_of_cycles, trace_len, ...]");
 
@@ -181,7 +197,6 @@ impl<'ast> CodeGenerator<'ast> {
             self.writer.dup(1);
             self.writer.movdn(4);
             self.writer.div(None);
-            self.writer.new_line();
             self.writer
                 .header("=> [i, z_1, z_0, num_of_cycles', trace_len, ...]");
 
@@ -209,7 +224,6 @@ impl<'ast> CodeGenerator<'ast> {
             self.writer.drop();
             self.writer.push(0);
             self.writer.push(0);
-            self.writer.new_line();
 
             for c in columns {
                 let addr = self.config.z_exp_address + c;
@@ -248,30 +262,42 @@ impl<'ast> CodeGenerator<'ast> {
         Ok(())
     }
 
-    /// Emits code for the procedure `compute_evaluate_transitions` and `compute_aux_evaluate_transitions`
+    /// Emits code for the procedure `compute_evaluate_integrity_constraints`.
     ///
-    /// This procedure evaluates each top-level transition constraint and leaves the result on the
+    /// This procedure evaluates each top-level integrity constraint and leaves the result on the
     /// stack. This is useful for testing the evaluation. Later on the value is aggregated.
-    fn gen_compute_evaluate_transitions(&mut self) -> Result<(), CodegenError> {
-        self.writer.proc("compute_evaluate_transitions");
+    fn gen_compute_evaluate_integrity_constraints(&mut self) -> Result<(), CodegenError> {
+        self.writer.proc("compute_evaluate_integrity_constraints");
         walk_integrity_constraints(self, self.ir, MAIN_TRACE)?;
+        self.integrity_contraints = 0; // reset counter for the aux trace
         walk_integrity_constraints(self, self.ir, AUX_TRACE)?;
         self.writer.end();
 
         Ok(())
     }
 
-    /// Emits code for the procedure `evaluate_transitions`.
+    /// Emits code for the procedure `compute_evaluate_boundary_constraints`.
+    fn gen_compute_evaluate_boundary_constraints(&mut self) -> Result<(), CodegenError> {
+        self.writer.proc("compute_evaluate_boundary_constraints");
+        walk_boundary_constraints(self, self.ir, MAIN_TRACE)?;
+        self.boundary_contraints = 0; // reset counter for the aux trace
+        walk_boundary_constraints(self, self.ir, AUX_TRACE)?;
+        self.writer.end();
+
+        Ok(())
+    }
+
+    /// Emits code for the procedure `evaluate_integrity_constraints`.
     ///
-    /// Evaluates the transition constraints for both the main and auxiliary traces.
-    fn gen_evaluate_transitions(&mut self) -> Result<(), CodegenError> {
-        self.writer.proc("evaluate_transitions");
+    /// Evaluates the integrity constraints for both the main and auxiliary traces.
+    fn gen_evaluate_integrity_constraints(&mut self) -> Result<(), CodegenError> {
+        self.writer.proc("evaluate_integrity_constraints");
 
         if !self.ir.periodic_columns().is_empty() {
             self.writer.exec("cache_periodic_polys");
         }
 
-        self.writer.exec("compute_evaluate_transitions");
+        self.writer.exec("compute_evaluate_integrity_constraints");
 
         self.writer
             .header("Accumulate the numerator of the constraint polynomial");
@@ -288,11 +314,23 @@ impl<'ast> CodeGenerator<'ast> {
         Ok(())
     }
 
-    /// Emits code for the procedure `evaluate_boundary`.
-    fn gen_evaluate_boundary(&mut self) -> Result<(), CodegenError> {
-        self.writer.proc("evaluate_boundary");
-        walk_boundary_constraints(self, self.ir, MAIN_TRACE)?;
-        walk_boundary_constraints(self, self.ir, AUX_TRACE)?;
+    /// Emits code for the procedure `evaluate_boundary_constraints`.
+    ///
+    /// Evaluates the boundary constraints for both the main and auxiliary traces.
+    fn gen_evaluate_boundary_constraints(&mut self) -> Result<(), CodegenError> {
+        self.writer.proc("evaluate_boundary_constraints");
+        self.writer.exec("compute_evaluate_boundary_constraints");
+
+        self.writer
+            .header("Accumulate the numerator of the constraint polynomial");
+
+        let total_len = self.ir.boundary_constraints(MAIN_TRACE).len()
+            + self.ir.boundary_constraints(AUX_TRACE).len();
+
+        for _ in 0..total_len {
+            self.writer.ext2add();
+        }
+
         self.writer.end();
 
         Ok(())
@@ -307,6 +345,8 @@ pub enum CodegenError {
     InvalidRowOffset,
     InvalidSize,
     InvalidIndex,
+    InvalidBoundaryConstraint,
+    InvalidIntegrityConstraint,
 }
 
 impl<'ast> AirVisitor<'ast> for CodeGenerator<'ast> {
@@ -319,10 +359,43 @@ impl<'ast> AirVisitor<'ast> for CodeGenerator<'ast> {
 
     fn visit_boundary_constraint(
         &mut self,
-        _constraint: &'ast ConstraintRoot,
-        _trace_segment: u8,
+        constraint: &'ast ConstraintRoot,
+        trace_segment: u8,
     ) -> Result<Self::Value, Self::Error> {
-        Ok(()) // TODO
+        if !constraint.domain().is_boundary() {
+            return Err(CodegenError::InvalidBoundaryConstraint);
+        }
+
+        let segment = if trace_segment == MAIN_TRACE {
+            "main"
+        } else {
+            "aux"
+        };
+
+        self.writer.header(format!(
+            "boundary constraint {} for {}",
+            self.boundary_contraints, segment
+        ));
+
+        // Note: AirScript's boundary constraints are only defined for the first or last row.
+        // Meaning they are implemented as an assertion for a single element. Visiting the
+        // [NodeIndex] will emit code to compute the difference of the expected value and the
+        // evaluation frame value.
+        self.visit_node_index(constraint.node_index())?;
+
+        self.writer
+            .header("Multiply by the composition coefficient");
+
+        load_quadratic_element(
+            &mut self.writer,
+            self.config.composition_coef_address,
+            self.composition_coefficient_count,
+        )?;
+        self.writer.ext2mul();
+        self.composition_coefficient_count += 1;
+
+        self.boundary_contraints += 1;
+        Ok(())
     }
 
     fn visit_air(&mut self) -> Result<Self::Value, Self::Error> {
@@ -335,9 +408,10 @@ impl<'ast> AirVisitor<'ast> for CodeGenerator<'ast> {
             self.gen_cache_z_exp()?;
             self.gen_evaluate_periodic_polys()?;
         }
-        self.gen_compute_evaluate_transitions()?;
-        self.gen_evaluate_transitions()?;
-        self.gen_evaluate_boundary()?;
+        self.gen_compute_evaluate_integrity_constraints()?;
+        self.gen_compute_evaluate_boundary_constraints()?;
+        self.gen_evaluate_integrity_constraints()?;
+        self.gen_evaluate_boundary_constraints()?;
 
         Ok(())
     }
@@ -368,6 +442,10 @@ impl<'ast> AirVisitor<'ast> for CodeGenerator<'ast> {
         constraint: &'ast ConstraintRoot,
         trace_segment: u8,
     ) -> Result<Self::Value, Self::Error> {
+        if !constraint.domain().is_integrity() {
+            return Err(CodegenError::InvalidIntegrityConstraint);
+        }
+
         let segment = if trace_segment == MAIN_TRACE {
             "main"
         } else {
@@ -375,8 +453,8 @@ impl<'ast> AirVisitor<'ast> for CodeGenerator<'ast> {
         };
 
         self.writer.header(format!(
-            "constraint {} for {}",
-            self.transition_contraint, segment
+            "integrity constraint {} for {}",
+            self.integrity_contraints, segment
         ));
 
         self.visit_node_index(constraint.node_index())?;
@@ -387,13 +465,12 @@ impl<'ast> AirVisitor<'ast> for CodeGenerator<'ast> {
         load_quadratic_element(
             &mut self.writer,
             self.config.composition_coef_address,
-            self.transition_contraint
-                .try_into()
-                .or(Err(CodegenError::InvalidIndex))?,
+            self.composition_coefficient_count,
         )?;
         self.writer.ext2mul();
+        self.composition_coefficient_count += 1;
 
-        self.transition_contraint += 1;
+        self.integrity_contraints += 1;
         Ok(())
     }
 
@@ -551,8 +628,19 @@ impl<'ast> AirVisitor<'ast> for CodeGenerator<'ast> {
 
     fn visit_public_input(
         &mut self,
-        _constant: &'ast PublicInput,
+        constant: &'ast PublicInput,
     ) -> Result<Self::Value, Self::Error> {
+        debug_assert!(
+            !self.public_input_to_offset.contains_key(&constant.0),
+            "public input {} has already been visited",
+            constant.0,
+        );
+
+        let start_offset = self.public_input_count;
+        self.public_input_to_offset
+            .insert(constant.0.clone(), start_offset);
+
+        self.public_input_count += constant.1;
         Ok(())
     }
 
@@ -633,7 +721,21 @@ impl<'ast> AirVisitor<'ast> for CodeGenerator<'ast> {
                     periodic_column_to_target_el(column),
                 )?;
             }
-            Value::PublicInput(_, _) => todo!(),
+            Value::PublicInput(name, index) => {
+                let start_offset = self
+                    .public_input_to_offset
+                    .get(name)
+                    .unwrap_or_else(|| panic!("public input {} unknown", name));
+
+                self.writer.header(format!(
+                    "Load public input {} pos {} with final offset {}",
+                    name, index, start_offset,
+                ));
+                let index: u32 = (start_offset + *index)
+                    .try_into()
+                    .or(Err(CodegenError::InvalidIndex))?;
+                load_quadratic_element(&mut self.writer, self.config.public_inputs_address, index)?;
+            }
             Value::RandomValue(element) => {
                 // Compute the target address for the random value. Each memory address contains
                 // two values.

--- a/codegen/masm/src/config.rs
+++ b/codegen/masm/src/config.rs
@@ -26,7 +26,18 @@ pub struct CodegenConfig {
     pub ood_aux_frame_address: u32,
 
     // Memory range for the composition coefficients.
+    //
+    // The coefficients are organized as follows:
+    //
+    // 1. Transition constraint coefficients for the main trace
+    // 2. Transition constraint coefficients for the aux trace
+    // 3. Boundary constraint coefficients for the main trace
+    // 4. Boundary constraint coefficients for the aux trace
+    //
     pub composition_coef_address: u32,
+
+    // Memory range for the public inputs.
+    pub public_inputs_address: u32,
 
     pub aux_rand_address: u32,
     pub periodic_values_address: u32,
@@ -44,6 +55,7 @@ impl Default for CodegenConfig {
             ood_frame_address: constants::OOD_FRAME_ADDRESS,
             ood_aux_frame_address: constants::OOD_AUX_FRAME_ADDRESS,
             composition_coef_address: constants::COMPOSITION_COEF_ADDRESS,
+            public_inputs_address: constants::PUBLIC_INPUTS_ADDRESS,
             aux_rand_address: constants::AUX_RAND_ELEM_PTR,
             periodic_values_address: constants::PERIODIC_VALUES_ADDRESS,
             z_exp_address: constants::Z_EXP_ADDRESS,

--- a/codegen/masm/src/config.rs
+++ b/codegen/masm/src/config.rs
@@ -4,36 +4,36 @@ pub struct CodegenConfig {
     // Memory location of the trace length using the following format:
     //
     //      [trace_len_address] => [trace_len, 0, 0, 0]
-    pub trace_len_address: u64,
+    pub trace_len_address: u32,
 
     // Memory location of the out-of-domain value using the following format:
     //
     //      [z_address] => [z8_0, z8_1, z_0, z_1]
-    pub z_address: u64,
+    pub z_address: u32,
 
     // Memory range for the OOD main frame values, starting at this value going up to
     // `ood_frame_address + main_frame_width`. Each memory location contains the values of the
     // current and next rows using the following format:
     //
     //      [ood_frame_address+0] => [ood_curr_0, ood_curr_1, ood_next_0, ood_next_1]
-    pub ood_frame_address: u64,
+    pub ood_frame_address: u32,
 
     // Memory range for the OOD auxiliary frame values, starting at this value going up to
     // `ood_aux_frame_address + aux_frame_width`. Each memory location contains the values of the
     // current and next rows using the following format:
     //
     //      [ood_aux_frame_address+0] => [ood_aux_curr_0, ood_aux_curr_1, ood_aux_next_0, ood_aux_next_1]
-    pub ood_aux_frame_address: u64,
+    pub ood_aux_frame_address: u32,
 
     // Memory range for the composition coefficients.
-    pub composition_coef_address: u64,
+    pub composition_coef_address: u32,
 
-    pub aux_rand_address: u64,
-    pub periodic_values_address: u64,
+    pub aux_rand_address: u32,
+    pub periodic_values_address: u32,
 
     /// Memory range used to store exponentiations of Z, each address contains one point to be used
     /// on the evaluation of each periodic polynimal.
-    pub z_exp_address: u64,
+    pub z_exp_address: u32,
 }
 
 impl Default for CodegenConfig {

--- a/codegen/masm/src/constants.rs
+++ b/codegen/masm/src/constants.rs
@@ -2,23 +2,24 @@ pub const MAIN_TRACE: u8 = 0;
 pub const AUX_TRACE: u8 = 1;
 
 // https://github.com/0xPolygonMiden/miden-vm/blob/next/stdlib/asm/crypto/stark/verifier.masm#L21
-pub const COMPOSITION_COEF_ADDRESS: u64 = 4294966016;
+pub const COMPOSITION_COEF_ADDRESS: u32 = 4294966016;
 
 // https://github.com/0xPolygonMiden/miden-vm/blob/next/stdlib/asm/crypto/stark/ood_frames.masm#L2
-pub const OOD_FRAME_ADDRESS: u64 = 4294965000;
+pub const OOD_FRAME_ADDRESS: u32 = 4294965000;
 
 // https://github.com/0xPolygonMiden/miden-vm/blob/next/stdlib/asm/crypto/stark/ood_frames.masm#L2
-pub const OOD_AUX_FRAME_ADDRESS: u64 = OOD_FRAME_ADDRESS + 72;
+pub const OOD_AUX_FRAME_ADDRESS: u32 = OOD_FRAME_ADDRESS + 72;
 
 // https://github.com/0xPolygonMiden/miden-vm/blob/next/stdlib/asm/crypto/stark/verifier.masm#L20
-pub const AUX_RAND_ELEM_PTR: u64 = 4294965000;
+pub const AUX_RAND_ELEM_PTR: u32 = 4294966000;
 
 // https://github.com/0xPolygonMiden/miden-vm/blob/next/stdlib/asm/crypto/stark/random_coin.masm#L12
-pub const TRACE_LEN_ADDRESS: u64 = 3294967296;
+pub const TRACE_LEN_ADDRESS: u32 = 4294959999;
+pub const LOG_TRACE_LEN_ADDRESS: u32 = 4294959998;
 
 // https://github.com/0xPolygonMiden/miden-vm/blob/next/stdlib/asm/crypto/stark/random_coin.masm#L5
-pub const Z_ADDRESS: u64 = 4294967291;
+pub const Z_ADDRESS: u32 = 4294967291;
 
 // TODO: define these addresses
-pub const PERIODIC_VALUES_ADDRESS: u64 = 500000000;
-pub const Z_EXP_ADDRESS: u64 = 500000100;
+pub const PERIODIC_VALUES_ADDRESS: u32 = 500000000;
+pub const Z_EXP_ADDRESS: u32 = 500000100;

--- a/codegen/masm/src/constants.rs
+++ b/codegen/masm/src/constants.rs
@@ -4,6 +4,9 @@ pub const AUX_TRACE: u8 = 1;
 // https://github.com/0xPolygonMiden/miden-vm/blob/next/stdlib/asm/crypto/stark/verifier.masm#L21
 pub const COMPOSITION_COEF_ADDRESS: u32 = 4294966016;
 
+// https://github.com/0xPolygonMiden/miden-vm/blob/next/stdlib/asm/crypto/stark/verifier.masm#L15
+pub const PUBLIC_INPUTS_ADDRESS: u32 = 4294960000;
+
 // https://github.com/0xPolygonMiden/miden-vm/blob/next/stdlib/asm/crypto/stark/ood_frames.masm#L2
 pub const OOD_FRAME_ADDRESS: u32 = 4294965000;
 

--- a/codegen/masm/src/writer.rs
+++ b/codegen/masm/src/writer.rs
@@ -199,27 +199,15 @@ impl Writer {
         self.ins(format!("dup.{}", arg));
     }
 
-    pub fn mem_load(&mut self, address: u64) {
-        assert!(
-            address < 2u64.pow(32),
-            "mem_load address must be 32 bits or less"
-        );
+    pub fn mem_load(&mut self, address: u32) {
         self.ins(format!("mem_load.{}", address));
     }
 
-    pub fn mem_loadw(&mut self, address: u64) {
-        assert!(
-            address < 2u64.pow(32),
-            "mem_loadw address must be 32 bits or less"
-        );
+    pub fn mem_loadw(&mut self, address: u32) {
         self.ins(format!("mem_loadw.{}", address));
     }
 
-    pub fn mem_storew(&mut self, address: u64) {
-        assert!(
-            address < 2u64.pow(32),
-            "mem_storew address must be 32 bits or less"
-        );
+    pub fn mem_storew(&mut self, address: u32) {
         self.ins(format!("mem_storew.{}", address));
     }
 

--- a/codegen/masm/tests/test_aux.rs
+++ b/codegen/masm/tests/test_aux.rs
@@ -67,7 +67,7 @@ fn test_simple_aux() {
         ],
         trace_len,
         z,
-        &["compute_evaluate_transitions"],
+        &["compute_evaluate_integrity_constraints"],
     );
     let program = Assembler::default().compile(code).unwrap();
 

--- a/codegen/masm/tests/test_basic_arithmetic.rs
+++ b/codegen/masm/tests/test_basic_arithmetic.rs
@@ -66,7 +66,7 @@ fn test_simple_arithmetic() {
         ],
         trace_len,
         z,
-        &["compute_evaluate_transitions"],
+        &["compute_evaluate_integrity_constraints"],
     );
     let program = Assembler::default().compile(code).unwrap();
 
@@ -155,7 +155,7 @@ fn test_exp() {
         ],
         trace_len,
         z,
-        &["compute_evaluate_transitions"],
+        &["compute_evaluate_integrity_constraints"],
     );
     let program = Assembler::default().compile(code).unwrap();
 
@@ -245,7 +245,7 @@ fn test_long_trace() {
         ],
         trace_len,
         z,
-        &["compute_evaluate_transitions"],
+        &["compute_evaluate_integrity_constraints"],
     );
     let program = Assembler::default().compile(code).unwrap();
 
@@ -324,7 +324,7 @@ fn test_vector() {
         ],
         trace_len,
         z,
-        &["compute_evaluate_transitions"],
+        &["compute_evaluate_integrity_constraints"],
     );
     let program = Assembler::default().compile(code).unwrap();
 
@@ -401,7 +401,7 @@ fn test_multiple_rows() {
         ],
         trace_len,
         z,
-        &["compute_evaluate_transitions"],
+        &["compute_evaluate_integrity_constraints"],
     );
     let program = Assembler::default().compile(code).unwrap();
 

--- a/codegen/masm/tests/test_boundary.rs
+++ b/codegen/masm/tests/test_boundary.rs
@@ -1,0 +1,252 @@
+use air_codegen_masm::{code_gen, constants};
+use assembly::Assembler;
+use ir::AirIR;
+use processor::{
+    math::{Felt, FieldElement},
+    AdviceInputs, Kernel, MemAdviceProvider, Process, QuadExtension, StackInputs,
+};
+
+mod utils;
+use utils::{parse, test_code, to_stack_order, Data};
+
+static SIMPLE_BOUNDARY_AIR: &str = "
+def SimpleBoundary
+
+trace_columns:
+    main: [a, b, len]
+
+public_inputs:
+    target: [1]
+
+boundary_constraints:
+    enf a.first = 1
+    enf b.first = 1
+
+    enf len.first = 0
+    enf len.last = target[0]
+
+integrity_constraints:
+    enf a' = a + b
+    enf b' = a
+";
+
+#[test]
+fn test_simple_boundary() {
+    let ast = parse(SIMPLE_BOUNDARY_AIR);
+    let ir = AirIR::new(ast).expect("build AirIR failed");
+    let code = code_gen(&ir).expect("codegen failed");
+
+    let trace_len = 32u64;
+    let one = QuadExtension::ONE;
+    let z = one.clone();
+    let a = QuadExtension::new(Felt::new(514229), Felt::ZERO);
+    let b = QuadExtension::new(Felt::new(317811), Felt::ZERO);
+    let len = QuadExtension::new(Felt::new(27), Felt::ZERO);
+    let a_prime = QuadExtension::new(Felt::new(514229 + 317811), Felt::ZERO);
+    let b_prime = a.clone();
+
+    let code = test_code(
+        code,
+        vec![
+            Data {
+                data: to_stack_order(&[a, a_prime, b, b_prime, len.clone(), len.clone()]),
+                address: constants::OOD_FRAME_ADDRESS,
+                descriptor: "main_trace",
+            },
+            Data {
+                data: to_stack_order(&[one; 6]),
+                address: constants::COMPOSITION_COEF_ADDRESS,
+                descriptor: "composition_coefficients",
+            },
+            Data {
+                data: to_stack_order(&[len]),
+                address: constants::PUBLIC_INPUTS_ADDRESS,
+                descriptor: "public_inputs",
+            },
+        ],
+        trace_len,
+        z,
+        &["compute_evaluate_boundary_constraints"],
+    );
+    let program = Assembler::default().compile(code).unwrap();
+
+    let mut process: Process<MemAdviceProvider> = Process::new(
+        Kernel::new(&[]),
+        StackInputs::new(vec![]),
+        AdviceInputs::default().into(),
+    );
+    let program_outputs = process.execute(&program).expect("execution failed");
+    let result_stack = program_outputs.stack();
+
+    // results are in stack-order
+    #[rustfmt::skip]
+    let expected = to_stack_order(&[
+        QuadExtension::ZERO,    // enf len.last = target[0]
+        len,                    // enf len.first = 0
+        b - QuadExtension::ONE, // enf b.first = 1
+        a - QuadExtension::ONE, // enf a.first = 1
+    ]);
+
+    assert!(
+        result_stack
+            .iter()
+            .zip(expected.iter())
+            .all(|(l, r)| l == r),
+        "results don't match result={:?} expected={:?}",
+        result_stack,
+        expected,
+    );
+}
+
+static COMPLEX_BOUNDARY_AIR: &str = "
+def ComplexBoundary
+
+const A = 1
+const B = [0, 1]
+const C = [[1, 2], [2, 0]]
+
+trace_columns:
+    main: [a, b, c, d, e[2]]
+    aux: [f]
+
+public_inputs:
+    stack_inputs: [2]
+    stack_outputs: [2]
+
+random_values:
+    rand: [2]
+
+boundary_constraints:
+    enf a.first = stack_inputs[0]
+    enf b.first = stack_inputs[1]
+    enf a.last = stack_outputs[0]
+    enf b.last = stack_outputs[1]
+
+    enf c.first = (B[0] - C[1][1]) * A
+    enf d.first = 1
+
+    enf e[0].first = 0
+    enf e[1].first = 1
+
+    enf f.first = $rand[0]
+    enf f.last = 1
+
+integrity_constraints:
+    enf a + b = 0
+";
+
+#[test]
+fn test_complex_boundary() {
+    let ast = parse(COMPLEX_BOUNDARY_AIR);
+    let ir = AirIR::new(ast).expect("build AirIR failed");
+    let code = code_gen(&ir).expect("codegen failed");
+
+    let trace_len = 32u64;
+    let one = QuadExtension::new(Felt::new(1), Felt::ZERO);
+    let z = one.clone();
+
+    let public_inputs = [
+        // stack_inputs
+        QuadExtension::new(Felt::new(2), Felt::ZERO),
+        QuadExtension::new(Felt::new(3), Felt::ZERO),
+        // stack_outputs
+        QuadExtension::new(Felt::new(5), Felt::ZERO),
+        QuadExtension::new(Felt::new(7), Felt::ZERO),
+    ];
+
+    let a = QuadExtension::new(Felt::new(11), Felt::ZERO);
+    let b = QuadExtension::new(Felt::new(13), Felt::ZERO);
+    let c = QuadExtension::new(Felt::new(17), Felt::ZERO);
+    let d = QuadExtension::new(Felt::new(19), Felt::ZERO);
+    let e = [
+        QuadExtension::new(Felt::new(23), Felt::ZERO),
+        QuadExtension::new(Felt::new(29), Felt::ZERO),
+    ];
+    let f = QuadExtension::new(Felt::new(31), Felt::ZERO);
+
+    let rand = [
+        QuadExtension::new(Felt::new(37), Felt::ZERO),
+        QuadExtension::new(Felt::new(41), Felt::ZERO),
+    ];
+
+    let a_prime = a + one;
+    let b_prime = b + one;
+    let c_prime = c + one;
+    let d_prime = d + one;
+    let e_prime = [e[0] + one, e[1] + one];
+    let f_prime = f + one;
+
+    let code = test_code(
+        code,
+        vec![
+            Data {
+                data: to_stack_order(&[
+                    a, a_prime, b, b_prime, c, c_prime, d, d_prime, e[0], e_prime[0], e[1],
+                    e_prime[1],
+                ]),
+                address: constants::OOD_FRAME_ADDRESS,
+                descriptor: "main_trace",
+            },
+            Data {
+                data: to_stack_order(&[f, f_prime]),
+                address: constants::OOD_AUX_FRAME_ADDRESS,
+                descriptor: "aux_trace",
+            },
+            Data {
+                data: to_stack_order(&public_inputs),
+                address: constants::PUBLIC_INPUTS_ADDRESS,
+                descriptor: "public_inputs",
+            },
+            Data {
+                data: to_stack_order(&[one; 11]),
+                address: constants::COMPOSITION_COEF_ADDRESS,
+                descriptor: "composition_coefficients",
+            },
+            Data {
+                data: to_stack_order(&rand),
+                address: constants::AUX_RAND_ELEM_PTR,
+                descriptor: "aux_random_elements",
+            },
+        ],
+        trace_len,
+        z,
+        &["compute_evaluate_boundary_constraints"],
+    );
+    let program = Assembler::default().compile(code).unwrap();
+
+    let mut process: Process<MemAdviceProvider> = Process::new(
+        Kernel::new(&[]),
+        StackInputs::new(vec![]),
+        AdviceInputs::default().into(),
+    );
+    let program_outputs = process.execute(&program).expect("execution failed");
+    let result_stack = program_outputs.stack();
+
+    // results are in stack-order
+    #[rustfmt::skip]
+    let expected = to_stack_order(&[
+        f - one,              // enf f.last = 1
+        f - rand[0],          // enf f.first = $rand[0]
+
+        e[1] - one,           // enf e[1].first = 1
+        e[0],                 // enf e[0].first = 0
+
+        d - one,              // enf d.first = 1
+        c,                    // enf c.first = (B[0] - C[1][1]) * A
+
+        b - public_inputs[3], // enf b.last = stack_outputs[1]
+        a - public_inputs[2], // enf a.last = stack_outputs[0]
+        b - public_inputs[1], // enf b.first = stack_inputs[1]
+        a - public_inputs[0], // enf a.first = stack_inputs[0]
+    ]);
+
+    assert!(
+        result_stack
+            .iter()
+            .zip(expected.iter())
+            .all(|(l, r)| l == r),
+        "results don't match result={:?} expected={:?}",
+        result_stack,
+        expected,
+    );
+}

--- a/codegen/masm/tests/test_constants.rs
+++ b/codegen/masm/tests/test_constants.rs
@@ -73,7 +73,7 @@ fn test_constants() {
         ],
         trace_len,
         z,
-        &["compute_evaluate_transitions"],
+        &["compute_evaluate_integrity_constraints"],
     );
     let program = Assembler::default().compile(code).unwrap();
 

--- a/codegen/masm/tests/test_periodic.rs
+++ b/codegen/masm/tests/test_periodic.rs
@@ -61,7 +61,10 @@ fn test_simple_periodic() {
         ],
         trace_len,
         z,
-        &["cache_periodic_polys", "compute_evaluate_transitions"],
+        &[
+            "cache_periodic_polys",
+            "compute_evaluate_integrity_constraints",
+        ],
     );
     let program = Assembler::default().compile(code).unwrap();
 

--- a/codegen/masm/tests/utils.rs
+++ b/codegen/masm/tests/utils.rs
@@ -103,7 +103,12 @@ where
     for check in ranges.windows(2) {
         let first = check[0];
         let second = check[1];
-        assert!(first.1 <= second.0, "memory ranges overlap");
+        assert!(
+            first.1 <= second.0,
+            "memory ranges overlap {:?} {:?}",
+            first,
+            second
+        );
     }
 
     let main_memory_pos = ranges

--- a/codegen/masm/tests/utils.rs
+++ b/codegen/masm/tests/utils.rs
@@ -14,7 +14,7 @@ where
     T: Default + std::fmt::Display,
 {
     pub data: Vec<T>,
-    pub address: u64,
+    pub address: u32,
     pub descriptor: &'a str,
 }
 
@@ -91,9 +91,12 @@ where
     );
 
     // asserts there is no overlap between the memory ranges
-    let mut ranges: Vec<(u64, u64)> = memory
+    let mut ranges: Vec<(u32, u32)> = memory
         .iter()
-        .map(|data| (data.address, data.address + data.data.len() as u64))
+        .map(|data| {
+            let len: u32 = data.data.len().try_into().unwrap();
+            (data.address, data.address + len)
+        })
         .collect();
     ranges.sort();
 


### PR DESCRIPTION
- Add support for public inputs
- Fix a bug with auxiliary random values (the address constant was wrong, it was caught by the tests)
- Codegen for boundary constraints

Notes:

- ~There is an issue with public inputs. For the code below:~ Edit: There was no issue with public inputs, the information is available on the [constraint domain](https://github.com/0xPolygonMiden/air-script/blob/7a24e00924ed38bee4bf94591c56228b2e210e74/ir/src/constraints/constraint.rs#L37-L42) 

```
public_inputs:
    stack_inputs: [2]
    stack_outputs: [2]
```
the indexes `Value::PublicInput(name, index)` instances reuse indexes. Since the names are user defined it is not really possible to differentiate which input should be used with an assertion for the first or last row.

- This doesn't implement the divisor. That should be the last piece to tie everything together.
- I have to review the code for the transition constraints that apply to every row, the codegen may be missing some pieces for that.