### PR TITLE
chores: a few small cleanup/reorganization tasks

### DIFF
--- a/parser/src/ast/declarations.rs
+++ b/parser/src/ast/declarations.rs
@@ -24,7 +24,7 @@
 ///!
 ///! There is no notion of public/private visiblity, so any declaration of the above types may be
 ///! imported into another module, and "wildcard" imports will import all importable items.
-use std::collections::HashSet;
+use std::{collections::HashSet, fmt};
 
 use miden_diagnostics::{SourceSpan, Spanned};
 
@@ -132,82 +132,20 @@ impl ConstantExpr {
         matches!(self, Self::Vector(_) | Self::Matrix(_))
     }
 }
-
-/// The types of values which can be represented in an AirScript program
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum Type {
-    /// A field element
-    Felt,
-    /// A vector of N integers
-    Vector(usize),
-    /// A matrix of N rows and M columns
-    Matrix(usize, usize),
-}
-impl Type {
-    /// Returns true if this type is an aggregate
-    #[inline]
-    pub fn is_aggregate(&self) -> bool {
-        match self {
-            Self::Felt => false,
-            Self::Vector(_) | Self::Matrix(_, _) => true,
-        }
-    }
-
-    /// Returns true if this type is a scalar
-    #[inline]
-    pub fn is_scalar(&self) -> bool {
-        matches!(self, Self::Felt)
-    }
-
-    /// Returns true if this type is a valid iterable in a comprehension
-    #[inline]
-    pub fn is_iterable(&self) -> bool {
-        self.is_vector()
-    }
-
-    /// Returns true if this type is a vector
-    #[inline]
-    pub fn is_vector(&self) -> bool {
-        matches!(self, Self::Vector(_))
-    }
-
-    /// Return a new [Type] representing the type of the value produced by the given [AccessType]
-    pub fn access(&self, access_type: AccessType) -> Result<Self, InvalidAccessError> {
-        match *self {
-            ty if access_type == AccessType::Default => Ok(ty),
-            Self::Felt => Err(InvalidAccessError::IndexIntoScalar),
-            Self::Vector(len) => match access_type {
-                AccessType::Slice(range) if range.end > len => {
-                    Err(InvalidAccessError::IndexOutOfBounds)
-                }
-                AccessType::Slice(range) => Ok(Self::Vector(range.end - range.start)),
-                AccessType::Index(idx) if idx >= len => Err(InvalidAccessError::IndexOutOfBounds),
-                AccessType::Index(_) => Ok(Self::Felt),
-                AccessType::Matrix(_, _) => Err(InvalidAccessError::IndexIntoScalar),
-                _ => unreachable!(),
-            },
-            Self::Matrix(rows, cols) => match access_type {
-                AccessType::Slice(range) if range.end > rows => {
-                    Err(InvalidAccessError::IndexOutOfBounds)
-                }
-                AccessType::Slice(range) => Ok(Self::Matrix(range.end - range.start, cols)),
-                AccessType::Index(idx) if idx >= rows => Err(InvalidAccessError::IndexOutOfBounds),
-                AccessType::Index(_) => Ok(Self::Vector(cols)),
-                AccessType::Matrix(row, col) if row >= rows || col >= cols => {
-                    Err(InvalidAccessError::IndexOutOfBounds)
-                }
-                AccessType::Matrix(_, _) => Ok(Self::Felt),
-                _ => unreachable!(),
-            },
-        }
-    }
-}
-impl fmt::Display for Type {
+impl fmt::Display for ConstantExpr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Felt => f.write_str("field element"),
-            Self::Vector(n) => write!(f, "vector of length {}", n),
-            Self::Matrix(rows, cols) => write!(f, "matrix of {} rows and {} columns", rows, cols),
+            Self::Scalar(value) => write!(f, "{}", value),
+            Self::Vector(ref values) => {
+                write!(f, "{}", DisplayList(values.as_slice()))
+            }
+            Self::Matrix(ref values) => write!(
+                f,
+                "{}",
+                DisplayBracketed(DisplayCsv::new(
+                    values.iter().map(|vs| DisplayList(vs.as_slice()))
+                ))
+            ),
         }
     }
 }

--- a/parser/src/ast/errors.rs
+++ b/parser/src/ast/errors.rs
@@ -1,100 +1,16 @@
-use miden_diagnostics::{Diagnostic, Label, SourceSpan, Spanned, ToDiagnostic};
-
-use super::*;
-
-/// Represents the various module validation errors we might encounter during semantic analysis.
-#[derive(Debug, thiserror::Error)]
-pub enum ModuleError {
-    #[error("root module is missing")]
-    MissingRoot,
-    #[error(
-        "root module must contain at both boundary_constraints and integrity_constraints sections"
-    )]
-    MissingConstraints,
-    #[error("root module must contain a public_inputs section")]
-    MissingPublicInputs,
-    #[error("reference to unknown module '{0}'")]
-    MissingModule(ModuleId),
-    #[error("invalid use of restricted section type in library module")]
-    RootSectionInLibrary(SourceSpan),
-    #[error("invalid import of root module")]
-    RootImport(SourceSpan),
-    #[error("name already in use")]
-    NameConflict(SourceSpan),
-    #[error("import refers to undefined item in '{0}'")]
-    ImportUndefined(ModuleId),
-    #[error("cannot import from self")]
-    ImportSelf(SourceSpan),
-    #[error("import conflict")]
-    ImportConflict { item: Identifier, prev: SourceSpan },
-    #[error("import failed")]
-    ImportFailed(SourceSpan),
-    #[error("module is invalid, see diagnostics for details")]
-    Invalid,
-}
-impl Eq for ModuleError {}
-impl PartialEq for ModuleError {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::MissingModule(lm), Self::MissingModule(rm)) => lm == rm,
-            (Self::ImportUndefined(lm), Self::ImportUndefined(rm)) => lm == rm,
-            (Self::ImportConflict { item: li, .. }, Self::ImportConflict { item: ri, .. }) => {
-                li == ri
-            }
-            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
-        }
-    }
-}
-impl ToDiagnostic for ModuleError {
-    fn to_diagnostic(self) -> Diagnostic {
-        match self {
-            Self::MissingRoot => Diagnostic::error().with_message("no root module found"),
-            Self::MissingConstraints => Diagnostic::error().with_message("root module must contain both boundary_constraints and integrity_constraints sections"),
-            Self::MissingPublicInputs => Diagnostic::error().with_message("root module must contain a public_inputs section"),
-            Self::MissingModule(id) => Diagnostic::error()
-                .with_message("found reference to module which does not exist")
-                .with_labels(vec![Label::primary(id.span().source_id(), id.span()).with_message("this module could not be found")]),
-            Self::RootSectionInLibrary(span) => Diagnostic::error()
-                .with_message("invalid use of restricted section type in library module")
-                .with_labels(vec![Label::primary(span.source_id(), span)
-                    .with_message("invalid declaration occurs here")]),
-            Self::RootImport(span) => Diagnostic::error()
-                .with_message("invalid import of root module")
-                .with_labels(vec![Label::primary(span.source_id(), span)
-                    .with_message("invalid declaration occurs here")])
-                .with_notes(vec!["The root module may not be imported. Try extracting the items you wish to import into a library module".to_string()]),
-            Self::NameConflict(span) => Diagnostic::error()
-                .with_message("name already in use")
-                .with_labels(vec![Label::primary(span.source_id(), span)
-                    .with_message("conflicting definition occurs here")]),
-            Self::ImportUndefined(from) => Diagnostic::error()
-                .with_message("invalid import")
-                .with_labels(vec![Label::primary(from.span().source_id(), from.span())
-                    .with_message(format!("no such item in '{}'", from))]),
-            Self::ImportSelf(span) => Diagnostic::error()
-                .with_message("invalid import")
-                .with_labels(vec![Label::primary(span.source_id(), span)
-                    .with_message("cannot import a module from within itself")]),
-            Self::ImportConflict { item, prev } => Diagnostic::error()
-                .with_message("conflicting import")
-                .with_labels(vec![Label::primary(item.span().source_id(), item.span())
-                    .with_message(format!("the item '{}' is imported here", item)),
-                                  Label::secondary(prev.source_id(), prev)
-                    .with_message("but it conflicts with an item of the same name here")]),
-            Self::ImportFailed(span) => Diagnostic::error()
-                .with_message("error occurred while resolving an import")
-                .with_labels(vec![Label::primary(span.source_id(), span)
-                    .with_message("failed import occurred here")]),
-            Self::Invalid => Diagnostic::error().with_message("module is invalid, see diagnostics for details"),
-        }
-    }
-}
+use miden_diagnostics::{Diagnostic, Label, SourceSpan, ToDiagnostic};
 
 /// Represents an invalid expression for use in an `Expr` context
 #[derive(Debug, thiserror::Error)]
 pub enum InvalidExprError {
+    #[error("this value is too large for an exponent")]
+    InvalidExponent(SourceSpan),
+    #[error("expected exponent to be a constant")]
+    NonConstantExponent(SourceSpan),
     #[error("accessing column boundaries is not allowed here")]
     BoundedSymbolAccess(SourceSpan),
+    #[error("expected scalar expression")]
+    InvalidScalarExpr(SourceSpan),
 }
 impl Eq for InvalidExprError {}
 impl PartialEq for InvalidExprError {
@@ -106,7 +22,26 @@ impl ToDiagnostic for InvalidExprError {
     fn to_diagnostic(self) -> Diagnostic {
         let message = format!("{}", &self);
         match self {
+            Self::InvalidExponent(span) => Diagnostic::error()
+                .with_message("invalid expression")
+                .with_labels(vec![
+                    Label::primary(span.source_id(), span).with_message(message)
+                ]),
+            Self::NonConstantExponent(span) => Diagnostic::error()
+                .with_message("invalid expression")
+                .with_labels(vec![
+                    Label::primary(span.source_id(), span).with_message(message)
+                ])
+                .with_notes(vec![
+                    "Only constant powers are supported with the exponentiation operator currently"
+                        .to_string(),
+                ]),
             Self::BoundedSymbolAccess(span) => Diagnostic::error()
+                .with_message("invalid expression")
+                .with_labels(vec![
+                    Label::primary(span.source_id(), span).with_message(message)
+                ]),
+            Self::InvalidScalarExpr(span) => Diagnostic::error()
                 .with_message("invalid expression")
                 .with_labels(vec![
                     Label::primary(span.source_id(), span).with_message(message)

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -5,6 +5,7 @@ mod expression;
 mod module;
 mod statement;
 mod trace;
+mod types;
 pub mod visit;
 
 pub use self::declarations::*;
@@ -14,6 +15,7 @@ pub use self::expression::*;
 pub use self::module::*;
 pub use self::statement::*;
 pub use self::trace::*;
+pub use self::types::*;
 
 use std::{
     collections::{BTreeMap, HashMap, HashSet, VecDeque},

--- a/parser/src/ast/types.rs
+++ b/parser/src/ast/types.rs
@@ -1,0 +1,99 @@
+use super::*;
+
+/// The types of values which can be represented in an AirScript program
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Type {
+    /// A field element
+    Felt,
+    /// A vector of N integers
+    Vector(usize),
+    /// A matrix of N rows and M columns
+    Matrix(usize, usize),
+}
+impl Type {
+    /// Returns true if this type is an aggregate
+    #[inline]
+    pub fn is_aggregate(&self) -> bool {
+        match self {
+            Self::Felt => false,
+            Self::Vector(_) | Self::Matrix(_, _) => true,
+        }
+    }
+
+    /// Returns true if this type is a scalar
+    #[inline]
+    pub fn is_scalar(&self) -> bool {
+        matches!(self, Self::Felt)
+    }
+
+    /// Returns true if this type is a valid iterable in a comprehension
+    #[inline]
+    pub fn is_iterable(&self) -> bool {
+        self.is_vector()
+    }
+
+    /// Returns true if this type is a vector
+    #[inline]
+    pub fn is_vector(&self) -> bool {
+        matches!(self, Self::Vector(_))
+    }
+
+    /// Return a new [Type] representing the type of the value produced by the given [AccessType]
+    pub fn access(&self, access_type: AccessType) -> Result<Self, InvalidAccessError> {
+        match *self {
+            ty if access_type == AccessType::Default => Ok(ty),
+            Self::Felt => Err(InvalidAccessError::IndexIntoScalar),
+            Self::Vector(len) => match access_type {
+                AccessType::Slice(range) if range.end > len => {
+                    Err(InvalidAccessError::IndexOutOfBounds)
+                }
+                AccessType::Slice(range) => Ok(Self::Vector(range.end - range.start)),
+                AccessType::Index(idx) if idx >= len => Err(InvalidAccessError::IndexOutOfBounds),
+                AccessType::Index(_) => Ok(Self::Felt),
+                AccessType::Matrix(_, _) => Err(InvalidAccessError::IndexIntoScalar),
+                _ => unreachable!(),
+            },
+            Self::Matrix(rows, cols) => match access_type {
+                AccessType::Slice(range) if range.end > rows => {
+                    Err(InvalidAccessError::IndexOutOfBounds)
+                }
+                AccessType::Slice(range) => Ok(Self::Matrix(range.end - range.start, cols)),
+                AccessType::Index(idx) if idx >= rows => Err(InvalidAccessError::IndexOutOfBounds),
+                AccessType::Index(_) => Ok(Self::Vector(cols)),
+                AccessType::Matrix(row, col) if row >= rows || col >= cols => {
+                    Err(InvalidAccessError::IndexOutOfBounds)
+                }
+                AccessType::Matrix(_, _) => Ok(Self::Felt),
+                _ => unreachable!(),
+            },
+        }
+    }
+}
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Felt => f.write_str("field element"),
+            Self::Vector(n) => write!(f, "vector of length {}", n),
+            Self::Matrix(rows, cols) => write!(f, "matrix of {} rows and {} columns", rows, cols),
+        }
+    }
+}
+
+/// Represents the type signature of a function
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FunctionType {
+    /// An evaluator function, which has no results, and has
+    /// a complex type signature due to the nature of trace bindings
+    Evaluator(Vec<TraceSegment>),
+    /// A standard function with one or more inputs, and a result
+    #[allow(dead_code)]
+    Function(Vec<Type>, Type),
+}
+impl FunctionType {
+    pub fn result(&self) -> Option<Type> {
+        match self {
+            Self::Evaluator(_) => None,
+            Self::Function(_, result) => Some(*result),
+        }
+    }
+}

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -3,10 +3,14 @@ use std::collections::HashSet;
 
 use miden_diagnostics::{CodeMap, DiagnosticsHandler, Severity, SourceSpan, Span, Spanned};
 
-use crate::ast::*;
-use crate::lexer::Token;
-use crate::parser::ParseError;
-use crate::{symbols, Symbol};
+use crate::{
+    ast::*,
+    lexer::Token,
+    parser::ParseError,
+    sema::SemanticAnalysisError,
+    symbols,
+    Symbol
+};
 
 grammar(diagnostics: &DiagnosticsHandler, codemap: &Arc<CodeMap>, next_var: &mut usize);
 
@@ -54,14 +58,14 @@ pub AnyModule: Module = {
 Root: Module = {
     <l:@L> "def" <name:Identifier> <decls:Declaration*> <r:@R> =>? {
         Module::from_declarations(diagnostics, ModuleType::Root, span!(l, r), name, decls)
-            .map_err(|err| ParseError::InvalidModule(err).into())
+            .map_err(|err| ParseError::Analysis(err).into())
     }
 }
 
 Module: Module = {
     <l:@L> "mod" <name:Identifier> <decls:Declaration*> <r:@R> =>? {
         Module::from_declarations(diagnostics, ModuleType::Library, span!(l, r), name, decls)
-            .map_err(|err| ParseError::InvalidModule(err).into())
+            .map_err(|err| ParseError::Analysis(err).into())
     }
 }
 
@@ -362,7 +366,7 @@ Expr: Expr = {
     <ScalarExpr> =>? {
         match Expr::try_from(<>) {
             Ok(expr) => Ok(expr),
-            Err(err) => Err(ParseError::from(err).into())
+            Err(err) => Err(ParseError::from(SemanticAnalysisError::InvalidExpr(err)).into())
         }
     },
     <l:@L> <value:Vector<ScalarExpr>> <r:@R> => Expr::Vector(Span::new(span!(l, r), value)),
@@ -455,7 +459,7 @@ ConstraintComprehension<T>: ComprehensionContext = {
                 .with_message("bindings and iterables lengths are mismatched")
                 .with_primary_label(span!(l, r), "in this comprehension")
                 .emit();
-            Err(ParseError::InvalidModule(ModuleError::Invalid).into())
+            Err(ParseError::Analysis(SemanticAnalysisError::Invalid).into())
         } else {
             Ok(members.into_iter().zip(iterables).collect::<Vec<_>>())
         }
@@ -468,7 +472,7 @@ ListComprehension<T>: ListComprehension = {
                 .with_message("bindings and iterables lengths are mismatched")
                 .with_primary_label(span!(l, r), "in this comprehension")
                 .emit();
-            Err(ParseError::InvalidModule(ModuleError::Invalid).into())
+            Err(ParseError::Analysis(SemanticAnalysisError::Invalid).into())
         } else {
             Ok(ListComprehension::new(span!(l, r), expr, members.into_iter().zip(iterables).collect::<Vec<_>>(), None))
         }

--- a/parser/src/sema/errors.rs
+++ b/parser/src/sema/errors.rs
@@ -1,0 +1,95 @@
+use miden_diagnostics::{Diagnostic, Label, SourceSpan, Spanned, ToDiagnostic};
+
+use crate::ast::{Identifier, InvalidExprError, ModuleId};
+
+/// Represents the various module validation errors we might encounter during semantic analysis.
+#[derive(Debug, thiserror::Error)]
+pub enum SemanticAnalysisError {
+    #[error("root module is missing")]
+    MissingRoot,
+    #[error(
+        "root module must contain at both boundary_constraints and integrity_constraints sections"
+    )]
+    MissingConstraints,
+    #[error("root module must contain a public_inputs section")]
+    MissingPublicInputs,
+    #[error("reference to unknown module '{0}'")]
+    MissingModule(ModuleId),
+    #[error("invalid use of restricted section type in library module")]
+    RootSectionInLibrary(SourceSpan),
+    #[error("invalid import of root module")]
+    RootImport(SourceSpan),
+    #[error("name already in use")]
+    NameConflict(SourceSpan),
+    #[error("import refers to undefined item in '{0}'")]
+    ImportUndefined(ModuleId),
+    #[error("cannot import from self")]
+    ImportSelf(SourceSpan),
+    #[error("import conflict")]
+    ImportConflict { item: Identifier, prev: SourceSpan },
+    #[error("import failed")]
+    ImportFailed(SourceSpan),
+    #[error(transparent)]
+    InvalidExpr(#[from] InvalidExprError),
+    #[error("module is invalid, see diagnostics for details")]
+    Invalid,
+}
+impl Eq for SemanticAnalysisError {}
+impl PartialEq for SemanticAnalysisError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::MissingModule(lm), Self::MissingModule(rm)) => lm == rm,
+            (Self::ImportUndefined(lm), Self::ImportUndefined(rm)) => lm == rm,
+            (Self::ImportConflict { item: li, .. }, Self::ImportConflict { item: ri, .. }) => {
+                li == ri
+            }
+            (Self::InvalidExpr(l), Self::InvalidExpr(r)) => l == r,
+            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
+        }
+    }
+}
+impl ToDiagnostic for SemanticAnalysisError {
+    fn to_diagnostic(self) -> Diagnostic {
+        match self {
+            Self::MissingRoot => Diagnostic::error().with_message("no root module found"),
+            Self::MissingConstraints => Diagnostic::error().with_message("root module must contain both boundary_constraints and integrity_constraints sections"),
+            Self::MissingPublicInputs => Diagnostic::error().with_message("root module must contain a public_inputs section"),
+            Self::MissingModule(id) => Diagnostic::error()
+                .with_message("found reference to module which does not exist")
+                .with_labels(vec![Label::primary(id.span().source_id(), id.span()).with_message("this module could not be found")]),
+            Self::RootSectionInLibrary(span) => Diagnostic::error()
+                .with_message("invalid use of restricted section type in library module")
+                .with_labels(vec![Label::primary(span.source_id(), span)
+                    .with_message("invalid declaration occurs here")]),
+            Self::RootImport(span) => Diagnostic::error()
+                .with_message("invalid import of root module")
+                .with_labels(vec![Label::primary(span.source_id(), span)
+                    .with_message("invalid declaration occurs here")])
+                .with_notes(vec!["The root module may not be imported. Try extracting the items you wish to import into a library module".to_string()]),
+            Self::NameConflict(span) => Diagnostic::error()
+                .with_message("name already in use")
+                .with_labels(vec![Label::primary(span.source_id(), span)
+                    .with_message("conflicting definition occurs here")]),
+            Self::ImportUndefined(from) => Diagnostic::error()
+                .with_message("invalid import")
+                .with_labels(vec![Label::primary(from.span().source_id(), from.span())
+                    .with_message(format!("no such item in '{}'", from))]),
+            Self::ImportSelf(span) => Diagnostic::error()
+                .with_message("invalid import")
+                .with_labels(vec![Label::primary(span.source_id(), span)
+                    .with_message("cannot import a module from within itself")]),
+            Self::ImportConflict { item, prev } => Diagnostic::error()
+                .with_message("conflicting import")
+                .with_labels(vec![Label::primary(item.span().source_id(), item.span())
+                    .with_message(format!("the item '{}' is imported here", item)),
+                                  Label::secondary(prev.source_id(), prev)
+                    .with_message("but it conflicts with an item of the same name here")]),
+            Self::ImportFailed(span) => Diagnostic::error()
+                .with_message("error occurred while resolving an import")
+                .with_labels(vec![Label::primary(span.source_id(), span)
+                    .with_message("failed import occurred here")]),
+            Self::InvalidExpr(err) => err.to_diagnostic(),
+            Self::Invalid => Diagnostic::error().with_message("module is invalid, see diagnostics for details"),
+        }
+    }
+}

--- a/parser/src/sema/mod.rs
+++ b/parser/src/sema/mod.rs
@@ -1,5 +1,7 @@
+mod errors;
 mod import_resolver;
 mod semantic_analysis;
 
+pub use self::errors::SemanticAnalysisError;
 pub use self::import_resolver::{ImportResolver, Imported};
 pub use self::semantic_analysis::{DependencyGraph, DependencyType, ModuleGraph, SemanticAnalysis};

--- a/parser/src/sema/semantic_analysis.rs
+++ b/parser/src/sema/semantic_analysis.rs
@@ -323,7 +323,13 @@ impl<'a> VisitMut<ModuleError> for SemanticAnalysis<'a> {
             assert_eq!(
                 self.globals.insert(
                     rv.name,
-                    BindingType::RandomValue(RandBinding::new(rv.name.span(), rv.name, rv.size, 0))
+                    BindingType::RandomValue(RandBinding::new(
+                        rv.name.span(),
+                        rv.name,
+                        rv.size,
+                        0,
+                        Type::Vector(rv.size)
+                    ))
                 ),
                 None
             );
@@ -344,11 +350,13 @@ impl<'a> VisitMut<ModuleError> for SemanticAnalysis<'a> {
                 assert_eq!(
                     self.locals.insert(
                         NamespacedIdentifier::Binding(segment.name),
-                        BindingType::TraceColumn(TraceRef {
-                            span: segment.name.span(),
+                        BindingType::TraceColumn(TraceBinding {
+                            span: segment.span(),
                             segment: segment.id,
-                            index: 0,
-                            size: segment.size
+                            name: Some(segment.name),
+                            offset: 0,
+                            size: segment.size,
+                            ty: Type::Vector(segment.size),
                         })
                     ),
                     None
@@ -356,12 +364,14 @@ impl<'a> VisitMut<ModuleError> for SemanticAnalysis<'a> {
                 for binding in segment.bindings.iter().copied() {
                     assert_eq!(
                         self.locals.insert(
-                            NamespacedIdentifier::Binding(binding.name),
-                            BindingType::TraceColumn(TraceRef {
+                            NamespacedIdentifier::Binding(binding.name.unwrap()),
+                            BindingType::TraceColumn(TraceBinding {
                                 span: segment.name.span(),
                                 segment: segment.id,
-                                index: binding.offset,
+                                name: binding.name,
+                                offset: binding.offset,
                                 size: binding.size,
+                                ty: binding.ty,
                             })
                         ),
                         None
@@ -532,11 +542,13 @@ impl<'a> VisitMut<ModuleError> for SemanticAnalysis<'a> {
                 }
                 self.locals.insert(
                     namespaced_name,
-                    BindingType::TraceParam(TraceRef {
+                    BindingType::TraceParam(TraceBinding {
                         span: trace_binding.span,
+                        name: Some(name),
                         segment: trace_segment.id,
-                        index: trace_binding.offset,
+                        offset: trace_binding.offset,
                         size: trace_binding.size,
+                        ty: trace_binding.ty,
                     }),
                 );
             }


### PR DESCRIPTION
This PR includes 3 commits which do the following:

* Extract the `Type` and `FunctionType` enums to a new AST module
* Add tracking of `Type` to random value and trace bindings
* Rename `ModuleError` to `SemanticAnalysisError` to better reflect its generality and purpose

NOTE: This is based on the branch from #297 and is part of a chain of PRs that implement modules, as well as a number of refactorings/improvements to the AirScript compiler toolchain. This is the 4th PR in that chain. It must be merged into #305 or merged into #297 after #305.