### PR TITLE
masm: add comments to procedures

### DIFF
--- a/air-script/tests/aux_trace/aux_trace.masm
+++ b/air-script/tests/aux_trace/aux_trace.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -16,6 +22,10 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
 proc.get_exemptions_points
     mem_load.4294799999
     # => [g, ...]
@@ -25,6 +35,13 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
     padw mem_loadw.500000100 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
@@ -45,6 +62,16 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 3 main and 2 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 5 quadratic elements to the stack
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub
@@ -68,6 +95,16 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900202 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints
 
+# Procedure to evaluate numerators of all boundary constraints.
+#
+# All the 2 main and 4 auxiliary constraints are computed.
+# The result constriants are evaluated in natural order, and their values are pushed to the stack.
+# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
+#        This procedure pushes 6 quadratic elements to the stack
 proc.compute_evaluate_boundary_constraints
     # boundary constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
@@ -95,6 +132,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900205 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_boundary_constraints
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
     # Numerator of the transition constraint polynomial
@@ -104,6 +146,11 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
     exec.compute_evaluate_boundary_constraints
     # Accumulate the numerator of the constraint polynomial

--- a/air-script/tests/binary/binary.masm
+++ b/air-script/tests/binary/binary.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -16,6 +22,10 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
 proc.get_exemptions_points
     mem_load.4294799999
     # => [g, ...]
@@ -25,6 +35,13 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
     padw mem_loadw.500000100 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
@@ -45,6 +62,16 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 2 main and 0 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 2 quadratic elements to the stack
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop
@@ -84,6 +111,16 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900200 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints
 
+# Procedure to evaluate numerators of all boundary constraints.
+#
+# All the 1 main and 0 auxiliary constraints are computed.
+# The result constriants are evaluated in natural order, and their values are pushed to the stack.
+# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
+#        This procedure pushes 1 quadratic elements to the stack
 proc.compute_evaluate_boundary_constraints
     # boundary constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
@@ -91,6 +128,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900201 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_boundary_constraints
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
     # Numerator of the transition constraint polynomial
@@ -100,6 +142,11 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
     exec.compute_evaluate_boundary_constraints
     # Accumulate the numerator of the constraint polynomial

--- a/air-script/tests/bitwise/bitwise.masm
+++ b/air-script/tests/bitwise/bitwise.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -30,6 +36,10 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
 proc.get_exemptions_points
     mem_load.4294799999
     # => [g, ...]
@@ -39,6 +49,12 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+# Procedure to evaluate the periodic polynomials.
+#
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [...]
 proc.cache_periodic_polys
     # periodic column 0
     padw mem_loadw.500000100 drop drop
@@ -131,6 +147,13 @@ proc.cache_periodic_polys
     push.0 push.0 mem_storew.500000001 dropw
 end # END PROC cache_periodic_polys
 
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
     padw mem_loadw.500000101 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
@@ -151,6 +174,16 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 17 main and 0 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 17 quadratic elements to the stack
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop
@@ -348,6 +381,16 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900208 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints
 
+# Procedure to evaluate numerators of all boundary constraints.
+#
+# All the 1 main and 0 auxiliary constraints are computed.
+# The result constriants are evaluated in natural order, and their values are pushed to the stack.
+# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
+#        This procedure pushes 1 quadratic elements to the stack
 proc.compute_evaluate_boundary_constraints
     # boundary constraint 0 for main
     padw mem_loadw.4294900013 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
@@ -355,6 +398,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900208 drop drop ext2mul
 end # END PROC compute_evaluate_boundary_constraints
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.cache_periodic_polys
     exec.compute_evaluate_integrity_constraints
@@ -365,6 +413,11 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
     exec.compute_evaluate_boundary_constraints
     # Accumulate the numerator of the constraint polynomial

--- a/air-script/tests/constants/constants.masm
+++ b/air-script/tests/constants/constants.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -16,6 +22,10 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
 proc.get_exemptions_points
     mem_load.4294799999
     # => [g, ...]
@@ -25,6 +35,13 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
     padw mem_loadw.500000100 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
@@ -45,6 +62,16 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 3 main and 2 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 5 quadratic elements to the stack
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
@@ -68,6 +95,16 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900202 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints
 
+# Procedure to evaluate numerators of all boundary constraints.
+#
+# All the 4 main and 2 auxiliary constraints are computed.
+# The result constriants are evaluated in natural order, and their values are pushed to the stack.
+# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
+#        This procedure pushes 6 quadratic elements to the stack
 proc.compute_evaluate_boundary_constraints
     # boundary constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
@@ -95,6 +132,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900205 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_boundary_constraints
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
     # Numerator of the transition constraint polynomial
@@ -104,6 +146,11 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
     exec.compute_evaluate_boundary_constraints
     # Accumulate the numerator of the constraint polynomial

--- a/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
+++ b/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -16,6 +22,10 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
 proc.get_exemptions_points
     mem_load.4294799999
     # => [g, ...]
@@ -25,6 +35,13 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
     padw mem_loadw.500000100 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
@@ -45,6 +62,16 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 0 main and 4 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 4 quadratic elements to the stack
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900075 movdn.3 movdn.3 drop drop padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop ext2sub
@@ -64,6 +91,16 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900201 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints
 
+# Procedure to evaluate numerators of all boundary constraints.
+#
+# All the 0 main and 1 auxiliary constraints are computed.
+# The result constriants are evaluated in natural order, and their values are pushed to the stack.
+# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
+#        This procedure pushes 1 quadratic elements to the stack
 proc.compute_evaluate_boundary_constraints
     # boundary constraint 0 for aux
     padw mem_loadw.4294900077 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
@@ -71,6 +108,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900202 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_boundary_constraints
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
     # Numerator of the transition constraint polynomial
@@ -80,6 +122,11 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
     exec.compute_evaluate_boundary_constraints
     # Accumulate the numerator of the constraint polynomial

--- a/air-script/tests/constraint_comprehension/constraint_comprehension.masm
+++ b/air-script/tests/constraint_comprehension/constraint_comprehension.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -16,6 +22,10 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
 proc.get_exemptions_points
     mem_load.4294799999
     # => [g, ...]
@@ -25,6 +35,13 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
     padw mem_loadw.500000100 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
@@ -45,6 +62,16 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 0 main and 4 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 4 quadratic elements to the stack
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900075 movdn.3 movdn.3 drop drop padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop ext2sub
@@ -64,6 +91,16 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900201 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints
 
+# Procedure to evaluate numerators of all boundary constraints.
+#
+# All the 0 main and 1 auxiliary constraints are computed.
+# The result constriants are evaluated in natural order, and their values are pushed to the stack.
+# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
+#        This procedure pushes 1 quadratic elements to the stack
 proc.compute_evaluate_boundary_constraints
     # boundary constraint 0 for aux
     padw mem_loadw.4294900077 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
@@ -71,6 +108,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900202 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_boundary_constraints
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
     # Numerator of the transition constraint polynomial
@@ -80,6 +122,11 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
     exec.compute_evaluate_boundary_constraints
     # Accumulate the numerator of the constraint polynomial

--- a/air-script/tests/evaluators/evaluators.masm
+++ b/air-script/tests/evaluators/evaluators.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -16,6 +22,10 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
 proc.get_exemptions_points
     mem_load.4294799999
     # => [g, ...]
@@ -25,6 +35,13 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
     padw mem_loadw.500000100 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
@@ -45,6 +62,16 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 7 main and 0 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 7 quadratic elements to the stack
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2sub
@@ -132,6 +159,16 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900203 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints
 
+# Procedure to evaluate numerators of all boundary constraints.
+#
+# All the 1 main and 0 auxiliary constraints are computed.
+# The result constriants are evaluated in natural order, and their values are pushed to the stack.
+# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
+#        This procedure pushes 1 quadratic elements to the stack
 proc.compute_evaluate_boundary_constraints
     # boundary constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
@@ -139,6 +176,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900203 drop drop ext2mul
 end # END PROC compute_evaluate_boundary_constraints
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
     # Numerator of the transition constraint polynomial
@@ -148,6 +190,11 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
     exec.compute_evaluate_boundary_constraints
     # Accumulate the numerator of the constraint polynomial

--- a/air-script/tests/indexed_trace_access/indexed_trace_access.masm
+++ b/air-script/tests/indexed_trace_access/indexed_trace_access.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -16,6 +22,10 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
 proc.get_exemptions_points
     mem_load.4294799999
     # => [g, ...]
@@ -25,6 +35,13 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
     padw mem_loadw.500000100 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
@@ -45,6 +62,16 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 1 main and 1 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 2 quadratic elements to the stack
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
@@ -56,6 +83,16 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900200 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints
 
+# Procedure to evaluate numerators of all boundary constraints.
+#
+# All the 1 main and 0 auxiliary constraints are computed.
+# The result constriants are evaluated in natural order, and their values are pushed to the stack.
+# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
+#        This procedure pushes 1 quadratic elements to the stack
 proc.compute_evaluate_boundary_constraints
     # boundary constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
@@ -63,6 +100,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900201 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_boundary_constraints
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
     # Numerator of the transition constraint polynomial
@@ -72,6 +114,11 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
     exec.compute_evaluate_boundary_constraints
     # Accumulate the numerator of the constraint polynomial

--- a/air-script/tests/list_comprehension/list_comprehension.masm
+++ b/air-script/tests/list_comprehension/list_comprehension.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -16,6 +22,10 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
 proc.get_exemptions_points
     mem_load.4294799999
     # => [g, ...]
@@ -25,6 +35,13 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
     padw mem_loadw.500000100 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
@@ -45,6 +62,16 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 1 main and 4 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 5 quadratic elements to the stack
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2sub
@@ -68,6 +95,16 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900202 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints
 
+# Procedure to evaluate numerators of all boundary constraints.
+#
+# All the 0 main and 1 auxiliary constraints are computed.
+# The result constriants are evaluated in natural order, and their values are pushed to the stack.
+# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
+#        This procedure pushes 1 quadratic elements to the stack
 proc.compute_evaluate_boundary_constraints
     # boundary constraint 0 for aux
     padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
@@ -75,6 +112,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900202 drop drop ext2mul
 end # END PROC compute_evaluate_boundary_constraints
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
     # Numerator of the transition constraint polynomial
@@ -84,6 +126,11 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
     exec.compute_evaluate_boundary_constraints
     # Accumulate the numerator of the constraint polynomial

--- a/air-script/tests/list_folding/list_folding.masm
+++ b/air-script/tests/list_folding/list_folding.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -16,6 +22,10 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
 proc.get_exemptions_points
     mem_load.4294799999
     # => [g, ...]
@@ -25,6 +35,13 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
     padw mem_loadw.500000100 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
@@ -45,6 +62,16 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 0 main and 4 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 4 quadratic elements to the stack
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900074 drop drop padw mem_loadw.4294900078 movdn.3 movdn.3 drop drop padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900080 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900081 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900082 movdn.3 movdn.3 drop drop padw mem_loadw.4294900083 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900084 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900085 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub
@@ -64,6 +91,16 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900201 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints
 
+# Procedure to evaluate numerators of all boundary constraints.
+#
+# All the 0 main and 1 auxiliary constraints are computed.
+# The result constriants are evaluated in natural order, and their values are pushed to the stack.
+# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
+#        This procedure pushes 1 quadratic elements to the stack
 proc.compute_evaluate_boundary_constraints
     # boundary constraint 0 for aux
     padw mem_loadw.4294900080 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
@@ -71,6 +108,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900202 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_boundary_constraints
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
     # Numerator of the transition constraint polynomial
@@ -80,6 +122,11 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
     exec.compute_evaluate_boundary_constraints
     # Accumulate the numerator of the constraint polynomial

--- a/air-script/tests/periodic_columns/periodic_columns.masm
+++ b/air-script/tests/periodic_columns/periodic_columns.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -44,6 +50,10 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
 proc.get_exemptions_points
     mem_load.4294799999
     # => [g, ...]
@@ -53,6 +63,12 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+# Procedure to evaluate the periodic polynomials.
+#
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [...]
 proc.cache_periodic_polys
     # periodic column 0
     padw mem_loadw.500000101 drop drop
@@ -125,6 +141,13 @@ proc.cache_periodic_polys
     push.0 push.0 mem_storew.500000001 dropw
 end # END PROC cache_periodic_polys
 
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
     padw mem_loadw.500000102 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
@@ -145,6 +168,16 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 2 main and 0 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 2 quadratic elements to the stack
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.500000001 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2add ext2mul push.0 push.0 ext2sub
@@ -156,6 +189,16 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900200 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints
 
+# Procedure to evaluate numerators of all boundary constraints.
+#
+# All the 1 main and 0 auxiliary constraints are computed.
+# The result constriants are evaluated in natural order, and their values are pushed to the stack.
+# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
+#        This procedure pushes 1 quadratic elements to the stack
 proc.compute_evaluate_boundary_constraints
     # boundary constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
@@ -163,6 +206,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900201 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_boundary_constraints
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.cache_periodic_polys
     exec.compute_evaluate_integrity_constraints
@@ -173,6 +221,11 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
     exec.compute_evaluate_boundary_constraints
     # Accumulate the numerator of the constraint polynomial

--- a/air-script/tests/pub_inputs/pub_inputs.masm
+++ b/air-script/tests/pub_inputs/pub_inputs.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -16,6 +22,10 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
 proc.get_exemptions_points
     mem_load.4294799999
     # => [g, ...]
@@ -25,6 +35,13 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
     padw mem_loadw.500000100 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
@@ -45,6 +62,16 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 1 main and 0 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 1 quadratic elements to the stack
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2add ext2sub
@@ -52,6 +79,16 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900200 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints
 
+# Procedure to evaluate numerators of all boundary constraints.
+#
+# All the 8 main and 0 auxiliary constraints are computed.
+# The result constriants are evaluated in natural order, and their values are pushed to the stack.
+# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
+#        This procedure pushes 8 quadratic elements to the stack
 proc.compute_evaluate_boundary_constraints
     # boundary constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop
@@ -103,6 +140,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900204 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_boundary_constraints
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
     # Numerator of the transition constraint polynomial
@@ -112,6 +154,11 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
     exec.compute_evaluate_boundary_constraints
     # Accumulate the numerator of the constraint polynomial

--- a/air-script/tests/random_values/random_values_bindings.masm
+++ b/air-script/tests/random_values/random_values_bindings.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -16,6 +22,10 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
 proc.get_exemptions_points
     mem_load.4294799999
     # => [g, ...]
@@ -25,6 +35,13 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
     padw mem_loadw.500000100 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
@@ -45,6 +62,16 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 0 main and 1 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 1 quadratic elements to the stack
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900073 drop drop padw mem_loadw.4294900157 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900151 drop drop ext2add ext2sub
@@ -52,6 +79,16 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900200 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints
 
+# Procedure to evaluate numerators of all boundary constraints.
+#
+# All the 0 main and 2 auxiliary constraints are computed.
+# The result constriants are evaluated in natural order, and their values are pushed to the stack.
+# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
+#        This procedure pushes 2 quadratic elements to the stack
 proc.compute_evaluate_boundary_constraints
     # boundary constraint 0 for aux
     padw mem_loadw.4294900073 movdn.3 movdn.3 drop drop padw mem_loadw.4294900152 drop drop padw mem_loadw.4294900151 drop drop ext2add padw mem_loadw.4294900157 drop drop ext2add ext2sub
@@ -63,6 +100,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900201 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_boundary_constraints
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
     # Numerator of the transition constraint polynomial
@@ -72,6 +114,11 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
     exec.compute_evaluate_boundary_constraints
     # Accumulate the numerator of the constraint polynomial

--- a/air-script/tests/random_values/random_values_simple.masm
+++ b/air-script/tests/random_values/random_values_simple.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -16,6 +22,10 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
 proc.get_exemptions_points
     mem_load.4294799999
     # => [g, ...]
@@ -25,6 +35,13 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
     padw mem_loadw.500000100 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
@@ -45,6 +62,16 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 0 main and 1 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 1 quadratic elements to the stack
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900073 drop drop padw mem_loadw.4294900157 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900151 drop drop ext2add ext2sub
@@ -52,6 +79,16 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900200 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints
 
+# Procedure to evaluate numerators of all boundary constraints.
+#
+# All the 0 main and 2 auxiliary constraints are computed.
+# The result constriants are evaluated in natural order, and their values are pushed to the stack.
+# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
+#        This procedure pushes 2 quadratic elements to the stack
 proc.compute_evaluate_boundary_constraints
     # boundary constraint 0 for aux
     padw mem_loadw.4294900073 movdn.3 movdn.3 drop drop padw mem_loadw.4294900152 drop drop padw mem_loadw.4294900151 drop drop ext2add padw mem_loadw.4294900157 drop drop ext2add ext2sub
@@ -63,6 +100,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900201 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_boundary_constraints
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
     # Numerator of the transition constraint polynomial
@@ -72,6 +114,11 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
     exec.compute_evaluate_boundary_constraints
     # Accumulate the numerator of the constraint polynomial

--- a/air-script/tests/system/system.masm
+++ b/air-script/tests/system/system.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -16,6 +22,10 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
 proc.get_exemptions_points
     mem_load.4294799999
     # => [g, ...]
@@ -25,6 +35,13 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
     padw mem_loadw.500000100 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
@@ -45,6 +62,16 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 1 main and 0 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 1 quadratic elements to the stack
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
@@ -52,6 +79,16 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900200 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints
 
+# Procedure to evaluate numerators of all boundary constraints.
+#
+# All the 1 main and 0 auxiliary constraints are computed.
+# The result constriants are evaluated in natural order, and their values are pushed to the stack.
+# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
+#        This procedure pushes 1 quadratic elements to the stack
 proc.compute_evaluate_boundary_constraints
     # boundary constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
@@ -59,6 +96,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900200 drop drop ext2mul
 end # END PROC compute_evaluate_boundary_constraints
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
     # Numerator of the transition constraint polynomial
@@ -68,6 +110,11 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
     exec.compute_evaluate_boundary_constraints
     # Accumulate the numerator of the constraint polynomial

--- a/air-script/tests/trace_col_groups/trace_col_groups.masm
+++ b/air-script/tests/trace_col_groups/trace_col_groups.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -16,6 +22,10 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
 proc.get_exemptions_points
     mem_load.4294799999
     # => [g, ...]
@@ -25,6 +35,13 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
     padw mem_loadw.500000100 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
@@ -45,6 +62,16 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 2 main and 0 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 2 quadratic elements to the stack
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900002 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
@@ -56,6 +83,16 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900200 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints
 
+# Procedure to evaluate numerators of all boundary constraints.
+#
+# All the 0 main and 1 auxiliary constraints are computed.
+# The result constriants are evaluated in natural order, and their values are pushed to the stack.
+# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
+#        This procedure pushes 1 quadratic elements to the stack
 proc.compute_evaluate_boundary_constraints
     # boundary constraint 0 for aux
     padw mem_loadw.4294900077 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
@@ -63,6 +100,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900201 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_boundary_constraints
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.compute_evaluate_integrity_constraints
     # Numerator of the transition constraint polynomial
@@ -72,6 +114,11 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
     exec.compute_evaluate_boundary_constraints
     # Accumulate the numerator of the constraint polynomial

--- a/air-script/tests/variables/variables.masm
+++ b/air-script/tests/variables/variables.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -30,6 +36,10 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
 proc.get_exemptions_points
     mem_load.4294799999
     # => [g, ...]
@@ -39,6 +49,12 @@ proc.get_exemptions_points
     # => [g^{-2}, g^{-1}, ...]
 end # END PROC get_exemptions_points
 
+# Procedure to evaluate the periodic polynomials.
+#
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [...]
 proc.cache_periodic_polys
     # periodic column 0
     padw mem_loadw.500000100 drop drop
@@ -87,6 +103,13 @@ proc.cache_periodic_polys
     push.0 push.0 mem_storew.500000000 dropw
 end # END PROC cache_periodic_polys
 
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
     padw mem_loadw.500000101 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
@@ -107,6 +130,16 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 4 main and 1 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 5 quadratic elements to the stack
 proc.compute_evaluate_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop
@@ -144,6 +177,16 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900202 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_integrity_constraints
 
+# Procedure to evaluate numerators of all boundary constraints.
+#
+# All the 2 main and 0 auxiliary constraints are computed.
+# The result constriants are evaluated in natural order, and their values are pushed to the stack.
+# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
+#        This procedure pushes 2 quadratic elements to the stack
 proc.compute_evaluate_boundary_constraints
     # boundary constraint 0 for main
     padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
@@ -155,6 +198,11 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900203 movdn.3 movdn.3 drop drop ext2mul
 end # END PROC compute_evaluate_boundary_constraints
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.cache_periodic_polys
     exec.compute_evaluate_integrity_constraints
@@ -165,6 +213,11 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
     exec.compute_evaluate_boundary_constraints
     # Accumulate the numerator of the constraint polynomial

--- a/codegen/masm/src/writer.rs
+++ b/codegen/masm/src/writer.rs
@@ -104,8 +104,13 @@ impl Writer {
                 self.indent();
             }
         }
-        self.code.push_str("# ");
-        self.code.push_str(comment.borrow());
+        let comment = comment.borrow();
+        if !comment.is_empty() {
+            self.code.push_str("# ");
+            self.code.push_str(comment);
+        } else {
+            self.code.push('#');
+        }
         self.state = LineState::Comment;
     }
 


### PR DESCRIPTION
The `masm` backend is now also emitting comments to each of the procedures.