### PR TITLE
Update z^exp caching

### DIFF
--- a/air-script/tests/aux_trace/aux_trace.masm
+++ b/air-script/tests/aux_trace/aux_trace.masm
@@ -1,3 +1,21 @@
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub

--- a/air-script/tests/binary/binary.masm
+++ b/air-script/tests/binary/binary.masm
@@ -1,3 +1,21 @@
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop

--- a/air-script/tests/bitwise/bitwise.masm
+++ b/air-script/tests/bitwise/bitwise.masm
@@ -1,38 +1,36 @@
 proc.cache_z_exp
-    # Load trace length
-    mem_load.4294903306
-    # => [trace_len, ...]
-    # Push initial num_of_cycles
-    push.1
-    # => [num_of_cycles, trace_len, ...]
-    # Load Z
     padw mem_loadw.4294903304 drop drop
-    # => [z_1, z_0, num_of_cycles, trace_len, ...]
-    # Compute exponentiations based on the number of cycles for a period of 8
-    dup.3 div.8
-    # => [num_of_cycles', z_1, z_0, num_of_cycles, trace_len, ...]
-    # Update next num_of_cycles and compute number of iterations
-    movup.3 dup.1 movdn.4 div
-    # => [i, z_1, z_0, num_of_cycles', trace_len, ...]
-    # Exponentiate the existing `z**num_of_cycles` an additional `i` times
-    dup.0 neq.1
+    # => [z_1, z_0, ...]
+    # Find number exponentiations required to get for a period of length 8
+    mem_load.4294903307 neg add.3
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len) + 3
+    # Exponentiate z
+    dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [z_1^2, z_0^2, i, num_of_cycles', trace_len, ...]
-        movup.2 div.2 dup.0 neq.1
-        # => [b, i+1, z_1^2, z_0^2, num_of_cycles', trace_len, ...]
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
     end # END while
-    drop push.0 push.0 mem_storew.500000100 # Save the exponentiation of z for column 0
-    mem_storew.500000101 # Save the exponentiation of z for column 1
-    # => [0, 0, z_1^2, z_0^2, num_of_cycles', trace_len, ...]
+    push.0 mem_storew.500000100 # z^8
+    # => [0, 0, (z_1, z_0)^n, ...] where n = trace_len-8
     drop drop
-    # => [z_1^2, z_0^2, num_of_cycles', trace_len, ...]
-    # Clean stack
-    dropw
+    # Exponentiate z 8 times, until trace_len
+    push.18446744069414584318
+    # => [count, (z_1, z_0)^n, ...] where count=-3 , n=trace_len-3
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000101 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
 end # END PROC cache_z_exp
 
 proc.cache_periodic_polys
-    exec.cache_z_exp
     # periodic column 0
     padw mem_loadw.500000100 drop drop
     # => [z_exp_1, z_exp_0, ...]
@@ -78,7 +76,7 @@ proc.cache_periodic_polys
     # => [a_1, a_0, ...]
     # Save the evaluation of the periodic polynomial at point z**exp, and clean stack
     push.0 push.0 mem_storew.500000000 dropw # periodic column 1
-    padw mem_loadw.500000101 drop drop
+    padw mem_loadw.500000100 drop drop
     # => [z_exp_1, z_exp_0, ...]
     push.2305843008676823041 push.0
     # => [a_1, a_0, z_exp_1, z_exp_0, ...]
@@ -144,7 +142,7 @@ proc.compute_evaluate_integrity_constraints
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 movdn.3 movdn.3 drop drop ext2mul
     # integrity constraint 1 for main
-    padw mem_loadw.500000001 drop drop padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2sub ext2mul push.0 push.0 ext2sub
+    padw mem_loadw.500000000 drop drop padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2sub ext2mul push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 drop drop ext2mul
     # integrity constraint 2 for main
@@ -408,7 +406,7 @@ proc.compute_evaluate_integrity_constraints
     # Multiply by the composition coefficient
     padw mem_loadw.4294900205 drop drop ext2mul
     # integrity constraint 12 for main
-    padw mem_loadw.500000001 drop drop padw mem_loadw.4294900001 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop push.16 push.0 ext2mul push.2 push.0
+    padw mem_loadw.500000000 drop drop padw mem_loadw.4294900001 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop push.16 push.0 ext2mul push.2 push.0
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
     # => [b1, b0, r1, r0, ...]
@@ -466,7 +464,7 @@ proc.compute_evaluate_integrity_constraints
     # Multiply by the composition coefficient
     padw mem_loadw.4294900206 movdn.3 movdn.3 drop drop ext2mul
     # integrity constraint 13 for main
-    padw mem_loadw.500000001 drop drop padw mem_loadw.4294900002 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop push.16 push.0 ext2mul push.2 push.0
+    padw mem_loadw.500000000 drop drop padw mem_loadw.4294900002 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop push.16 push.0 ext2mul push.2 push.0
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
     # => [b1, b0, r1, r0, ...]
@@ -528,7 +526,7 @@ proc.compute_evaluate_integrity_constraints
     # Multiply by the composition coefficient
     padw mem_loadw.4294900207 movdn.3 movdn.3 drop drop ext2mul
     # integrity constraint 15 for main
-    padw mem_loadw.500000001 drop drop padw mem_loadw.4294900012 movdn.3 movdn.3 drop drop padw mem_loadw.4294900011 drop drop ext2sub ext2mul push.0 push.0 ext2sub
+    padw mem_loadw.500000000 drop drop padw mem_loadw.4294900012 movdn.3 movdn.3 drop drop padw mem_loadw.4294900011 drop drop ext2sub ext2mul push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900207 drop drop ext2mul
     # integrity constraint 16 for main

--- a/air-script/tests/constants/constants.masm
+++ b/air-script/tests/constants/constants.masm
@@ -1,3 +1,21 @@
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub

--- a/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
+++ b/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
@@ -1,3 +1,21 @@
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900075 movdn.3 movdn.3 drop drop padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop ext2sub

--- a/air-script/tests/constraint_comprehension/constraint_comprehension.masm
+++ b/air-script/tests/constraint_comprehension/constraint_comprehension.masm
@@ -1,3 +1,21 @@
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900075 movdn.3 movdn.3 drop drop padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop ext2sub

--- a/air-script/tests/evaluators/evaluators.masm
+++ b/air-script/tests/evaluators/evaluators.masm
@@ -1,3 +1,21 @@
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2sub

--- a/air-script/tests/indexed_trace_access/indexed_trace_access.masm
+++ b/air-script/tests/indexed_trace_access/indexed_trace_access.masm
@@ -1,3 +1,21 @@
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub

--- a/air-script/tests/list_comprehension/list_comprehension.masm
+++ b/air-script/tests/list_comprehension/list_comprehension.masm
@@ -1,3 +1,21 @@
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2sub

--- a/air-script/tests/list_folding/list_folding.masm
+++ b/air-script/tests/list_folding/list_folding.masm
@@ -1,3 +1,21 @@
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900074 drop drop padw mem_loadw.4294900078 movdn.3 movdn.3 drop drop padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900080 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900081 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900082 movdn.3 movdn.3 drop drop padw mem_loadw.4294900083 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900084 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900085 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub

--- a/air-script/tests/periodic_columns/periodic_columns.masm
+++ b/air-script/tests/periodic_columns/periodic_columns.masm
@@ -1,56 +1,52 @@
 proc.cache_z_exp
-    # Load trace length
-    mem_load.4294903306
-    # => [trace_len, ...]
-    # Push initial num_of_cycles
-    push.1
-    # => [num_of_cycles, trace_len, ...]
-    # Load Z
     padw mem_loadw.4294903304 drop drop
-    # => [z_1, z_0, num_of_cycles, trace_len, ...]
-    # Compute exponentiations based on the number of cycles for a period of 8
-    dup.3 div.8
-    # => [num_of_cycles', z_1, z_0, num_of_cycles, trace_len, ...]
-    # Update next num_of_cycles and compute number of iterations
-    movup.3 dup.1 movdn.4 div
-    # => [i, z_1, z_0, num_of_cycles', trace_len, ...]
-    # Exponentiate the existing `z**num_of_cycles` an additional `i` times
-    dup.0 neq.1
+    # => [z_1, z_0, ...]
+    # Find number exponentiations required to get for a period of length 8
+    mem_load.4294903307 neg add.3
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len) + 3
+    # Exponentiate z
+    dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [z_1^2, z_0^2, i, num_of_cycles', trace_len, ...]
-        movup.2 div.2 dup.0 neq.1
-        # => [b, i+1, z_1^2, z_0^2, num_of_cycles', trace_len, ...]
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
     end # END while
-    drop push.0 push.0 mem_storew.500000101 # Save the exponentiation of z for column 1
-    # => [0, 0, z_1^2, z_0^2, num_of_cycles', trace_len, ...]
+    push.0 mem_storew.500000100 # z^8
+    # => [0, 0, (z_1, z_0)^n, ...] where n = trace_len-8
     drop drop
-    # Compute exponentiations based on the number of cycles for a period of 4
-    dup.3 div.4
-    # => [num_of_cycles', z_1, z_0, num_of_cycles, trace_len, ...]
-    # Update next num_of_cycles and compute number of iterations
-    movup.3 dup.1 movdn.4 div
-    # => [i, z_1, z_0, num_of_cycles', trace_len, ...]
-    # Exponentiate the existing `z**num_of_cycles` an additional `i` times
-    dup.0 neq.1
+    # Find number of exponentiations to bring from length 8 to 4
+    push.18446744069414584320
+    # => [count, (z_1, z_0)^3, ...] where count = 2 - 3
+    # Exponentiate z
+    dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [z_1^2, z_0^2, i, num_of_cycles', trace_len, ...]
-        movup.2 div.2 dup.0 neq.1
-        # => [b, i+1, z_1^2, z_0^2, num_of_cycles', trace_len, ...]
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
     end # END while
-    drop push.0 push.0 mem_storew.500000100 # Save the exponentiation of z for column 0
-    # => [0, 0, z_1^2, z_0^2, num_of_cycles', trace_len, ...]
+    push.0 mem_storew.500000101 # z^4
+    # => [0, 0, (z_1, z_0)^n, ...] where n = trace_len-4
     drop drop
-    # => [z_1^2, z_0^2, num_of_cycles', trace_len, ...]
-    # Clean stack
-    dropw
+    # Exponentiate z 4 times, until trace_len
+    push.18446744069414584319
+    # => [count, (z_1, z_0)^n, ...] where count=-2 , n=trace_len-2
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000102 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
 end # END PROC cache_z_exp
 
 proc.cache_periodic_polys
-    exec.cache_z_exp
     # periodic column 0
-    padw mem_loadw.500000100 drop drop
+    padw mem_loadw.500000101 drop drop
     # => [z_exp_1, z_exp_0, ...]
     push.13835058052060938241 push.0
     # => [a_1, a_0, z_exp_1, z_exp_0, ...]
@@ -74,7 +70,7 @@ proc.cache_periodic_polys
     # => [a_1, a_0, ...]
     # Save the evaluation of the periodic polynomial at point z**exp, and clean stack
     push.0 push.0 mem_storew.500000000 dropw # periodic column 1
-    padw mem_loadw.500000101 drop drop
+    padw mem_loadw.500000100 drop drop
     # => [z_exp_1, z_exp_0, ...]
     push.2305843008676823041 push.0
     # => [a_1, a_0, z_exp_1, z_exp_0, ...]
@@ -122,11 +118,11 @@ end # END PROC cache_periodic_polys
 
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
-    padw mem_loadw.500000000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2add ext2mul push.0 push.0 ext2sub
+    padw mem_loadw.500000001 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2add ext2mul push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 movdn.3 movdn.3 drop drop ext2mul
     # integrity constraint 1 for main
-    padw mem_loadw.500000001 drop drop padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2sub ext2mul push.0 push.0 ext2sub
+    padw mem_loadw.500000000 drop drop padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2sub ext2mul push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints

--- a/air-script/tests/pub_inputs/pub_inputs.masm
+++ b/air-script/tests/pub_inputs/pub_inputs.masm
@@ -1,3 +1,21 @@
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2add ext2sub

--- a/air-script/tests/random_values/random_values_bindings.masm
+++ b/air-script/tests/random_values/random_values_bindings.masm
@@ -1,3 +1,21 @@
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900073 drop drop padw mem_loadw.4294900157 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900151 drop drop ext2add ext2sub

--- a/air-script/tests/random_values/random_values_simple.masm
+++ b/air-script/tests/random_values/random_values_simple.masm
@@ -1,3 +1,21 @@
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900073 drop drop padw mem_loadw.4294900157 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900151 drop drop ext2add ext2sub

--- a/air-script/tests/selectors/selectors.masm
+++ b/air-script/tests/selectors/selectors.masm
@@ -1,3 +1,21 @@
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900003 drop drop push.0 push.0 ext2sub padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul

--- a/air-script/tests/selectors/selectors_with_evaluators.masm
+++ b/air-script/tests/selectors/selectors_with_evaluators.masm
@@ -1,3 +1,21 @@
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900003 drop drop push.0 push.0 ext2sub padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul

--- a/air-script/tests/system/system.masm
+++ b/air-script/tests/system/system.masm
@@ -1,3 +1,21 @@
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub

--- a/air-script/tests/trace_col_groups/trace_col_groups.masm
+++ b/air-script/tests/trace_col_groups/trace_col_groups.masm
@@ -1,3 +1,21 @@
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900002 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub

--- a/air-script/tests/variables/variables.masm
+++ b/air-script/tests/variables/variables.masm
@@ -1,37 +1,36 @@
 proc.cache_z_exp
-    # Load trace length
-    mem_load.4294903306
-    # => [trace_len, ...]
-    # Push initial num_of_cycles
-    push.1
-    # => [num_of_cycles, trace_len, ...]
-    # Load Z
     padw mem_loadw.4294903304 drop drop
-    # => [z_1, z_0, num_of_cycles, trace_len, ...]
-    # Compute exponentiations based on the number of cycles for a period of 8
-    dup.3 div.8
-    # => [num_of_cycles', z_1, z_0, num_of_cycles, trace_len, ...]
-    # Update next num_of_cycles and compute number of iterations
-    movup.3 dup.1 movdn.4 div
-    # => [i, z_1, z_0, num_of_cycles', trace_len, ...]
-    # Exponentiate the existing `z**num_of_cycles` an additional `i` times
-    dup.0 neq.1
+    # => [z_1, z_0, ...]
+    # Find number exponentiations required to get for a period of length 8
+    mem_load.4294903307 neg add.3
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len) + 3
+    # Exponentiate z
+    dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [z_1^2, z_0^2, i, num_of_cycles', trace_len, ...]
-        movup.2 div.2 dup.0 neq.1
-        # => [b, i+1, z_1^2, z_0^2, num_of_cycles', trace_len, ...]
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
     end # END while
-    drop push.0 push.0 mem_storew.500000100 # Save the exponentiation of z for column 0
-    # => [0, 0, z_1^2, z_0^2, num_of_cycles', trace_len, ...]
+    push.0 mem_storew.500000100 # z^8
+    # => [0, 0, (z_1, z_0)^n, ...] where n = trace_len-8
     drop drop
-    # => [z_1^2, z_0^2, num_of_cycles', trace_len, ...]
-    # Clean stack
-    dropw
+    # Exponentiate z 8 times, until trace_len
+    push.18446744069414584318
+    # => [count, (z_1, z_0)^n, ...] where count=-3 , n=trace_len-3
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(z_1, z_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (z_1, z_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000101 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
 end # END PROC cache_z_exp
 
 proc.cache_periodic_polys
-    exec.cache_z_exp
     # periodic column 0
     padw mem_loadw.500000100 drop drop
     # => [z_exp_1, z_exp_0, ...]

--- a/codegen/masm/src/config.rs
+++ b/codegen/masm/src/config.rs
@@ -6,6 +6,11 @@ pub struct CodegenConfig {
     //      [trace_len_address] => [trace_len, 0, 0, 0]
     pub trace_len_address: u32,
 
+    // Memory location of the `log_2(trace_length)` using the following format:
+    //
+    //      [log2_trace_len_address] => [log_2(trace_len), 0, 0, 0]
+    pub log2_trace_len_address: u32,
+
     // Memory location of the out-of-domain value using the following format:
     //
     //      [z_address] => [z8_0, z8_1, z_0, z_1]
@@ -51,6 +56,7 @@ impl Default for CodegenConfig {
     fn default() -> Self {
         CodegenConfig {
             trace_len_address: constants::TRACE_LEN_ADDRESS,
+            log2_trace_len_address: constants::LOG2_TRACE_LEN_ADDRESS,
             z_address: constants::Z_ADDRESS,
             ood_frame_address: constants::OOD_FRAME_ADDRESS,
             ood_aux_frame_address: constants::OOD_AUX_FRAME_ADDRESS,

--- a/codegen/masm/src/writer.rs
+++ b/codegen/masm/src/writer.rs
@@ -188,6 +188,11 @@ impl Writer {
     simple_ins!(ext2mul);
     simple_ins!(ext2add);
     simple_ins!(ext2sub);
+    simple_ins!(neg);
+
+    pub(crate) fn add(&mut self, arg: u64) {
+        self.ins(format!("add.{}", arg));
+    }
 
     pub fn dup(&mut self, arg: u64) {
         assert!(
@@ -241,16 +246,6 @@ impl Writer {
             "Value is larger than modulus, likely a bug"
         );
         self.ins(format!("push.{}", arg));
-    }
-
-    pub fn div(&mut self, divisor: Option<u64>) {
-        match divisor {
-            Some(divisor) => {
-                assert!(divisor != 0, "Division by zero is not supported, got div.0");
-                self.ins(format!("div.{}", divisor))
-            }
-            None => self.ins("div"),
-        }
     }
 
     pub fn neq(&mut self, arg: u64) {

--- a/codegen/masm/tests/test_periodic.rs
+++ b/codegen/masm/tests/test_periodic.rs
@@ -62,6 +62,7 @@ fn test_simple_periodic() {
         trace_len,
         z,
         &[
+            "cache_z_exp",
             "cache_periodic_polys",
             "compute_evaluate_integrity_constraints",
         ],
@@ -79,6 +80,101 @@ fn test_simple_periodic() {
     // results are in stack-order
     #[rustfmt::skip]
     let expected = to_stack_order(&[
+        a,
+    ]);
+
+    assert!(
+        result_stack
+            .iter()
+            .zip(expected.iter())
+            .all(|(l, r)| l == r),
+        "results don't match result={:?} expected={:?}",
+        result_stack,
+        expected,
+    );
+}
+
+static MULTIPLE_AUX_AIR: &str = "
+def MultipleAux
+
+trace_columns:
+    main: [a, b, c]
+
+periodic_columns:
+    m: [1, 0]
+    n: [1, 1, 1, 0]
+    o: [1, 0, 0, 0]
+
+public_inputs:
+    stack_inputs: [16]
+
+boundary_constraints:
+    enf a.first = 0
+
+integrity_constraints:
+    enf a * m = 0
+    enf b * n = 0
+    enf c * o = 0
+";
+
+#[test]
+fn test_multiple_periodic() {
+    let ast = parse(MULTIPLE_AUX_AIR);
+    let ir = AirIR::new(ast).expect("build AirIR failed");
+    let code = code_gen(&ir).expect("codegen failed");
+
+    let trace_len = 2u64.pow(4);
+    let one = QuadExtension::new(Felt::new(1), Felt::ZERO);
+    let z = one;
+    let a = QuadExtension::new(Felt::new(3), Felt::ZERO);
+    let a_prime = a;
+    let b = QuadExtension::new(Felt::new(5), Felt::ZERO);
+    let b_prime = b;
+    let c = QuadExtension::new(Felt::new(7), Felt::ZERO);
+    let c_prime = c;
+
+    let code = test_code(
+        code,
+        vec![
+            Data {
+                data: to_stack_order(&[a, a_prime, b, b_prime, c, c_prime]),
+                address: constants::OOD_FRAME_ADDRESS,
+                descriptor: "main_trace",
+            },
+            Data {
+                data: to_stack_order(&[]),
+                address: constants::OOD_AUX_FRAME_ADDRESS,
+                descriptor: "aux_trace",
+            },
+            Data {
+                data: to_stack_order(&vec![one; 3]),
+                address: constants::COMPOSITION_COEF_ADDRESS,
+                descriptor: "composition_coefficients",
+            },
+        ],
+        trace_len,
+        z,
+        &[
+            "cache_z_exp",
+            "cache_periodic_polys",
+            "compute_evaluate_integrity_constraints",
+        ],
+    );
+    let program = Assembler::default().compile(code).unwrap();
+
+    let mut process: Process<MemAdviceProvider> = Process::new(
+        Kernel::new(&[]),
+        StackInputs::new(vec![]),
+        AdviceInputs::default().into(),
+    );
+    let program_outputs = process.execute(&program).expect("execution failed");
+    let result_stack = program_outputs.stack();
+
+    // results are in stack-order
+    #[rustfmt::skip]
+    let expected = to_stack_order(&[
+        c,
+        b,
         a,
     ]);
 

--- a/codegen/masm/tests/utils.rs
+++ b/codegen/masm/tests/utils.rs
@@ -126,6 +126,11 @@ where
         trace_len,
         constants::TRACE_LEN_ADDRESS
     ));
+    code.push_str(&format!(
+        "    push.{} push.{} mem_store # log2(trace_len)\n",
+        trace_len.ilog2(),
+        constants::LOG2_TRACE_LEN_ADDRESS,
+    ));
 
     // save the out-of-domain element
     let [z_0, z_1] = z.to_base_elements();


### PR DESCRIPTION
Review/Merge after #318 (this needs the LOG2 address added by 318)

```
    masm: caching `z^trace_len`

    - The value `z^trace_len` is used in the divisor of the transition
      constraints. This commit extends `cache_z_exp` to compute that value and
      cache the result along size the other points used by the periodic
      columns.
    - This also updates the code to use `log` of the trace_len instead of
      the absolute value. This allowed for some small optimizations and
      reduce stack manipulation.
    - The store/load of the cache value is also optimized, now the periodic
      columns are grouped by their cycle length, and only a single item per
      group is stored. In contrast to the previous implementation that
      stored one element per column, which could include duplicates.
```