### PR TITLE
masm: added get_exemptions_points procedure

### DIFF
--- a/air-script/tests/aux_trace/aux_trace.masm
+++ b/air-script/tests/aux_trace/aux_trace.masm
@@ -16,6 +16,15 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub

--- a/air-script/tests/binary/binary.masm
+++ b/air-script/tests/binary/binary.masm
@@ -16,6 +16,15 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop

--- a/air-script/tests/bitwise/bitwise.masm
+++ b/air-script/tests/bitwise/bitwise.masm
@@ -30,6 +30,15 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
 proc.cache_periodic_polys
     # periodic column 0
     padw mem_loadw.500000100 drop drop

--- a/air-script/tests/constants/constants.masm
+++ b/air-script/tests/constants/constants.masm
@@ -16,6 +16,15 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub

--- a/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
+++ b/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
@@ -16,6 +16,15 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900075 movdn.3 movdn.3 drop drop padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop ext2sub

--- a/air-script/tests/constraint_comprehension/constraint_comprehension.masm
+++ b/air-script/tests/constraint_comprehension/constraint_comprehension.masm
@@ -16,6 +16,15 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900075 movdn.3 movdn.3 drop drop padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop ext2sub

--- a/air-script/tests/evaluators/evaluators.masm
+++ b/air-script/tests/evaluators/evaluators.masm
@@ -16,6 +16,15 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2sub

--- a/air-script/tests/indexed_trace_access/indexed_trace_access.masm
+++ b/air-script/tests/indexed_trace_access/indexed_trace_access.masm
@@ -16,6 +16,15 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub

--- a/air-script/tests/list_comprehension/list_comprehension.masm
+++ b/air-script/tests/list_comprehension/list_comprehension.masm
@@ -16,6 +16,15 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2sub

--- a/air-script/tests/list_folding/list_folding.masm
+++ b/air-script/tests/list_folding/list_folding.masm
@@ -16,6 +16,15 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900074 drop drop padw mem_loadw.4294900078 movdn.3 movdn.3 drop drop padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900080 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900081 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900082 movdn.3 movdn.3 drop drop padw mem_loadw.4294900083 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900084 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900085 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub

--- a/air-script/tests/periodic_columns/periodic_columns.masm
+++ b/air-script/tests/periodic_columns/periodic_columns.masm
@@ -44,6 +44,15 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
 proc.cache_periodic_polys
     # periodic column 0
     padw mem_loadw.500000101 drop drop

--- a/air-script/tests/pub_inputs/pub_inputs.masm
+++ b/air-script/tests/pub_inputs/pub_inputs.masm
@@ -16,6 +16,15 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2add ext2sub

--- a/air-script/tests/random_values/random_values_bindings.masm
+++ b/air-script/tests/random_values/random_values_bindings.masm
@@ -16,6 +16,15 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900073 drop drop padw mem_loadw.4294900157 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900151 drop drop ext2add ext2sub

--- a/air-script/tests/random_values/random_values_simple.masm
+++ b/air-script/tests/random_values/random_values_simple.masm
@@ -16,6 +16,15 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900073 drop drop padw mem_loadw.4294900157 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900151 drop drop ext2add ext2sub

--- a/air-script/tests/system/system.masm
+++ b/air-script/tests/system/system.masm
@@ -16,6 +16,15 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub

--- a/air-script/tests/trace_col_groups/trace_col_groups.masm
+++ b/air-script/tests/trace_col_groups/trace_col_groups.masm
@@ -16,6 +16,15 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900002 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub

--- a/air-script/tests/variables/variables.masm
+++ b/air-script/tests/variables/variables.masm
@@ -30,6 +30,15 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
 proc.cache_periodic_polys
     # periodic column 0
     padw mem_loadw.500000100 drop drop

--- a/codegen/masm/src/config.rs
+++ b/codegen/masm/src/config.rs
@@ -51,6 +51,11 @@ pub struct CodegenConfig {
     /// Memory range used to store exponentiations of Z, each address contains one point to be used
     /// on the evaluation of each periodic polynimal.
     pub z_exp_address: u32,
+
+    /// Memory position of the trace domain generator.
+    ///
+    /// Note: `g_trace = g_lde^{blowup}`
+    pub trace_domain_generator_address: u32,
 }
 
 impl Default for CodegenConfig {
@@ -66,6 +71,7 @@ impl Default for CodegenConfig {
             aux_rand_address: constants::AUX_RAND_ELEM_PTR,
             periodic_values_address: constants::PERIODIC_VALUES_ADDRESS,
             z_exp_address: constants::Z_EXP_ADDRESS,
+            trace_domain_generator_address: constants::TRACE_DOMAIN_GENERATOR_ADDRESS,
         }
     }
 }

--- a/codegen/masm/src/constants.rs
+++ b/codegen/masm/src/constants.rs
@@ -26,6 +26,8 @@ pub const LOG2_TRACE_LEN_ADDRESS: u32 = 4294903307;
 // https://github.com/0xPolygonMiden/miden-vm/blob/next/stdlib/asm/crypto/stark/constants.masm#L79
 pub const Z_ADDRESS: u32 = 4294903304;
 
+pub const TRACE_DOMAIN_GENERATOR_ADDRESS: u32 = 4294799999;
+
 // CODEGEN CONSTANTS ------------------------------------------------------------------------------
 pub const PERIODIC_VALUES_ADDRESS: u32 = 500000000;
 pub const Z_EXP_ADDRESS: u32 = 500000100;

--- a/codegen/masm/src/writer.rs
+++ b/codegen/masm/src/writer.rs
@@ -1,6 +1,7 @@
 use miden_processor::math::{Felt, StarkField};
 use std::borrow::{Borrow, Cow};
 
+#[derive(Debug, Clone, Copy)]
 enum ControlFlow {
     While,
 }
@@ -187,6 +188,9 @@ impl Writer {
     simple_ins!(ext2add);
     simple_ins!(ext2sub);
     simple_ins!(neg);
+    simple_ins!(swap);
+    simple_ins!(div);
+    simple_ins!(mul);
 
     pub(crate) fn add(&mut self, arg: u64) {
         self.ins(format!("add.{}", arg));
@@ -251,6 +255,10 @@ impl Writer {
     }
 
     pub fn r#while(&mut self) {
+        assert!(
+            self.procedure.is_some(),
+            "Can not open a while outside of a procedure"
+        );
         self.new_line();
         self.indent();
         self.code.push_str("while.true");

--- a/codegen/masm/tests/test_exemption_points.rs
+++ b/codegen/masm/tests/test_exemption_points.rs
@@ -1,0 +1,75 @@
+use air_codegen_masm::constants;
+use miden_assembly::Assembler;
+use miden_processor::{
+    math::{Felt, FieldElement, StarkField},
+    AdviceInputs, Kernel, MemAdviceProvider, Process, QuadExtension, StackInputs,
+};
+
+mod utils;
+use utils::{codegen, test_code, to_stack_order, Data};
+
+static SIMPLE_AIR: &str = "
+def Simple
+
+trace_columns:
+    main: [a]
+
+public_inputs:
+    stack_inputs: [16]
+
+boundary_constraints:
+    enf a.first = 0
+
+integrity_constraints:
+    enf a + a = 0
+";
+
+#[test]
+fn test_exemption_points() {
+    let one = QuadExtension::new(Felt::new(1), Felt::ZERO);
+    let z = one;
+    let a = QuadExtension::new(Felt::new(3), Felt::ZERO);
+    let a_prime = a;
+
+    for power in 3..32 {
+        let trace_len = 2u64.pow(power);
+
+        let code = codegen(SIMPLE_AIR);
+        let code = test_code(
+            code,
+            vec![Data {
+                data: to_stack_order(&[a, a_prime]),
+                address: constants::OOD_FRAME_ADDRESS,
+                descriptor: "main_trace",
+            }],
+            trace_len,
+            z,
+            &["get_exemptions_points"],
+        );
+        let program = Assembler::default().compile(code).unwrap();
+
+        let mut process: Process<MemAdviceProvider> = Process::new(
+            Kernel::new(&[]),
+            StackInputs::new(vec![]),
+            AdviceInputs::default().into(),
+        );
+        let program_outputs = process.execute(&program).expect("execution failed");
+        let result_stack = program_outputs.stack();
+
+        let g = Felt::get_root_of_unity(power);
+        let one = g.exp(trace_len - 1).as_int();
+        let two = g.exp(trace_len - 2).as_int();
+
+        // results are in stack-order
+        let expected = vec![two, one];
+        assert!(
+            result_stack
+                .iter()
+                .zip(expected.iter())
+                .all(|(l, r)| l == r),
+            "results don't match result={:?} expected={:?}",
+            result_stack,
+            expected,
+        );
+    }
+}

--- a/codegen/masm/tests/utils.rs
+++ b/codegen/masm/tests/utils.rs
@@ -142,6 +142,13 @@ where
         constants::LOG2_TRACE_LEN_ADDRESS,
     ));
 
+    let g = Felt::get_root_of_unity(trace_len.ilog2());
+    code.push_str(&format!(
+        "    push.{} push.{} mem_store # trace domain generator `g`\n",
+        g,
+        constants::TRACE_DOMAIN_GENERATOR_ADDRESS,
+    ));
+
     // save the out-of-domain element
     let [z_0, z_1] = z.to_base_elements();
     code.push_str(&format!(


### PR DESCRIPTION
follow up to https://github.com/0xPolygonMiden/air-script/pull/320

This adds a `get_exemption_points` procedure which relies on the pre computed generator from the FRI stdlib.