### PR TITLE
masm: added procedure to load exemption points

### DIFF
--- a/air-script/tests/aux_trace/aux_trace.masm
+++ b/air-script/tests/aux_trace/aux_trace.masm
@@ -16,6 +16,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub

--- a/air-script/tests/binary/binary.masm
+++ b/air-script/tests/binary/binary.masm
@@ -16,6 +16,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop

--- a/air-script/tests/bitwise/bitwise.masm
+++ b/air-script/tests/bitwise/bitwise.masm
@@ -30,6 +30,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.cache_periodic_polys
     # periodic column 0
     padw mem_loadw.500000100 drop drop

--- a/air-script/tests/constants/constants.masm
+++ b/air-script/tests/constants/constants.masm
@@ -16,6 +16,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub

--- a/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
+++ b/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
@@ -16,6 +16,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900075 movdn.3 movdn.3 drop drop padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop ext2sub

--- a/air-script/tests/constraint_comprehension/constraint_comprehension.masm
+++ b/air-script/tests/constraint_comprehension/constraint_comprehension.masm
@@ -16,6 +16,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900075 movdn.3 movdn.3 drop drop padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop ext2sub

--- a/air-script/tests/evaluators/evaluators.masm
+++ b/air-script/tests/evaluators/evaluators.masm
@@ -16,6 +16,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2sub

--- a/air-script/tests/indexed_trace_access/indexed_trace_access.masm
+++ b/air-script/tests/indexed_trace_access/indexed_trace_access.masm
@@ -16,6 +16,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub

--- a/air-script/tests/list_comprehension/list_comprehension.masm
+++ b/air-script/tests/list_comprehension/list_comprehension.masm
@@ -16,6 +16,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2sub

--- a/air-script/tests/list_folding/list_folding.masm
+++ b/air-script/tests/list_folding/list_folding.masm
@@ -16,6 +16,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900074 drop drop padw mem_loadw.4294900078 movdn.3 movdn.3 drop drop padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900080 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900081 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900082 movdn.3 movdn.3 drop drop padw mem_loadw.4294900083 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900084 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900085 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub

--- a/air-script/tests/periodic_columns/periodic_columns.masm
+++ b/air-script/tests/periodic_columns/periodic_columns.masm
@@ -44,6 +44,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.cache_periodic_polys
     # periodic column 0
     padw mem_loadw.500000101 drop drop

--- a/air-script/tests/pub_inputs/pub_inputs.masm
+++ b/air-script/tests/pub_inputs/pub_inputs.masm
@@ -16,6 +16,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2add ext2sub

--- a/air-script/tests/random_values/random_values_bindings.masm
+++ b/air-script/tests/random_values/random_values_bindings.masm
@@ -16,6 +16,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900073 drop drop padw mem_loadw.4294900157 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900151 drop drop ext2add ext2sub

--- a/air-script/tests/random_values/random_values_simple.masm
+++ b/air-script/tests/random_values/random_values_simple.masm
@@ -16,6 +16,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900073 drop drop padw mem_loadw.4294900157 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900151 drop drop ext2add ext2sub

--- a/air-script/tests/selectors/selectors.masm
+++ b/air-script/tests/selectors/selectors.masm
@@ -16,6 +16,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900003 drop drop push.0 push.0 ext2sub padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul

--- a/air-script/tests/selectors/selectors_with_evaluators.masm
+++ b/air-script/tests/selectors/selectors_with_evaluators.masm
@@ -16,6 +16,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900003 drop drop push.0 push.0 ext2sub padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul

--- a/air-script/tests/system/system.masm
+++ b/air-script/tests/system/system.masm
@@ -16,6 +16,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub

--- a/air-script/tests/trace_col_groups/trace_col_groups.masm
+++ b/air-script/tests/trace_col_groups/trace_col_groups.masm
@@ -16,6 +16,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900002 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub

--- a/air-script/tests/variables/variables.masm
+++ b/air-script/tests/variables/variables.masm
@@ -30,6 +30,96 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294903306
+    # => [trace_len, ...]
+    dup.0 push.131064 u32checked_and neq.0 # Included(3)..Included(16)
+    if.true
+        dup.0 push.2040 u32checked_and neq.0 # Included(3)..Included(10)
+        if.true
+            dup.0 push.120 u32checked_and neq.0 # Included(3)..Included(6)
+            if.true
+                dup.0 push.24 u32checked_and neq.0 # Included(3)..Included(4)
+                if.true
+                    push.8 u32checked_and neq.0 # Test if trace length is a power of 2^3
+                    push.18442240469788262401 push.18446742969902956801 dup.2 cdrop push.18446742969902956801 push.18446462594437873665 movup.3 cdrop
+                else
+                    push.32 u32checked_and neq.0 # Test if trace length is a power of 2^5
+                    push.16140901060737761281 push.18158513693329981441 dup.2 cdrop push.18158513693329981441 push.18442240469788262401 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.384 u32checked_and neq.0 # Included(7)..Included(8)
+                if.true
+                    push.128 u32checked_and neq.0 # Test if trace length is a power of 2^7
+                    push.9171943329124577373 push.274873712576 dup.2 cdrop push.274873712576 push.16140901060737761281 movup.3 cdrop
+                else
+                    push.512 u32checked_and neq.0 # Test if trace length is a power of 2^9
+                    push.4088309022520035137 push.5464760906092500108 dup.2 cdrop push.5464760906092500108 push.9171943329124577373 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.30720 u32checked_and neq.0 # Included(11)..Included(14)
+            if.true
+                dup.0 push.6144 u32checked_and neq.0 # Included(11)..Included(12)
+                if.true
+                    push.2048 u32checked_and neq.0 # Test if trace length is a power of 2^11
+                    push.386651765402340522 push.6141391951880571024 dup.2 cdrop push.6141391951880571024 push.4088309022520035137 movup.3 cdrop
+                else
+                    push.8192 u32checked_and neq.0 # Test if trace length is a power of 2^13
+                    push.2841727033376697931 push.11575992183625933494 dup.2 cdrop push.11575992183625933494 push.386651765402340522 movup.3 cdrop
+                end # END else
+            else
+                push.32768 u32checked_and neq.0 # Test if trace length is a power of 2^15
+                push.9071788333329385449 push.8892493137794983311 dup.2 cdrop push.8892493137794983311 push.2841727033376697931 movup.3 cdrop
+            end # END else
+        end # END else
+    else
+        dup.0 push.33423360 u32checked_and neq.0 # Included(17)..Included(24)
+        if.true
+            dup.0 push.1966080 u32checked_and neq.0 # Included(17)..Included(20)
+            if.true
+                dup.0 push.393216 u32checked_and neq.0 # Included(17)..Included(18)
+                if.true
+                    push.131072 u32checked_and neq.0 # Test if trace length is a power of 2^17
+                    push.14996013474702747840 push.15139302138664925958 dup.2 cdrop push.15139302138664925958 push.9071788333329385449 movup.3 cdrop
+                else
+                    push.524288 u32checked_and neq.0 # Test if trace length is a power of 2^19
+                    push.6451340039662992847 push.5708508531096855759 dup.2 cdrop push.5708508531096855759 push.14996013474702747840 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.6291456 u32checked_and neq.0 # Included(21)..Included(22)
+                if.true
+                    push.2097152 u32checked_and neq.0 # Test if trace length is a power of 2^21
+                    push.10420286214021487819 push.5102364342718059185 dup.2 cdrop push.5102364342718059185 push.6451340039662992847 movup.3 cdrop
+                else
+                    push.8388608 u32checked_and neq.0 # Test if trace length is a power of 2^23
+                    push.17538441494603169704 push.13945510089405579673 dup.2 cdrop push.13945510089405579673 push.10420286214021487819 movup.3 cdrop
+                end # END else
+            end # END else
+        else
+            dup.0 push.503316480 u32checked_and neq.0 # Included(25)..Included(28)
+            if.true
+                dup.0 push.100663296 u32checked_and neq.0 # Included(25)..Included(26)
+                if.true
+                    push.33554432 u32checked_and neq.0 # Test if trace length is a power of 2^25
+                    push.8974194941257008806 push.16784649996768716373 dup.2 cdrop push.16784649996768716373 push.17538441494603169704 movup.3 cdrop
+                else
+                    push.134217728 u32checked_and neq.0 # Test if trace length is a power of 2^27
+                    push.5506647088734794298 push.16194875529212099076 dup.2 cdrop push.16194875529212099076 push.8974194941257008806 movup.3 cdrop
+                end # END else
+            else
+                dup.0 push.1610612736 u32checked_and neq.0 # Included(29)..Included(30)
+                if.true
+                    push.536870912 u32checked_and neq.0 # Test if trace length is a power of 2^29
+                    push.16558868196663692994 push.7731871677141058814 dup.2 cdrop push.7731871677141058814 push.5506647088734794298 movup.3 cdrop
+                else
+                    push.9896756522253134970 push.16558868196663692994
+                end # END else
+            end # END else
+        end # END else
+    end # END else
+end # END PROC get_exemptions_points
+
 proc.cache_periodic_polys
     # periodic column 0
     padw mem_loadw.500000100 drop drop

--- a/codegen/masm/src/codegen.rs
+++ b/codegen/masm/src/codegen.rs
@@ -4,8 +4,9 @@ use air_ir::{
 };
 use std::collections::BTreeMap;
 use std::mem::{replace, take};
+use std::ops::{Bound, RangeBounds};
 
-use miden_processor::math::{Felt, StarkField};
+use miden_processor::math::{Felt, FieldElement, StarkField};
 use winter_prover::math::fft;
 
 use crate::config::CodegenConfig;
@@ -119,6 +120,83 @@ fn load_quadratic_element(
     }
 
     Ok(())
+}
+
+/// Precomputes the exemption points for a given power.
+///
+/// The current version of the generated code has hardcoded 2 exemption points, this means the
+/// points can be precomputed during compilation time to save a few cycles during runtime.
+fn points_for_power(power: u32) -> (u64, u64) {
+    let g = Felt::get_root_of_unity(power);
+    let trace_len = 2u64.pow(power);
+    let one = g.exp(trace_len - 1).as_int();
+    let two = g.exp(trace_len - 2).as_int();
+    (one, two)
+}
+
+/// Generate code to push the exemptions point to the top of the stack.
+///
+/// This procedure handles two powers using conditional drops, instead of control flow with if
+/// statements, since the former is slightly faster for the small number of instructions used. The
+/// emitted code assumes the trace_length is at the top of the stack, and afer executing it will
+/// leave the stack as follows:
+///
+/// Stack: [g^{trace_len-2}, g^{trace_len-1}, ...]
+fn exemption_points(writer: &mut Writer, small_power: u32) {
+    let (lone, ltwo) = points_for_power(small_power);
+    let (hone, htwo) = points_for_power(small_power + 1);
+
+    writer.push(2u64.pow(small_power));
+    writer.u32checked_and();
+    writer.neq(0);
+    writer.comment(format!(
+        "Test if trace length is a power of 2^{}",
+        small_power
+    ));
+
+    writer.push(hone);
+    writer.push(lone);
+    writer.dup(2);
+    writer.cdrop();
+
+    writer.push(htwo);
+    writer.push(ltwo);
+    writer.movup(3);
+    writer.cdrop();
+}
+
+/// Helper function to emit efficient code to bisect the trace length value.
+///
+/// The callbacks `yes` and `no` are used to emit the code for each branch.
+fn bisect_trace_len<L, R>(writer: &mut Writer, range: impl RangeBounds<u32>, yes: L, no: R)
+where
+    L: FnOnce(&mut Writer),
+    R: FnOnce(&mut Writer),
+{
+    let mask = match (range.end_bound(), range.start_bound()) {
+        (Bound::Included(&start), Bound::Included(&end)) => {
+            let high_mask = 2u64.pow(start + 1) - 1;
+            let low_mask = 2u64.pow(end) - 1;
+            high_mask ^ low_mask
+        }
+        _ => panic!("Only inclusive ranges are supported"),
+    };
+
+    writer.dup(0);
+    writer.push(mask);
+    writer.u32checked_and();
+    writer.neq(0);
+    writer.comment(format!(
+        "{:?}..{:?}",
+        range.start_bound(),
+        range.end_bound()
+    ));
+
+    writer.r#if();
+    yes(writer);
+    writer.r#else();
+    no(writer);
+    writer.r#end();
 }
 
 /// Assumes a quadratic element is at the top of the stack and square it `n` times.
@@ -397,6 +475,140 @@ impl<'ast> Backend<'ast> {
         Ok(())
     }
 
+    /// Emits code for the procedure `get_exemptions_points`.
+    ///
+    /// The generated procedure contains the precomputed exemption points to be used when computing
+    /// the divisors. The values are returned in the stack.
+    fn gen_get_exemptions_points(&mut self) -> Result<(), CodegenError> {
+        // Notes:
+        // - Computing the exemption points on the fly would require 1 exponentiation to find the
+        // root-of-unity from the two-adicity, followed by another exponetiation to compute the
+        // two-to-last exemption point, and a multiplication to compute the last exemption point.
+        // Each exponentiation is 41 cycles, giving around 83 cycles to compute the values.
+        // - For the range from powers 3 to 32 there are 30 unique values, which requires 8 words
+        // of data. Storing the data to memory requires pushing the 4 elements of a word to the
+        // stack, the target address, the store, and cleaning the stack, resulting in 10 cycles per
+        // word for a total of 80 cycles and some additional cycles to load the right value from
+        // memory when needed.
+        // - The code below instead uses a binary search to find the right value. And push only the
+        // necessary data to memory, in 62/73 cycles.
+        // - The smallest trace length is 2^3,
+        // Ref: https://github.com/facebook/winterfell/blob/main/air/src/air/trace_info.rs#L34-L35
+        // - The trace length is guaranteed to be a power-of-two and to fit in a u32.
+        // Ref: https://github.com/0xPolygonMiden/miden-vm/blob/next/stdlib/asm/crypto/stark/random_coin.masm#L76
+
+        self.writer.proc("get_exemptions_points");
+        self.load_trace_len();
+        self.writer.header("=> [trace_len, ...]");
+
+        let writer = &mut self.writer;
+        bisect_trace_len(
+            writer,
+            3..=16,
+            |writer: &mut Writer| {
+                bisect_trace_len(
+                    writer,
+                    3..=10,
+                    |writer: &mut Writer| {
+                        bisect_trace_len(
+                            writer,
+                            3..=6,
+                            |writer: &mut Writer| {
+                                bisect_trace_len(
+                                    writer,
+                                    3..=4,
+                                    |writer: &mut Writer| exemption_points(writer, 3),
+                                    |writer: &mut Writer| exemption_points(writer, 5),
+                                )
+                            },
+                            |writer: &mut Writer| {
+                                bisect_trace_len(
+                                    writer,
+                                    7..=8,
+                                    |writer: &mut Writer| exemption_points(writer, 7),
+                                    |writer: &mut Writer| exemption_points(writer, 9),
+                                )
+                            },
+                        )
+                    },
+                    |writer: &mut Writer| {
+                        bisect_trace_len(
+                            writer,
+                            11..=14,
+                            |writer: &mut Writer| {
+                                bisect_trace_len(
+                                    writer,
+                                    11..=12,
+                                    |writer: &mut Writer| exemption_points(writer, 11),
+                                    |writer: &mut Writer| exemption_points(writer, 13),
+                                )
+                            },
+                            |writer: &mut Writer| exemption_points(writer, 15),
+                        )
+                    },
+                );
+            },
+            |writer: &mut Writer| {
+                bisect_trace_len(
+                    writer,
+                    17..=24,
+                    |writer: &mut Writer| {
+                        bisect_trace_len(
+                            writer,
+                            17..=20,
+                            |writer: &mut Writer| {
+                                bisect_trace_len(
+                                    writer,
+                                    17..=18,
+                                    |writer: &mut Writer| exemption_points(writer, 17),
+                                    |writer: &mut Writer| exemption_points(writer, 19),
+                                )
+                            },
+                            |writer: &mut Writer| {
+                                bisect_trace_len(
+                                    writer,
+                                    21..=22,
+                                    |writer: &mut Writer| exemption_points(writer, 21),
+                                    |writer: &mut Writer| exemption_points(writer, 23),
+                                )
+                            },
+                        )
+                    },
+                    |writer: &mut Writer| {
+                        bisect_trace_len(
+                            writer,
+                            25..=28,
+                            |writer: &mut Writer| {
+                                bisect_trace_len(
+                                    writer,
+                                    25..=26,
+                                    |writer: &mut Writer| exemption_points(writer, 25),
+                                    |writer: &mut Writer| exemption_points(writer, 27),
+                                )
+                            },
+                            |writer: &mut Writer| {
+                                bisect_trace_len(
+                                    writer,
+                                    29..=30,
+                                    |writer: &mut Writer| exemption_points(writer, 29),
+                                    |writer: &mut Writer| {
+                                        let (one, two) = points_for_power(31);
+                                        writer.push(one);
+                                        writer.push(two);
+                                    },
+                                )
+                            },
+                        )
+                    },
+                );
+            },
+        );
+
+        self.writer.end(); // end proc
+
+        Ok(())
+    }
+
     /// Emits code for the procedure `evaluate_integrity_constraints`.
     ///
     /// Evaluates the integrity constraints for both the main and auxiliary traces.
@@ -457,6 +669,10 @@ impl<'ast> Backend<'ast> {
         self.writer.mem_loadw(self.config.z_address);
         self.writer.drop();
         self.writer.drop();
+    }
+
+    fn load_trace_len(&mut self) {
+        self.writer.mem_load(self.config.trace_len_address);
     }
 }
 
@@ -533,6 +749,8 @@ impl<'ast> AirVisitor<'ast> for Backend<'ast> {
         walk_integrity_constraint_degrees(self, self.ir, AUX_TRACE)?;
 
         self.gen_cache_z_exp()?;
+        self.gen_get_exemptions_points()?;
+
         if !self.ir.periodic_columns.is_empty() {
             self.gen_evaluate_periodic_polys()?;
         }

--- a/codegen/masm/tests/test_exemption_points.rs
+++ b/codegen/masm/tests/test_exemption_points.rs
@@ -1,0 +1,75 @@
+use air_codegen_masm::constants;
+use miden_assembly::Assembler;
+use miden_processor::{
+    math::{Felt, FieldElement, StarkField},
+    AdviceInputs, Kernel, MemAdviceProvider, Process, QuadExtension, StackInputs,
+};
+
+mod utils;
+use utils::{codegen, test_code, to_stack_order, Data};
+
+static SIMPLE_AIR: &str = "
+def Simple
+
+trace_columns:
+    main: [a]
+
+public_inputs:
+    stack_inputs: [16]
+
+boundary_constraints:
+    enf a.first = 0
+
+integrity_constraints:
+    enf a + a = 0
+";
+
+#[test]
+fn test_exemption_points() {
+    let one = QuadExtension::new(Felt::new(1), Felt::ZERO);
+    let z = one;
+    let a = QuadExtension::new(Felt::new(3), Felt::ZERO);
+    let a_prime = a;
+
+    for power in 3..32 {
+        let trace_len = 2u64.pow(power);
+
+        let code = codegen(SIMPLE_AIR);
+        let code = test_code(
+            code,
+            vec![Data {
+                data: to_stack_order(&[a, a_prime]),
+                address: constants::OOD_FRAME_ADDRESS,
+                descriptor: "main_trace",
+            }],
+            trace_len,
+            z,
+            &["get_exemptions_points"],
+        );
+        let program = Assembler::default().compile(code).unwrap();
+
+        let mut process: Process<MemAdviceProvider> = Process::new(
+            Kernel::new(&[]),
+            StackInputs::new(vec![]),
+            AdviceInputs::default().into(),
+        );
+        let program_outputs = process.execute(&program).expect("execution failed");
+        let result_stack = program_outputs.stack();
+
+        let g = Felt::get_root_of_unity(power);
+        let one = g.exp(trace_len - 1).as_int();
+        let two = g.exp(trace_len - 2).as_int();
+
+        // results are in stack-order
+        let expected = vec![two, one];
+        assert!(
+            result_stack
+                .iter()
+                .zip(expected.iter())
+                .all(|(l, r)| l == r),
+            "results don't match result={:?} expected={:?}",
+            result_stack,
+            expected,
+        );
+    }
+}


### PR DESCRIPTION
The generated procedure takes the approach of pre-computing the values during compilations, and then searching for the correct exemption points during runtime, doing a binary search on the runtime trace length to find the correct points.

The alternative of computing the points during runtime or creating a lookup table would have worked, but both approaches would be sligthly slower in comparison.

The data is kept in the stack for 1. testability 2. performance, since mem load/stores are no longer necessary.