### PR TITLE
masm: added integrity constraint divisor

### DIFF
--- a/air-script/tests/aux_trace/aux_trace.masm
+++ b/air-script/tests/aux_trace/aux_trace.masm
@@ -25,6 +25,26 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub
@@ -77,8 +97,11 @@ end # END PROC compute_evaluate_boundary_constraints
 
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/binary/binary.masm
+++ b/air-script/tests/binary/binary.masm
@@ -25,6 +25,26 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop
@@ -73,8 +93,11 @@ end # END PROC compute_evaluate_boundary_constraints
 
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/bitwise/bitwise.masm
+++ b/air-script/tests/bitwise/bitwise.masm
@@ -131,6 +131,26 @@ proc.cache_periodic_polys
     push.0 push.0 mem_storew.500000001 dropw
 end # END PROC cache_periodic_polys
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000101 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop
@@ -338,8 +358,11 @@ end # END PROC compute_evaluate_boundary_constraints
 proc.evaluate_integrity_constraints
     exec.cache_periodic_polys
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/constants/constants.masm
+++ b/air-script/tests/constants/constants.masm
@@ -25,6 +25,26 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
@@ -77,8 +97,11 @@ end # END PROC compute_evaluate_boundary_constraints
 
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
+++ b/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
@@ -25,6 +25,26 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900075 movdn.3 movdn.3 drop drop padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop ext2sub
@@ -53,8 +73,11 @@ end # END PROC compute_evaluate_boundary_constraints
 
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/constraint_comprehension/constraint_comprehension.masm
+++ b/air-script/tests/constraint_comprehension/constraint_comprehension.masm
@@ -25,6 +25,26 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900075 movdn.3 movdn.3 drop drop padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop ext2sub
@@ -53,8 +73,11 @@ end # END PROC compute_evaluate_boundary_constraints
 
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/evaluators/evaluators.masm
+++ b/air-script/tests/evaluators/evaluators.masm
@@ -25,6 +25,26 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2sub
@@ -121,8 +141,11 @@ end # END PROC compute_evaluate_boundary_constraints
 
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add ext2add ext2add ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/indexed_trace_access/indexed_trace_access.masm
+++ b/air-script/tests/indexed_trace_access/indexed_trace_access.masm
@@ -25,6 +25,26 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
@@ -45,8 +65,11 @@ end # END PROC compute_evaluate_boundary_constraints
 
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/list_comprehension/list_comprehension.masm
+++ b/air-script/tests/list_comprehension/list_comprehension.masm
@@ -25,6 +25,26 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2sub
@@ -57,8 +77,11 @@ end # END PROC compute_evaluate_boundary_constraints
 
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/list_folding/list_folding.masm
+++ b/air-script/tests/list_folding/list_folding.masm
@@ -25,6 +25,26 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900074 drop drop padw mem_loadw.4294900078 movdn.3 movdn.3 drop drop padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900080 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900081 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900082 movdn.3 movdn.3 drop drop padw mem_loadw.4294900083 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900084 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900085 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub
@@ -53,8 +73,11 @@ end # END PROC compute_evaluate_boundary_constraints
 
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/periodic_columns/periodic_columns.masm
+++ b/air-script/tests/periodic_columns/periodic_columns.masm
@@ -125,6 +125,26 @@ proc.cache_periodic_polys
     push.0 push.0 mem_storew.500000001 dropw
 end # END PROC cache_periodic_polys
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000102 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.500000001 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2add ext2mul push.0 push.0 ext2sub
@@ -146,8 +166,11 @@ end # END PROC compute_evaluate_boundary_constraints
 proc.evaluate_integrity_constraints
     exec.cache_periodic_polys
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/pub_inputs/pub_inputs.masm
+++ b/air-script/tests/pub_inputs/pub_inputs.masm
@@ -25,6 +25,26 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2add ext2sub
@@ -85,8 +105,11 @@ end # END PROC compute_evaluate_boundary_constraints
 
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/random_values/random_values_bindings.masm
+++ b/air-script/tests/random_values/random_values_bindings.masm
@@ -25,6 +25,26 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900073 drop drop padw mem_loadw.4294900157 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900151 drop drop ext2add ext2sub
@@ -45,8 +65,11 @@ end # END PROC compute_evaluate_boundary_constraints
 
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/random_values/random_values_simple.masm
+++ b/air-script/tests/random_values/random_values_simple.masm
@@ -25,6 +25,26 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900073 drop drop padw mem_loadw.4294900157 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900151 drop drop ext2add ext2sub
@@ -45,8 +65,11 @@ end # END PROC compute_evaluate_boundary_constraints
 
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/selectors/selectors.masm
+++ b/air-script/tests/selectors/selectors.masm
@@ -16,6 +16,26 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900003 drop drop push.0 push.0 ext2sub padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul
@@ -40,8 +60,11 @@ end # END PROC compute_evaluate_boundary_constraints
 
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/selectors/selectors_with_evaluators.masm
+++ b/air-script/tests/selectors/selectors_with_evaluators.masm
@@ -16,6 +16,26 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900003 drop drop push.0 push.0 ext2sub padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul
@@ -40,8 +60,11 @@ end # END PROC compute_evaluate_boundary_constraints
 
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/system/system.masm
+++ b/air-script/tests/system/system.masm
@@ -25,6 +25,26 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
@@ -41,8 +61,11 @@ end # END PROC compute_evaluate_boundary_constraints
 
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/trace_col_groups/trace_col_groups.masm
+++ b/air-script/tests/trace_col_groups/trace_col_groups.masm
@@ -25,6 +25,26 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900002 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
@@ -45,8 +65,11 @@ end # END PROC compute_evaluate_boundary_constraints
 
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/air-script/tests/variables/variables.masm
+++ b/air-script/tests/variables/variables.masm
@@ -87,6 +87,26 @@ proc.cache_periodic_polys
     push.0 push.0 mem_storew.500000000 dropw
 end # END PROC cache_periodic_polys
 
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000101 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop
@@ -138,8 +158,11 @@ end # END PROC compute_evaluate_boundary_constraints
 proc.evaluate_integrity_constraints
     exec.cache_periodic_polys
     exec.compute_evaluate_integrity_constraints
-    # Accumulate the numerator of the constraint polynomial
+    # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
 proc.evaluate_boundary_constraints

--- a/codegen/masm/src/visitor.rs
+++ b/codegen/masm/src/visitor.rs
@@ -1,14 +1,12 @@
 use crate::constants::{AUX_TRACE, MAIN_TRACE};
 use air_ir::{
-    AccessType, Air, ConstraintDomain, ConstraintRoot, IntegrityConstraintDegree, NodeIndex,
-    Operation, PeriodicColumn, PublicInput, TraceAccess, TraceSegmentId, Value,
+    Air, ConstraintDomain, ConstraintRoot, IntegrityConstraintDegree, NodeIndex, Operation,
+    PeriodicColumn, PublicInput, TraceAccess, TraceSegmentId, Value,
 };
 
 pub trait AirVisitor<'ast> {
     type Value;
     type Error;
-
-    fn visit_access_type(&mut self, access: &'ast AccessType) -> Result<Self::Value, Self::Error>;
 
     fn visit_boundary_constraint(
         &mut self,

--- a/codegen/masm/src/writer.rs
+++ b/codegen/masm/src/writer.rs
@@ -185,6 +185,7 @@ impl Writer {
     simple_ins!(dropw);
     simple_ins!(padw);
     simple_ins!(ext2mul);
+    simple_ins!(ext2div);
     simple_ins!(ext2add);
     simple_ins!(ext2sub);
     simple_ins!(neg);

--- a/codegen/masm/tests/test_divisor.rs
+++ b/codegen/masm/tests/test_divisor.rs
@@ -1,0 +1,91 @@
+use air_codegen_masm::constants;
+use miden_assembly::Assembler;
+use miden_processor::{
+    math::{Felt, FieldElement},
+    AdviceInputs, Kernel, MemAdviceProvider, Process, QuadExtension, StackInputs,
+};
+use winter_prover::ConstraintDivisor;
+
+mod utils;
+use utils::{codegen, test_code, to_stack_order, Data};
+
+static SIMPLE_AIR: &str = "
+def SimpleAux
+
+trace_columns:
+    main: [a]
+
+public_inputs:
+    stack_inputs: [1]
+
+boundary_constraints:
+    enf a.first = 0
+
+integrity_constraints:
+    enf a = 0
+";
+
+#[test]
+fn test_integrity_divisor() {
+    let code = codegen(SIMPLE_AIR);
+
+    let exemptions = 2;
+    let one = QuadExtension::new(Felt::new(1), Felt::ZERO);
+    let a = QuadExtension::new(Felt::new(3), Felt::ZERO);
+    let a_prime = a;
+    let z = QuadExtension::new(Felt::new(5), Felt::new(7));
+
+    for power in 3..32 {
+        let trace_len = 2u64.pow(power);
+
+        let code = test_code(
+            code.clone(),
+            vec![
+                Data {
+                    data: to_stack_order(&[a, a_prime]),
+                    address: constants::OOD_FRAME_ADDRESS,
+                    descriptor: "main_trace",
+                },
+                Data {
+                    data: to_stack_order(&vec![one; 6]),
+                    address: constants::COMPOSITION_COEF_ADDRESS,
+                    descriptor: "composition_coefficients",
+                },
+            ],
+            trace_len,
+            z,
+            &["cache_z_exp", "compute_integrity_constraint_divisor"],
+        );
+        let program = Assembler::default().compile(code).unwrap();
+
+        let constraint_divisor =
+            ConstraintDivisor::<Felt>::from_transition(trace_len.try_into().unwrap(), exemptions);
+        let divisor = constraint_divisor.evaluate_at(z);
+
+        let mut process: Process<MemAdviceProvider> = Process::new(
+            Kernel::new(&[]),
+            StackInputs::new(vec![]),
+            AdviceInputs::default().into(),
+        );
+        let program_outputs = process.execute(&program).expect("execution failed");
+        let result_stack = program_outputs.stack();
+
+        // results are in stack-order
+        #[rustfmt::skip]
+        let expected = to_stack_order(&[
+            divisor,
+        ]);
+
+        assert!(
+            result_stack
+                .iter()
+                .zip(expected.iter())
+                .all(|(l, r)| l == r),
+            "results don't match trace_len={} power={} result={:?} expected={:?}",
+            trace_len,
+            power,
+            result_stack,
+            expected,
+        );
+    }
+}


### PR DESCRIPTION
Adds codegen for the procedure `compute_integrity_constraint_divisor` to compute the integrity constraint divisor.