### PR TITLE
feat: add utilities for pretty-printing ast

### DIFF
--- a/parser/src/ast/declarations.rs
+++ b/parser/src/ast/declarations.rs
@@ -428,6 +428,20 @@ impl fmt::Debug for RandomValues {
             .finish()
     }
 }
+impl fmt::Display for RandomValues {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(name) = self.name.as_str().strip_prefix('$') {
+            write!(f, "{}: ", name)?;
+        } else {
+            write!(f, "{}: ", self.name)?;
+        }
+        if self.bindings.is_empty() {
+            write!(f, "[{}]", self.size)
+        } else {
+            write!(f, "{}", DisplayList(self.bindings.as_slice()))
+        }
+    }
+}
 
 /// Declaration of a random value binding used in [RandomValues].
 ///
@@ -504,6 +518,15 @@ impl fmt::Debug for RandBinding {
             .field("size", &self.size)
             .field("offset", &self.offset)
             .finish()
+    }
+}
+impl fmt::Display for RandBinding {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.size == 1 {
+            write!(f, "{}", self.name)
+        } else {
+            write!(f, "{}[{}]", self.name, self.size)
+        }
     }
 }
 

--- a/parser/src/ast/display.rs
+++ b/parser/src/ast/display.rs
@@ -1,0 +1,102 @@
+use std::{cell::Cell, fmt};
+
+use super::Statement;
+
+/// Displays an item surrounded by brackets, e.g. `[foo]`
+pub struct DisplayBracketed<T>(pub T);
+impl<T: fmt::Display> fmt::Display for DisplayBracketed<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "[{}]", &self.0)
+    }
+}
+
+/// Displays a slice of items surrounded by brackets, e.g. `[foo]`
+pub struct DisplayList<'a, T>(pub &'a [T]);
+impl<'a, T: fmt::Display> fmt::Display for DisplayList<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "[{}]", DisplayCsv::new(self.0.iter()))
+    }
+}
+
+/// Displays an item surrounded by parentheses, e.g. `(foo)`
+pub struct DisplayParenthesized<T>(pub T);
+impl<T: fmt::Display> fmt::Display for DisplayParenthesized<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({})", &self.0)
+    }
+}
+
+/// Displays a slice of items surrounded by parentheses, e.g. `(foo)`
+pub struct DisplayTuple<'a, T>(pub &'a [T]);
+impl<'a, T: fmt::Display> fmt::Display for DisplayTuple<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({})", DisplayCsv::new(self.0.iter()))
+    }
+}
+
+/// Displays one or more items separated by commas, e.g. `foo, bar`
+pub struct DisplayCsv<T>(Cell<Option<T>>);
+impl<T, I> DisplayCsv<I>
+where
+    T: fmt::Display,
+    I: Iterator<Item = T>,
+{
+    pub fn new(iter: I) -> Self {
+        Self(Cell::new(Some(iter)))
+    }
+}
+impl<T, I> fmt::Display for DisplayCsv<I>
+where
+    T: fmt::Display,
+    I: Iterator<Item = T>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let iter = self.0.take().unwrap();
+        for (i, item) in iter.enumerate() {
+            if i > 0 {
+                f.write_str(", ")?;
+            }
+            write!(f, "{}", item)?;
+        }
+        Ok(())
+    }
+}
+
+pub struct DisplayStatement<'a> {
+    pub statement: &'a Statement,
+    pub indent: usize,
+}
+impl DisplayStatement<'_> {
+    const INDENT: &str = "    ";
+
+    fn write_indent(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for _ in 0..self.indent {
+            f.write_str(Self::INDENT)?;
+        }
+        Ok(())
+    }
+}
+impl<'a> fmt::Display for DisplayStatement<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.write_indent(f)?;
+        match self.statement {
+            Statement::Let(ref expr) => {
+                writeln!(f, "let {} = {}", expr.name, expr.value)?;
+                for statement in expr.body.iter() {
+                    writeln!(f, "{}", statement.display(self.indent))?;
+                }
+                Ok(())
+            }
+            Statement::Enforce(ref expr) => {
+                write!(f, "enf {}", expr)
+            }
+            Statement::EnforceIf(ref expr, ref selector) => {
+                write!(f, "enf {} when {}", expr, selector)
+            }
+            Statement::EnforceAll(ref expr) => {
+                write!(f, "enf {}", expr)
+            }
+            Statement::Expr(ref expr) => write!(f, "{}", expr),
+        }
+    }
+}

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -1,4 +1,5 @@
 mod declarations;
+mod display;
 mod errors;
 mod expression;
 mod module;
@@ -7,6 +8,7 @@ mod trace;
 pub mod visit;
 
 pub use self::declarations::*;
+pub(crate) use self::display::*;
 pub use self::errors::*;
 pub use self::expression::*;
 pub use self::module::*;
@@ -286,6 +288,90 @@ impl PartialEq for Program {
             && self.trace_columns == other.trace_columns
             && self.boundary_constraints == other.boundary_constraints
             && self.integrity_constraints == other.integrity_constraints
+    }
+}
+impl fmt::Display for Program {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "def {}\n", self.name)?;
+
+        writeln!(f, "trace_columns:")?;
+        for segment in self.trace_columns.iter() {
+            writeln!(f, "    {}", segment)?;
+        }
+        f.write_str("\n")?;
+
+        writeln!(f, "public_inputs:")?;
+        for public_input in self.public_inputs.values() {
+            writeln!(f, "    {}: [{}]", public_input.name, public_input.size)?;
+        }
+        f.write_str("\n")?;
+
+        if let Some(rv) = self.random_values.as_ref() {
+            writeln!(f, "random_values:")?;
+            writeln!(f, "    {}", rv)?;
+            f.write_str("\n")?;
+        }
+
+        if !self.periodic_columns.is_empty() {
+            writeln!(f, "periodic_columns:")?;
+            for (qid, column) in self.periodic_columns.iter() {
+                if qid.module == self.name {
+                    writeln!(
+                        f,
+                        "    {}: {}",
+                        &qid.item,
+                        DisplayList(column.values.as_slice())
+                    )?;
+                } else {
+                    writeln!(f, "    {}: {}", qid, DisplayList(column.values.as_slice()))?;
+                }
+            }
+            f.write_str("\n")?;
+        }
+
+        if !self.constants.is_empty() {
+            for (qid, constant) in self.constants.iter() {
+                if qid.module == self.name {
+                    writeln!(f, "const {} = {}", &qid.item, &constant.value)?;
+                } else {
+                    writeln!(f, "const {} = {}", qid, &constant.value)?;
+                }
+            }
+            f.write_str("\n")?;
+        }
+
+        writeln!(f, "boundary_constraints:")?;
+        for statement in self.boundary_constraints.iter() {
+            writeln!(f, "{}", statement.display(1))?;
+        }
+        f.write_str("\n")?;
+
+        writeln!(f, "integrity_constraints:")?;
+        for statement in self.integrity_constraints.iter() {
+            writeln!(f, "{}", statement.display(1))?;
+        }
+        f.write_str("\n")?;
+
+        for (qid, evaluator) in self.evaluators.iter() {
+            f.write_str("ev ")?;
+            if qid.module == self.name {
+                writeln!(
+                    f,
+                    "{}{}",
+                    &qid.item,
+                    DisplayTuple(evaluator.params.as_slice())
+                )?;
+            } else {
+                writeln!(f, "{}{}", qid, DisplayTuple(evaluator.params.as_slice()))?;
+            }
+
+            for statement in evaluator.body.iter() {
+                writeln!(f, "{}", statement.display(1))?;
+            }
+            f.write_str("\n")?;
+        }
+
+        Ok(())
     }
 }
 

--- a/parser/src/ast/statement.rs
+++ b/parser/src/ast/statement.rs
@@ -53,6 +53,13 @@ impl Statement {
             Self::Let(Let { body, .. }) => body.iter().any(|s| s.has_constraints()),
         }
     }
+
+    pub fn display(&self, indent: usize) -> DisplayStatement<'_> {
+        DisplayStatement {
+            statement: self,
+            indent,
+        }
+    }
 }
 
 /// A `let` statement binds `name` to the value of `expr` in `body`.


### PR DESCRIPTION
This PR adds support for pretty printing the AST, useful for troubleshooting and reviewing the results of various transformations.

NOTE: This is based on the branch from #297 and is part of a chain of PRs that implement modules, as well as a number of refactorings/improvements to the AirScript compiler toolchain. This is the 3rd PR in that chain. It must be merged into #304 or merged into #297 after #304.