### PR TITLE
fix: use btreemap for more deterministic ast diffs

### DIFF
--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -68,16 +68,16 @@ pub struct Program {
     /// The name of an AirScript program is the name of its root module.
     pub name: Identifier,
     /// The set of used constants referenced in this program.
-    pub constants: HashMap<QualifiedIdentifier, Constant>,
+    pub constants: BTreeMap<QualifiedIdentifier, Constant>,
     /// The set of used evaluator functions referenced in this program.
     pub evaluators: BTreeMap<QualifiedIdentifier, EvaluatorFunction>,
     /// The set of used periodic columns referenced in this program.
-    pub periodic_columns: HashMap<QualifiedIdentifier, PeriodicColumn>,
+    pub periodic_columns: BTreeMap<QualifiedIdentifier, PeriodicColumn>,
     /// The set of public inputs defined in the root module
     ///
     /// NOTE: Public inputs are only visible in the root module, so we do
     /// not use [QualifiedIdentifier] as a key into this collection.
-    pub public_inputs: HashMap<Identifier, PublicInput>,
+    pub public_inputs: BTreeMap<Identifier, PublicInput>,
     /// The set of random values defined in the root module, if present
     pub random_values: Option<RandomValues>,
     /// The set of trace columns defined in the root module

--- a/parser/src/ast/module.rs
+++ b/parser/src/ast/module.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 
 use miden_diagnostics::{DiagnosticsHandler, Severity, SourceSpan, Span, Spanned};
 
@@ -51,11 +51,11 @@ pub struct Module {
     pub span: SourceSpan,
     pub name: ModuleId,
     pub ty: ModuleType,
-    pub imports: HashMap<ModuleId, Import>,
-    pub constants: HashMap<Identifier, Constant>,
+    pub imports: BTreeMap<ModuleId, Import>,
+    pub constants: BTreeMap<Identifier, Constant>,
     pub evaluators: BTreeMap<Identifier, EvaluatorFunction>,
-    pub periodic_columns: HashMap<Identifier, PeriodicColumn>,
-    pub public_inputs: HashMap<Identifier, PublicInput>,
+    pub periodic_columns: BTreeMap<Identifier, PeriodicColumn>,
+    pub public_inputs: BTreeMap<Identifier, PublicInput>,
     pub random_values: Option<RandomValues>,
     pub trace_columns: Vec<TraceSegment>,
     pub boundary_constraints: Option<Span<Vec<Statement>>>,
@@ -76,11 +76,11 @@ impl Module {
             span,
             name,
             ty,
-            imports: HashMap::default(),
-            constants: HashMap::default(),
-            evaluators: BTreeMap::default(),
-            periodic_columns: HashMap::default(),
-            public_inputs: HashMap::default(),
+            imports: Default::default(),
+            constants: Default::default(),
+            evaluators: Default::default(),
+            periodic_columns: Default::default(),
+            public_inputs: Default::default(),
             random_values: None,
             trace_columns: vec![],
             boundary_constraints: None,

--- a/parser/src/symbols.rs
+++ b/parser/src/symbols.rs
@@ -49,7 +49,7 @@ impl SymbolTable {
 unsafe impl Sync for SymbolTable {}
 
 /// A symbol is an interned string.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Symbol(SymbolIndex);
 
 impl Symbol {
@@ -90,6 +90,16 @@ impl fmt::Debug for Symbol {
 impl fmt::Display for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.as_str(), f)
+    }
+}
+impl PartialOrd for Symbol {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for Symbol {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.as_str().cmp(other.as_str())
     }
 }
 impl<T: Deref<Target = str>> PartialEq<T> for Symbol {


### PR DESCRIPTION
As mentioned in the title, this PR swaps out the use of `HashMap` in the AST for `BTreeMap`, so that diffs in test assertions do not contain spurious differences related to iteration order. In general it should make compilation more deterministic, which is of particular value in generated test artifacts which must match previous outputs.

NOTE: This is based on the branch from #297 and is part of a chain of PRs that implement modules