### PR TITLE
chore: clean up semantic analysis/constant propagation

### DIFF
--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.65"
 lalrpop = { version = "0.20.0", default-features = false }
 
 [dependencies]
+air-pass = { path = "../pass", version = "0.1.0" }
 miden-diagnostics = { git = "https://github.com/0xPolygonMiden/miden-diagnostics" }
 miden-parsing = { git = "https://github.com/0xPolygonMiden/miden-parsing" }
 lalrpop-util = { version = "0.20.0" }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -9,6 +9,7 @@ pub mod symbols;
 pub mod transforms;
 
 pub use self::parser::{ParseError, Parser};
+pub use self::sema::{LexicalScope, SemanticAnalysisError};
 pub use self::symbols::Symbol;
 
 use std::path::Path;

--- a/parser/src/parser/tests/constant_propagation.rs
+++ b/parser/src/parser/tests/constant_propagation.rs
@@ -1,8 +1,9 @@
+use air_pass::Pass;
 use miden_diagnostics::SourceSpan;
 
 use pretty_assertions::assert_eq;
 
-use crate::{ast::*, transforms::ConstantPropagator};
+use crate::{ast::*, transforms::ConstantPropagation};
 
 use super::ParseTest;
 
@@ -48,7 +49,7 @@ fn test_constant_propagation() {
     let path = std::env::current_dir().unwrap().join("lib.air");
     test.add_virtual_file(path, lib.to_string());
 
-    let mut program = match test.parse_program(root) {
+    let program = match test.parse_program(root) {
         Err(err) => {
             test.diagnostics.emit(err);
             panic!("expected parsing to succeed, see diagnostics for details");
@@ -56,8 +57,8 @@ fn test_constant_propagation() {
         Ok(ast) => ast,
     };
 
-    let pass = ConstantPropagator::new();
-    pass.run(&mut program).unwrap();
+    let mut pass = ConstantPropagation::new(&test.diagnostics);
+    let program = pass.run(program).unwrap();
 
     let mut expected = Program::new(ident!(root));
     expected.trace_columns.push(trace_segment!(

--- a/parser/src/sema/binding_type.rs
+++ b/parser/src/sema/binding_type.rs
@@ -1,0 +1,236 @@
+use crate::ast::{AccessType, FunctionType, InvalidAccessError, RandBinding, TraceBinding, Type};
+use std::fmt;
+
+/// This type provides type and contextual information about a binding,
+/// i.e. not only does it tell us the type of a binding, but what type
+/// of value was bound. This is used during analysis to check whether a
+/// particular access is valid for the context it is in, as well as to
+/// propagate type information while retaining information about where
+/// the type was derived from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BindingType {
+    /// A local variable whose value is not an alias of a global/module declaration
+    Local(Type),
+    /// A local variable that aliases a global/module declaration
+    Alias(Box<BindingType>),
+    /// A direct reference to a constant declaration
+    Constant(Type),
+    /// A type associated with a function signature
+    ///
+    /// The result type is None if the function is an evaluator
+    Function(FunctionType),
+    /// A function parameter corresponding to trace columns
+    TraceParam(TraceBinding),
+    /// A direct reference to one or more contiguous trace columns
+    TraceColumn(TraceBinding),
+    /// A potentially non-contiguous set of trace columns
+    Vector(Vec<BindingType>),
+    /// A direct reference to a random value binding
+    RandomValue(RandBinding),
+    /// A direct reference to a public input
+    PublicInput(Type),
+    /// A direct reference to a periodic column
+    PeriodicColumn(usize),
+}
+impl BindingType {
+    /// Get the value type of this binding, if applicable
+    pub fn ty(&self) -> Option<Type> {
+        match self {
+            Self::TraceColumn(tb) | Self::TraceParam(tb) => Some(tb.ty()),
+            Self::Vector(elems) => Some(Type::Vector(elems.len())),
+            Self::RandomValue(rb) => Some(rb.ty()),
+            Self::Alias(aliased) => aliased.ty(),
+            Self::Local(ty) | Self::Constant(ty) | Self::PublicInput(ty) => Some(*ty),
+            Self::PeriodicColumn(_) => Some(Type::Felt),
+            Self::Function(ty) => ty.result(),
+        }
+    }
+
+    /// Returns true if this binding type is a trace binding
+    pub fn is_trace_binding(&self) -> bool {
+        match self {
+            Self::TraceColumn(_) | Self::TraceParam(_) => true,
+            Self::Vector(ref elems) => elems.iter().all(|e| e.is_trace_binding()),
+            _ => false,
+        }
+    }
+
+    /// This function is used to split the current binding into two parts, the
+    /// first of which contains `n` trace columns, the second of which contains
+    /// what remains of the original binding. This function returns `Ok` when
+    /// there were `n` columns in the input binding type, otherwise `Err` with
+    /// a binding that contains as many columns as possible.
+    ///
+    /// If the input binding type is a single logical binding, then the resulting
+    /// binding types will be of the same type. If however, the input binding type
+    /// is a vector of bindings, then the first part of the split will be a vector
+    /// containing `n` elements, where each element is a single logical binding of
+    /// size 1. This corresponds to the way trace column bindings are packed/unpacked
+    /// using vectors/lists in AirScript
+    pub fn split_columns(&self, n: usize) -> Result<(Self, Option<Self>), Self> {
+        use core::cmp::Ordering;
+
+        if n == 1 {
+            return Ok(self.pop_column());
+        }
+
+        match self {
+            Self::TraceColumn(ref tb) => match n.cmp(&tb.size) {
+                Ordering::Equal => Ok((self.clone(), None)),
+                Ordering::Less => {
+                    let remaining = tb.size - n;
+                    let first = Self::TraceColumn(TraceBinding { size: n, ..*tb });
+                    let rest = Self::TraceColumn(TraceBinding {
+                        size: remaining,
+                        offset: tb.offset + n,
+                        ..*tb
+                    });
+                    Ok((first, Some(rest)))
+                }
+                Ordering::Greater => Err(self.clone()),
+            },
+            Self::Vector(ref elems) if elems.len() == 1 => elems[0].split_columns(n),
+            Self::Vector(ref elems) => {
+                let mut index = 0;
+                let mut remaining = n;
+                let mut set = Vec::with_capacity(elems.len());
+                let mut next = elems.get(index).cloned();
+                while remaining > 0 {
+                    match next.take() {
+                        None => return Err(Self::Vector(set)),
+                        Some(binding_ty) => {
+                            let (col, rest) = binding_ty.pop_column();
+                            set.push(col);
+                            remaining -= 1;
+                            next = rest.or_else(|| {
+                                index += 1;
+                                elems.get(index).cloned()
+                            });
+                        }
+                    }
+                }
+                let leftover = elems.len() - (index + 1);
+                match next {
+                    None => Ok((Self::Vector(set), None)),
+                    Some(mid) => {
+                        index += 1;
+                        let mut rest = Vec::with_capacity(leftover + 1);
+                        rest.push(mid);
+                        rest.extend_from_slice(&elems[index..]);
+                        Ok((Self::Vector(set), Some(Self::Vector(rest))))
+                    }
+                }
+            }
+            invalid => panic!("invalid trace column(s) binding type: {:#?}", invalid),
+        }
+    }
+
+    /// This function is like `split`, for the use case in which only a single
+    /// column is desired. This is used internally by `split` to handle those
+    /// cases, but may be used directly as well.
+    pub fn pop_column(&self) -> (Self, Option<Self>) {
+        match self {
+            // If we have a single logical binding, return the first half as
+            // a binding containing the first column of that binding, and the
+            // second half as a binding representing whatever was left, or `None`
+            // if it is empty.
+            Self::TraceColumn(ref tb) if tb.is_scalar() => (Self::TraceColumn(*tb), None),
+            Self::TraceColumn(ref tb) => {
+                let first = Self::TraceColumn(TraceBinding {
+                    size: 1,
+                    ty: Type::Felt,
+                    ..*tb
+                });
+                let remaining = tb.size - 1;
+                if remaining == 0 {
+                    (first, None)
+                } else {
+                    let rest = Self::TraceColumn(TraceBinding {
+                        size: remaining,
+                        ty: Type::Vector(remaining),
+                        offset: tb.offset + 1,
+                        ..*tb
+                    });
+                    (first, Some(rest))
+                }
+            }
+            // If the vector has only one element, remove the vector and
+            // return the result of popping a column on the first element.
+            Self::Vector(ref elems) if elems.len() == 1 => elems[0].pop_column(),
+            // If the vector has multiple elements, then we're going to return
+            // a vector for the remainder of the split.
+            Self::Vector(ref elems) => {
+                // Take the first element out of the vector
+                let (popped, rest) = elems.split_first().unwrap();
+                // Pop a single trace column from that element
+                let (first, mid) = popped.pop_column();
+                // The `popped` binding must have been a TraceColumn type, as
+                // as nested binding vectors are not permitted in calls to evaluators
+                match mid {
+                    None => (first, Some(Self::Vector(rest.to_vec()))),
+                    Some(mid) => {
+                        let mut mid_and_rest = Vec::with_capacity(rest.len() + 1);
+                        mid_and_rest.push(mid);
+                        mid_and_rest.extend_from_slice(rest);
+                        (first, Some(Self::Vector(mid_and_rest)))
+                    }
+                }
+            }
+            invalid => panic!("invalid trace column(s) binding type: {:#?}", invalid),
+        }
+    }
+
+    /// Produce a new [BindingType] which represents accessing the current binding via `access_type`
+    pub fn access(&self, access_type: AccessType) -> Result<Self, InvalidAccessError> {
+        match self {
+            Self::Alias(aliased) => aliased.access(access_type),
+            Self::Local(ty) => ty.access(access_type).map(Self::Local),
+            Self::Constant(ty) => ty
+                .access(access_type)
+                .map(|t| Self::Alias(Box::new(Self::Constant(t)))),
+            Self::TraceColumn(tb) => tb.access(access_type).map(Self::TraceColumn),
+            Self::TraceParam(tb) => tb.access(access_type).map(Self::TraceParam),
+            Self::Vector(elems) => match access_type {
+                AccessType::Default => Ok(Self::Vector(elems.clone())),
+                AccessType::Index(idx) if idx >= elems.len() => {
+                    Err(InvalidAccessError::IndexOutOfBounds)
+                }
+                AccessType::Index(idx) => Ok(elems[idx].clone()),
+                AccessType::Slice(range) if range.end > elems.len() => {
+                    Err(InvalidAccessError::IndexOutOfBounds)
+                }
+                AccessType::Slice(range) => {
+                    Ok(Self::Vector(elems[range.start..range.end].to_vec()))
+                }
+                AccessType::Matrix(row, _) if row >= elems.len() => {
+                    Err(InvalidAccessError::IndexOutOfBounds)
+                }
+                AccessType::Matrix(row, col) => elems[row].access(AccessType::Index(col)),
+            },
+            Self::RandomValue(tb) => tb
+                .access(access_type)
+                .map(|tb| Self::Alias(Box::new(Self::RandomValue(tb)))),
+            Self::PublicInput(ty) => ty.access(access_type).map(Self::PublicInput),
+            Self::PeriodicColumn(period) => match access_type {
+                AccessType::Default => Ok(Self::PeriodicColumn(*period)),
+                _ => Err(InvalidAccessError::IndexIntoScalar),
+            },
+            Self::Function(_) => Err(InvalidAccessError::InvalidBinding),
+        }
+    }
+}
+impl fmt::Display for BindingType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Alias(aliased) => write!(f, "{}", aliased),
+            Self::Local(_) => f.write_str("local"),
+            Self::Constant(_) => f.write_str("constant"),
+            Self::Vector(_) => f.write_str("vector"),
+            Self::Function(_) => f.write_str("function"),
+            Self::TraceColumn(_) | Self::TraceParam(_) => f.write_str("trace column(s)"),
+            Self::RandomValue(_) => f.write_str("random value(s)"),
+            Self::PublicInput(_) => f.write_str("public input(s)"),
+            Self::PeriodicColumn(_) => f.write_str("periodic column(s)"),
+        }
+    }
+}

--- a/parser/src/sema/dependencies.rs
+++ b/parser/src/sema/dependencies.rs
@@ -1,0 +1,27 @@
+use crate::ast::{ModuleId, QualifiedIdentifier};
+
+/// Represents the graph of dependencies between module items and items they
+/// reference, either in the same module, or via imports.
+///
+/// The dependency graph is used to construct the final [Program] representation,
+/// containing only those parts of the program which are referenced from the root
+/// module.
+pub type DependencyGraph = petgraph::graphmap::DiGraphMap<QualifiedIdentifier, DependencyType>;
+
+/// Represents the graph of dependencies between modules, with no regard to what
+/// items in those modules are actually used. In other words, this graph tells us
+/// what modules depend on what other modules in the program.
+pub type ModuleGraph = petgraph::graphmap::DiGraphMap<ModuleId, ()>;
+
+/// Represents the type of edges in the dependency graph
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum DependencyType {
+    /// Depends on an imported constant
+    Constant,
+    /// Depends on an imported evaluator function
+    Evaluator,
+    /// Depends on an imported function
+    Function,
+    /// Depends on a periodic_columns declaration (not visible as an export)
+    PeriodicColumn,
+}

--- a/parser/src/sema/mod.rs
+++ b/parser/src/sema/mod.rs
@@ -1,7 +1,9 @@
 mod errors;
 mod import_resolver;
+mod scope;
 mod semantic_analysis;
 
 pub use self::errors::SemanticAnalysisError;
 pub use self::import_resolver::{ImportResolver, Imported};
 pub use self::semantic_analysis::{DependencyGraph, DependencyType, ModuleGraph, SemanticAnalysis};
+pub use self::scope::LexicalScope;

--- a/parser/src/sema/mod.rs
+++ b/parser/src/sema/mod.rs
@@ -1,9 +1,13 @@
+mod binding_type;
+mod dependencies;
 mod errors;
 mod import_resolver;
 mod scope;
 mod semantic_analysis;
 
+pub(crate) use self::binding_type::BindingType;
+pub use self::dependencies::*;
 pub use self::errors::SemanticAnalysisError;
 pub use self::import_resolver::{ImportResolver, Imported};
-pub use self::semantic_analysis::{DependencyGraph, DependencyType, ModuleGraph, SemanticAnalysis};
 pub use self::scope::LexicalScope;
+pub use self::semantic_analysis::SemanticAnalysis;

--- a/parser/src/sema/scope.rs
+++ b/parser/src/sema/scope.rs
@@ -1,0 +1,165 @@
+use std::{
+    borrow::Borrow,
+    collections::HashMap,
+    hash::Hash,
+    ops::{Index, IndexMut},
+};
+
+/// A simple type alias for a boxed `HashMap` to aid in readability of the code below
+pub type Env<K, V> = Box<HashMap<K, V>>;
+
+/// A lexically scoped environment is essentially a hierarchical mapping of keys to values,
+/// where keys may be defined at multiple levels, but only a single definition at any point
+/// in the program is active - the definition closest to that point.
+///
+/// A [LexicalScope] starts out at the root, empty. Any number of keys may be inserted at
+/// the current scope, or a new nested scope may be entered. When entering a new nested scope,
+/// keys inserted there take precedence over the same keys in previous (higher) scopes, but
+/// do not overwrite those definitions. When exiting a scope, all definitions in that scope
+/// are discarded, and definitions from the parent scope take effect again.
+///
+/// When searching for keys, the search begins in the current scope, and searches upwards
+/// in the scope tree until either the root is reached and the search terminates, or the
+/// key is found in some intervening scope.
+#[derive(Clone)]
+pub enum LexicalScope<K, V> {
+    /// An empty scope, this is the default state in which all [LexicalScope] start
+    Empty,
+    /// Represents a non-empty, top-level (root) scope
+    Root(Env<K, V>),
+    /// Represents a (possibly empty) nested scope, as a tuple of the parent scope and
+    /// the environment of the current scope.
+    Nested(Box<LexicalScope<K, V>>, Env<K, V>),
+}
+impl<K, V> Default for LexicalScope<K, V> {
+    fn default() -> Self {
+        Self::Empty
+    }
+}
+impl<K, V> LexicalScope<K, V> {
+    /// Returns true if this scope is empty
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Empty => true,
+            Self::Root(_) => false,
+            Self::Nested(parent, env) => env.is_empty() && parent.is_empty(),
+        }
+    }
+
+    /// Enters a new, nested lexical scope
+    pub fn enter(&mut self) {
+        let moved = Box::new(core::mem::take(self));
+        *self = Self::Nested(moved, Env::default());
+    }
+
+    /// Exits the current lexical scope
+    pub fn exit(&mut self) {
+        match self {
+            Self::Empty => (),
+            Self::Root(_env) => {
+                *self = Self::Empty;
+            }
+            Self::Nested(ref mut parent, _) => {
+                let moved = core::mem::take(parent.as_mut());
+                *self = moved;
+            }
+        }
+    }
+}
+impl<K, V> LexicalScope<K, V>
+where
+    K: Eq + Hash,
+{
+    /// Inserts a new binding in the current scope, returning a conflicting definition
+    /// if one is present (i.e. the same name was already declared in the same (current) scope).
+    ///
+    /// NOTE: This does not return `Some` if a previous definition exists in an outer scope,
+    /// the new definition will shadow that one, but is not considered in conflict with it.
+    pub fn insert(&mut self, k: K, v: V) -> Option<V> {
+        match self {
+            Self::Empty => {
+                let mut env = Env::default();
+                env.insert(k, v);
+                *self = Self::Root(env);
+                None
+            }
+            Self::Root(ref mut env) => env.insert(k, v),
+            Self::Nested(_, ref mut env) => env.insert(k, v),
+        }
+    }
+
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+    {
+        match self {
+            Self::Empty => None,
+            Self::Root(ref env) => env.get(key),
+            Self::Nested(ref parent, ref env) => env.get(key).or_else(|| parent.get(key)),
+        }
+    }
+
+    pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+    {
+        match self {
+            Self::Empty => None,
+            Self::Root(ref mut env) => env.get_mut(key),
+            Self::Nested(ref mut parent, ref mut env) => {
+                env.get_mut(key).or_else(|| parent.get_mut(key))
+            }
+        }
+    }
+
+    pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&K, &V)>
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+    {
+        match self {
+            Self::Empty => None,
+            Self::Root(ref env) => env.get_key_value(key),
+            Self::Nested(ref parent, ref env) => {
+                env.get_key_value(key).or_else(|| parent.get_key_value(key))
+            }
+        }
+    }
+
+    /// Gets the value of the key stored in this structure by `key`
+    ///
+    /// This is used in some cases where a field of the key contains useful metadata
+    /// (such as source spans), but is not part of the eq/hash impl. This function
+    /// allows you to obtain the actual key stored in the map.
+    pub fn get_key<Q>(&self, key: &Q) -> Option<&K>
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+    {
+        self.get_key_value(key).map(|(k, _)| k)
+    }
+}
+impl<K, V, Q> Index<&Q> for LexicalScope<K, V>
+where
+    K: Eq + Hash + Borrow<Q>,
+    Q: Eq + Hash + ?Sized,
+{
+    type Output = V;
+
+    #[inline]
+    fn index(&self, key: &Q) -> &Self::Output {
+        self.get(key).unwrap()
+    }
+}
+impl<K, V, Q> IndexMut<&Q> for LexicalScope<K, V>
+where
+    K: Eq + Hash + Borrow<Q>,
+    Q: Eq + Hash + ?Sized,
+{
+    #[inline]
+    fn index_mut(&mut self, key: &Q) -> &mut Self::Output {
+        self.get_mut(key).unwrap()
+    }
+}

--- a/parser/src/transforms/mod.rs
+++ b/parser/src/transforms/mod.rs
@@ -1,3 +1,3 @@
 mod constant_propagation;
 
-pub use self::constant_propagation::{ConstantPropagator, InvalidConstantError};
+pub use self::constant_propagation::ConstantPropagation;


### PR DESCRIPTION
This PR refactors the semantic analysis and constant propagation passes to factor out some unnecessarily large functions, split up the `sema` module better, and provide a better data structure for handling various types of bindings based on lexical scope.

NOTE: This is based on the branch from #297 and is part of a chain of PRs that implement modules, as well as a number of refactorings/improvements to the AirScript compiler toolchain. This is the 7th PR in that chain. It should be merged into #308 or merged into #297 after #308.