### PR TITLE
katex: udpate config

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -5,11 +5,11 @@ multilingual = false
 src = "src"
 title = "AirScript by Polygon Miden"
 
-[output.katex]
 [output.html]
 git-repository-url = "https://github.com/0xPolygonMiden/air-script/"
 
+[preprocessor.katex]
+after = ["links"]
+
 [output.linkcheck]
 warning-policy = "ignore"
-
-[preprocessor.katex]


### PR DESCRIPTION
`mdbook-katex 0.5.3` no longer accepts the configuration option `output.katex`, update it to `preprocessor.katex` [ref](https://github.com/lzanini/mdbook-katex#katex-options).

Note: For local runs updating katex may be necessary `cargo install mdbook mdbook-katex`