### PR TITLE
masm: sorting boundary constraints

### DIFF
--- a/air-script/tests/aux_trace/aux_trace.masm
+++ b/air-script/tests/aux_trace/aux_trace.masm
@@ -30,19 +30,19 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900203 movdn.3 movdn.3 drop drop ext2mul
-    # boundary constraint 0 for aux
+    # boundary constraint 2 for aux
     padw mem_loadw.4294900073 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900203 drop drop ext2mul
-    # boundary constraint 1 for aux
-    padw mem_loadw.4294900073 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
-    # Multiply by the composition coefficient
-    padw mem_loadw.4294900204 movdn.3 movdn.3 drop drop ext2mul
-    # boundary constraint 2 for aux
+    # boundary constraint 3 for aux
     padw mem_loadw.4294900074 movdn.3 movdn.3 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
+    padw mem_loadw.4294900204 movdn.3 movdn.3 drop drop ext2mul
+    # boundary constraint 4 for aux
+    padw mem_loadw.4294900073 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
+    # Multiply by the composition coefficient
     padw mem_loadw.4294900204 drop drop ext2mul
-    # boundary constraint 3 for aux
+    # boundary constraint 5 for aux
     padw mem_loadw.4294900074 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900205 movdn.3 movdn.3 drop drop ext2mul

--- a/air-script/tests/constants/constants.masm
+++ b/air-script/tests/constants/constants.masm
@@ -38,11 +38,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop push.1 push.0 push.0 push.0 ext2add push.1 push.0 ext2sub push.1 push.0 ext2add push.2 push.0 ext2sub push.2 push.0 ext2add push.0 push.0 ext2sub ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900204 movdn.3 movdn.3 drop drop ext2mul
-    # boundary constraint 0 for aux
+    # boundary constraint 4 for aux
     padw mem_loadw.4294900073 movdn.3 movdn.3 drop drop push.1 push.0 push.0 push.0 push.2 push.0 ext2mul ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900204 drop drop ext2mul
-    # boundary constraint 1 for aux
+    # boundary constraint 5 for aux
     padw mem_loadw.4294900073 movdn.3 movdn.3 drop drop push.1 push.0 push.1 push.0 push.1 push.0 ext2mul ext2sub ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900205 movdn.3 movdn.3 drop drop ext2mul

--- a/codegen/masm/tests/test_boundary.rs
+++ b/codegen/masm/tests/test_boundary.rs
@@ -222,20 +222,34 @@ fn test_complex_boundary() {
     let program_outputs = process.execute(&program).expect("execution failed");
     let result_stack = program_outputs.stack();
 
-    // results are in stack-order
+    // Note: The order of the results is _not_ the same as the definition order in the AirScript.
+    // The order below is:
+    //
+    // 1. First row boundary constraints for the MAIN trace
+    // 2. Last row boundary constraints for the MAIN trace
+    // 3. First row boundary constraints for the AUX trace
+    // 4. Last row boundary constraints for the AUX trace
+    //
+    // Results are in stack-order.
     #[rustfmt::skip]
     let expected = to_stack_order(&[
+        // last row aux trace
         f - one,              // enf f.last = 1
+
+        // first row aux trace
         f - rand[0],          // enf f.first = $rand[0]
 
+        // last row main trace
+        b - public_inputs[3], // enf b.last = stack_outputs[1]
+        a - public_inputs[2], // enf a.last = stack_outputs[0]
+
+        // first row main trace
         e[1] - one,           // enf e[1].first = 1
         e[0],                 // enf e[0].first = 0
 
         d - one,              // enf d.first = 1
         c,                    // enf c.first = (B[0] - C[1][1]) * A
 
-        b - public_inputs[3], // enf b.last = stack_outputs[1]
-        a - public_inputs[2], // enf a.last = stack_outputs[0]
         b - public_inputs[1], // enf b.first = stack_inputs[1]
         a - public_inputs[0], // enf a.first = stack_inputs[0]
     ]);


### PR DESCRIPTION
The Winterfell framework groups assertions by trace (main or auxiliary), by stride, and step (the first row to which the assertion is enforced). The assertions in a group are further ordered by the column which they apply to.

In AirScript only single value assertions are supported, which means the stride is always `0` and grouping only happens by trace and step. And they are further ordered by column.

The ordering described above is important because it defines the position of the composition coefficient to be used.

This commits introduces the ordering by `step`. The ordering by column needs to be implemented later on.