### PR TITLE
Move chiplet bus constraints to the separate file. 

### DIFF
--- a/constraints/miden-vm/bitwise.air
+++ b/constraints/miden-vm/bitwise.air
@@ -95,32 +95,14 @@ ev output_aggregation([s, a, b, a_limb[4], b_limb[4], zp, z]):
         z = zp * 16 + a_and_b when !s
 
 
-# Enforces the constraint for the bitwise chiplet bus.
-#
-# Constraint degree: 4
-ev bitwise_chiplet_bus([a, b, z], [b_chip]):
-    # u_i represents reduction of a, b abd z into a single value for row i.
-    let u_i = $alpha[1] * a + $alpha[2] * b + $alpha[3] * z
-
-    # m represents inversion of k1 periodic column.
-    let m = !k1
-
-    # v_i represents value that includes u_i into the product when k1 = 0.
-    let v_i = m * u_i
-
-    # Enforce the constraints for the two sides of the bus communication.
-    # Constraint degree: 4
-    enf b_chip' * ($alpha[0] + u_i) = b_chip * (($alpha[0] + v_i) * m + 1 - m)
-
-
 ### Bitwise Chiplet Air Constraints ###############################################################
 
 # Enforces the constraints on the bitwise chiplet, given the columns of the bitwise execution 
 # trace.
 #
 # Max constraint degree: 4
-ev bitwise_chiplet(main: [s, a, b, a_limb[4], b_limb[4], zp, z], [b_chip]):
+ev bitwise_chiplet([s, a, b, a_limb[4], b_limb[4], zp, z]):
     enf bitwise_selector([s])
     enf input_decomposition([a, b, a_limb, b_limb])
     enf output_aggregation([s, a, b, a_limb, b_limb, zp, z])
-    enf bitwise_chiplet_bus([a, b, z], [b_chip])
+    # Bus constraint is implemented in a separate file

--- a/constraints/miden-vm/memory.air
+++ b/constraints/miden-vm/memory.air
@@ -104,31 +104,13 @@ ev enforce_values([s[2], v[4]]):
     enf is_unchanged([v_i]) for v_i in v when s[1]
 
 
-# Enforces that values of memory table rows are included into the chiplet bus.
-ev chiplet_bus([s[2], ctx, addr, clk, v[4]], [b_chip]): 
-    # Calculate the operation label for the memory access operation.
-    let op_mem = s[0] * 2^3 + 4
-
-    # v_mem represents a row in the memory table.
-    let v_mem = $alpha[0] + $alpha[1] * op_mem + $alpha[2] * ctx + $alpha[3] * addr +
-        $alpha[4] * clk + sum([$alpha[j + 5] * v[j] for j in 0..4])
-
-    # Enforce that values of memory table rows are included into the chiplet bus.
-    enf b_chip' = b_chip * v_mem
-
-
 ### Memory Chiplet Air Constraints ################################################################
 
 # Enforces the constraints on the memory chiplet, given the columns of the memory execution trace.
-ev memory_chiplet([s[2], ctx, addr, clk, v[4], d[2], t], [b_chip]):
+ev memory_chiplet([s[2], ctx, addr, clk, v[4], d[2], t]):
     enf flags_validity([ctx, addr, t])
-
     enf enforce_selectors([s, ctx, addr, t])
-
     enf enforce_delta([ctx, addr, clk, d, t])
-
     # TODO: perform range checks for values in columns d[0] and d[1]
-
     enf enforce_values([s, v])
-
-    enf chiplet_bus([s[2], ctx, addr, clk, v[4]], [b_chip])
+    # Bus constraint is implemented in a separate file


### PR DESCRIPTION
This small PR removes chiplet bus constraints from the `memory.air` and `bitwise.air` files. In the next PR these constraints will be implemented in a separate file along with the rest of chiplet bus constraints. 