### PR TITLE
masm: added boundary constraint divisor computation

### DIFF
--- a/air-script/tests/aux_trace/aux_trace.masm
+++ b/air-script/tests/aux_trace/aux_trace.masm
@@ -52,6 +52,7 @@ proc.compute_integrity_constraint_divisor
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -71,8 +72,8 @@ end # END PROC compute_integrity_constraint_divisor
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
 # where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
-#        This procedure pushes 5 quadratic elements to the stack
-proc.compute_evaluate_integrity_constraints
+#        This procedure pushes 5 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub
     # Multiply by the composition coefficient
@@ -93,19 +94,14 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900073 movdn.3 movdn.3 drop drop padw mem_loadw.4294900073 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop ext2add ext2mul ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900202 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-# Procedure to evaluate numerators of all boundary constraints.
-#
-# All the 2 main and 4 auxiliary constraints are computed.
-# The result constriants are evaluated in natural order, and their values are pushed to the stack.
-# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+# Procedure to evaluate the boundary constraint numerator for the first row of the main trace
 #
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
-# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
-#        This procedure pushes 6 quadratic elements to the stack
-proc.compute_evaluate_boundary_constraints
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_main_first
     # boundary constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
     # Multiply by the composition coefficient
@@ -114,6 +110,14 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900203 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_boundary_constraints_main_first
+
+# Procedure to evaluate the boundary constraint numerator for the first row of the auxiliary trace
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_aux_first
     # boundary constraint 2 for aux
     padw mem_loadw.4294900072 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
     # Multiply by the composition coefficient
@@ -122,6 +126,14 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900073 movdn.3 movdn.3 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900204 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_boundary_constraints_aux_first
+
+# Procedure to evaluate the boundary constraint numerator for the last row of the auxiliary trace
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_aux_last
     # boundary constraint 4 for aux
     padw mem_loadw.4294900072 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
     # Multiply by the composition coefficient
@@ -130,7 +142,7 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900073 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900205 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_aux_last
 
 # Procedure to evaluate all integrity constraints.
 #
@@ -138,7 +150,7 @@ end # END PROC compute_evaluate_boundary_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add ext2add
     # Divisor of the transition constraint polynomial
@@ -152,8 +164,29 @@ end # END PROC evaluate_integrity_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add ext2add ext2add ext2add ext2add ext2add
+    exec.compute_boundary_constraints_aux_last
+    # Accumulate the numerator for segment 1 LastRow
+    ext2add ext2add
+    # => [(aux_last1, aux_last0), ...]
+    # Compute the denominator for domain LastRow
+    padw mem_loadw.4294903304 drop drop mem_load.500000101 push.0 ext2sub
+    # Compute numerator/denominator for last row
+    ext2div
+    exec.compute_boundary_constraints_aux_first
+    # Accumulate the numerator for segment 1 FirstRow
+    ext2add ext2add
+    # => [(aux_first1, aux_first0), ...]
+    exec.compute_boundary_constraints_main_first
+    # Accumulate the numerator for segment 0 FirstRow
+    ext2add ext2add
+    # => [(main_first1, main_first0), (aux_first1, aux_first0), ...]
+    ext2add
+    # => [(first1, first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
+    # Add first and last row groups
+    ext2add
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/binary/binary.masm
+++ b/air-script/tests/binary/binary.masm
@@ -52,6 +52,7 @@ proc.compute_integrity_constraint_divisor
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -71,8 +72,8 @@ end # END PROC compute_integrity_constraint_divisor
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
 # where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
-#        This procedure pushes 2 quadratic elements to the stack
-proc.compute_evaluate_integrity_constraints
+#        This procedure pushes 2 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
@@ -109,24 +110,19 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2sub push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-# Procedure to evaluate numerators of all boundary constraints.
-#
-# All the 1 main and 0 auxiliary constraints are computed.
-# The result constriants are evaluated in natural order, and their values are pushed to the stack.
-# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+# Procedure to evaluate the boundary constraint numerator for the first row of the main trace
 #
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
-# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
-#        This procedure pushes 1 quadratic elements to the stack
-proc.compute_evaluate_boundary_constraints
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_main_first
     # boundary constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900201 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_main_first
 
 # Procedure to evaluate all integrity constraints.
 #
@@ -134,7 +130,7 @@ end # END PROC compute_evaluate_boundary_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add ext2add
     # Divisor of the transition constraint polynomial
@@ -148,8 +144,11 @@ end # END PROC evaluate_integrity_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add
+    exec.compute_boundary_constraints_main_first
+    # => [(first1, first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/bitwise/bitwise.masm
+++ b/air-script/tests/bitwise/bitwise.masm
@@ -164,6 +164,7 @@ proc.compute_integrity_constraint_divisor
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -183,8 +184,8 @@ end # END PROC compute_integrity_constraint_divisor
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
 # where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
-#        This procedure pushes 17 quadratic elements to the stack
-proc.compute_evaluate_integrity_constraints
+#        This procedure pushes 17 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
@@ -379,24 +380,19 @@ proc.compute_evaluate_integrity_constraints
     push.1 push.0 padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900012 movdn.3 movdn.3 drop drop padw mem_loadw.4294900011 movdn.3 movdn.3 drop drop push.16 push.0 ext2mul push.1 push.0 padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900007 movdn.3 movdn.3 drop drop ext2mul ext2add push.2 push.0 padw mem_loadw.4294900004 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900008 movdn.3 movdn.3 drop drop ext2mul ext2add push.4 push.0 padw mem_loadw.4294900005 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900009 movdn.3 movdn.3 drop drop ext2mul ext2add push.8 push.0 padw mem_loadw.4294900006 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900010 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub ext2mul padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop padw mem_loadw.4294900012 movdn.3 movdn.3 drop drop padw mem_loadw.4294900011 movdn.3 movdn.3 drop drop push.16 push.0 ext2mul push.1 push.0 padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop padw mem_loadw.4294900007 movdn.3 movdn.3 drop drop ext2add push.2 push.0 padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900007 movdn.3 movdn.3 drop drop ext2mul ext2sub ext2mul ext2add push.2 push.0 padw mem_loadw.4294900004 movdn.3 movdn.3 drop drop padw mem_loadw.4294900008 movdn.3 movdn.3 drop drop ext2add push.2 push.0 padw mem_loadw.4294900004 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900008 movdn.3 movdn.3 drop drop ext2mul ext2sub ext2mul ext2add push.4 push.0 padw mem_loadw.4294900005 movdn.3 movdn.3 drop drop padw mem_loadw.4294900009 movdn.3 movdn.3 drop drop ext2add push.2 push.0 padw mem_loadw.4294900005 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900009 movdn.3 movdn.3 drop drop ext2mul ext2sub ext2mul ext2add push.8 push.0 padw mem_loadw.4294900006 movdn.3 movdn.3 drop drop padw mem_loadw.4294900010 movdn.3 movdn.3 drop drop ext2add push.2 push.0 padw mem_loadw.4294900006 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900010 movdn.3 movdn.3 drop drop ext2mul ext2sub ext2mul ext2add ext2sub ext2mul ext2add push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900208 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-# Procedure to evaluate numerators of all boundary constraints.
-#
-# All the 1 main and 0 auxiliary constraints are computed.
-# The result constriants are evaluated in natural order, and their values are pushed to the stack.
-# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+# Procedure to evaluate the boundary constraint numerator for the first row of the main trace
 #
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
-# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
-#        This procedure pushes 1 quadratic elements to the stack
-proc.compute_evaluate_boundary_constraints
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_main_first
     # boundary constraint 0 for main
     padw mem_loadw.4294900013 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900208 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_main_first
 
 # Procedure to evaluate all integrity constraints.
 #
@@ -405,7 +401,7 @@ end # END PROC compute_evaluate_boundary_constraints
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.cache_periodic_polys
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add
     # Divisor of the transition constraint polynomial
@@ -419,8 +415,11 @@ end # END PROC evaluate_integrity_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add
+    exec.compute_boundary_constraints_main_first
+    # => [(first1, first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/constants/constants.masm
+++ b/air-script/tests/constants/constants.masm
@@ -52,6 +52,7 @@ proc.compute_integrity_constraint_divisor
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -71,8 +72,8 @@ end # END PROC compute_integrity_constraint_divisor
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
 # where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
-#        This procedure pushes 5 quadratic elements to the stack
-proc.compute_evaluate_integrity_constraints
+#        This procedure pushes 5 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
     # Multiply by the composition coefficient
@@ -93,19 +94,14 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900072 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900202 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-# Procedure to evaluate numerators of all boundary constraints.
-#
-# All the 4 main and 2 auxiliary constraints are computed.
-# The result constriants are evaluated in natural order, and their values are pushed to the stack.
-# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+# Procedure to evaluate the boundary constraint numerator for the first row of the main trace
 #
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
-# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
-#        This procedure pushes 6 quadratic elements to the stack
-proc.compute_evaluate_boundary_constraints
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_main_first
     # boundary constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
     # Multiply by the composition coefficient
@@ -122,15 +118,31 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop push.1 push.0 push.2 push.0 ext2sub push.2 push.0 ext2add push.0 push.0 ext2sub ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900204 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_boundary_constraints_main_first
+
+# Procedure to evaluate the boundary constraint numerator for the first row of the auxiliary trace
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_aux_first
     # boundary constraint 4 for aux
     padw mem_loadw.4294900072 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900204 drop drop ext2mul
+end # END PROC compute_boundary_constraints_aux_first
+
+# Procedure to evaluate the boundary constraint numerator for the last row of the auxiliary trace
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_aux_last
     # boundary constraint 5 for aux
     padw mem_loadw.4294900072 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900205 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_aux_last
 
 # Procedure to evaluate all integrity constraints.
 #
@@ -138,7 +150,7 @@ end # END PROC compute_evaluate_boundary_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add ext2add
     # Divisor of the transition constraint polynomial
@@ -152,8 +164,25 @@ end # END PROC evaluate_integrity_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add ext2add ext2add ext2add ext2add ext2add
+    exec.compute_boundary_constraints_aux_last
+    # => [(aux_last1, aux_last0), ...]
+    # Compute the denominator for domain LastRow
+    padw mem_loadw.4294903304 drop drop mem_load.500000101 push.0 ext2sub
+    # Compute numerator/denominator for last row
+    ext2div
+    exec.compute_boundary_constraints_aux_first
+    # => [(aux_first1, aux_first0), ...]
+    exec.compute_boundary_constraints_main_first
+    # Accumulate the numerator for segment 0 FirstRow
+    ext2add ext2add ext2add ext2add
+    # => [(main_first1, main_first0), (aux_first1, aux_first0), ...]
+    ext2add
+    # => [(first1, first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
+    # Add first and last row groups
+    ext2add
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
+++ b/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
@@ -52,6 +52,7 @@ proc.compute_integrity_constraint_divisor
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -71,8 +72,8 @@ end # END PROC compute_integrity_constraint_divisor
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
 # where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
-#        This procedure pushes 4 quadratic elements to the stack
-proc.compute_evaluate_integrity_constraints
+#        This procedure pushes 4 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900074 movdn.3 movdn.3 drop drop padw mem_loadw.4294900078 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
@@ -89,24 +90,19 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900077 movdn.3 movdn.3 drop drop padw mem_loadw.4294900081 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900201 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-# Procedure to evaluate numerators of all boundary constraints.
-#
-# All the 0 main and 1 auxiliary constraints are computed.
-# The result constriants are evaluated in natural order, and their values are pushed to the stack.
-# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+# Procedure to evaluate the boundary constraint numerator for the first row of the auxiliary trace
 #
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
-# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
-#        This procedure pushes 1 quadratic elements to the stack
-proc.compute_evaluate_boundary_constraints
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_aux_first
     # boundary constraint 0 for aux
     padw mem_loadw.4294900076 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900202 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_aux_first
 
 # Procedure to evaluate all integrity constraints.
 #
@@ -114,7 +110,7 @@ end # END PROC compute_evaluate_boundary_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add
     # Divisor of the transition constraint polynomial
@@ -128,8 +124,11 @@ end # END PROC evaluate_integrity_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add
+    exec.compute_boundary_constraints_aux_first
+    # => [(aux_first1, aux_first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/constraint_comprehension/constraint_comprehension.masm
+++ b/air-script/tests/constraint_comprehension/constraint_comprehension.masm
@@ -52,6 +52,7 @@ proc.compute_integrity_constraint_divisor
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -71,8 +72,8 @@ end # END PROC compute_integrity_constraint_divisor
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
 # where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
-#        This procedure pushes 4 quadratic elements to the stack
-proc.compute_evaluate_integrity_constraints
+#        This procedure pushes 4 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900074 movdn.3 movdn.3 drop drop padw mem_loadw.4294900078 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
@@ -89,24 +90,19 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900077 movdn.3 movdn.3 drop drop padw mem_loadw.4294900081 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900201 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-# Procedure to evaluate numerators of all boundary constraints.
-#
-# All the 0 main and 1 auxiliary constraints are computed.
-# The result constriants are evaluated in natural order, and their values are pushed to the stack.
-# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+# Procedure to evaluate the boundary constraint numerator for the first row of the auxiliary trace
 #
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
-# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
-#        This procedure pushes 1 quadratic elements to the stack
-proc.compute_evaluate_boundary_constraints
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_aux_first
     # boundary constraint 0 for aux
     padw mem_loadw.4294900076 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900202 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_aux_first
 
 # Procedure to evaluate all integrity constraints.
 #
@@ -114,7 +110,7 @@ end # END PROC compute_evaluate_boundary_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add
     # Divisor of the transition constraint polynomial
@@ -128,8 +124,11 @@ end # END PROC evaluate_integrity_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add
+    exec.compute_boundary_constraints_aux_first
+    # => [(aux_first1, aux_first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/evaluators/evaluators.masm
+++ b/air-script/tests/evaluators/evaluators.masm
@@ -52,6 +52,7 @@ proc.compute_integrity_constraint_divisor
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -71,8 +72,8 @@ end # END PROC compute_integrity_constraint_divisor
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
 # where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
-#        This procedure pushes 7 quadratic elements to the stack
-proc.compute_evaluate_integrity_constraints
+#        This procedure pushes 7 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
@@ -157,24 +158,19 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900203 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-# Procedure to evaluate numerators of all boundary constraints.
-#
-# All the 1 main and 0 auxiliary constraints are computed.
-# The result constriants are evaluated in natural order, and their values are pushed to the stack.
-# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+# Procedure to evaluate the boundary constraint numerator for the first row of the main trace
 #
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
-# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
-#        This procedure pushes 1 quadratic elements to the stack
-proc.compute_evaluate_boundary_constraints
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_main_first
     # boundary constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900203 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_main_first
 
 # Procedure to evaluate all integrity constraints.
 #
@@ -182,7 +178,7 @@ end # END PROC compute_evaluate_boundary_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add ext2add ext2add ext2add
     # Divisor of the transition constraint polynomial
@@ -196,8 +192,11 @@ end # END PROC evaluate_integrity_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add
+    exec.compute_boundary_constraints_main_first
+    # => [(first1, first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/indexed_trace_access/indexed_trace_access.masm
+++ b/air-script/tests/indexed_trace_access/indexed_trace_access.masm
@@ -52,6 +52,7 @@ proc.compute_integrity_constraint_divisor
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -71,8 +72,8 @@ end # END PROC compute_integrity_constraint_divisor
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
 # where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
-#        This procedure pushes 2 quadratic elements to the stack
-proc.compute_evaluate_integrity_constraints
+#        This procedure pushes 2 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
     # Multiply by the composition coefficient
@@ -81,24 +82,19 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900072 drop drop padw mem_loadw.4294900073 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-# Procedure to evaluate numerators of all boundary constraints.
-#
-# All the 1 main and 0 auxiliary constraints are computed.
-# The result constriants are evaluated in natural order, and their values are pushed to the stack.
-# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+# Procedure to evaluate the boundary constraint numerator for the first row of the main trace
 #
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
-# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
-#        This procedure pushes 1 quadratic elements to the stack
-proc.compute_evaluate_boundary_constraints
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_main_first
     # boundary constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900201 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_main_first
 
 # Procedure to evaluate all integrity constraints.
 #
@@ -106,7 +102,7 @@ end # END PROC compute_evaluate_boundary_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add ext2add
     # Divisor of the transition constraint polynomial
@@ -120,8 +116,11 @@ end # END PROC evaluate_integrity_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add
+    exec.compute_boundary_constraints_main_first
+    # => [(first1, first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/list_comprehension/list_comprehension.masm
+++ b/air-script/tests/list_comprehension/list_comprehension.masm
@@ -52,6 +52,7 @@ proc.compute_integrity_constraint_divisor
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -71,8 +72,8 @@ end # END PROC compute_integrity_constraint_divisor
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
 # where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
-#        This procedure pushes 5 quadratic elements to the stack
-proc.compute_evaluate_integrity_constraints
+#        This procedure pushes 5 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2sub
     # Multiply by the composition coefficient
@@ -93,24 +94,19 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900072 movdn.3 movdn.3 drop drop push.0 push.0 padw mem_loadw.4294900073 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900076 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900080 movdn.3 movdn.3 drop drop ext2sub push.1 push.0 padw mem_loadw.4294900074 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900077 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900081 movdn.3 movdn.3 drop drop ext2sub ext2add push.2 push.0 padw mem_loadw.4294900075 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900078 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900082 movdn.3 movdn.3 drop drop ext2sub ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900202 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-# Procedure to evaluate numerators of all boundary constraints.
-#
-# All the 0 main and 1 auxiliary constraints are computed.
-# The result constriants are evaluated in natural order, and their values are pushed to the stack.
-# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+# Procedure to evaluate the boundary constraint numerator for the first row of the auxiliary trace
 #
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
-# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
-#        This procedure pushes 1 quadratic elements to the stack
-proc.compute_evaluate_boundary_constraints
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_aux_first
     # boundary constraint 0 for aux
     padw mem_loadw.4294900078 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900202 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_aux_first
 
 # Procedure to evaluate all integrity constraints.
 #
@@ -118,7 +114,7 @@ end # END PROC compute_evaluate_boundary_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add ext2add
     # Divisor of the transition constraint polynomial
@@ -132,8 +128,11 @@ end # END PROC evaluate_integrity_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add
+    exec.compute_boundary_constraints_aux_first
+    # => [(aux_first1, aux_first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/list_folding/list_folding.masm
+++ b/air-script/tests/list_folding/list_folding.masm
@@ -52,6 +52,7 @@ proc.compute_integrity_constraint_divisor
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -71,8 +72,8 @@ end # END PROC compute_integrity_constraint_divisor
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
 # where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
-#        This procedure pushes 4 quadratic elements to the stack
-proc.compute_evaluate_integrity_constraints
+#        This procedure pushes 4 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900073 drop drop padw mem_loadw.4294900077 movdn.3 movdn.3 drop drop padw mem_loadw.4294900078 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900080 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900081 movdn.3 movdn.3 drop drop padw mem_loadw.4294900082 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900083 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900084 movdn.3 movdn.3 drop drop ext2mul ext2add ext2sub
     # Multiply by the composition coefficient
@@ -89,24 +90,19 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900076 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900077 movdn.3 movdn.3 drop drop padw mem_loadw.4294900081 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900078 movdn.3 movdn.3 drop drop padw mem_loadw.4294900082 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop padw mem_loadw.4294900083 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294900080 movdn.3 movdn.3 drop drop padw mem_loadw.4294900084 movdn.3 movdn.3 drop drop ext2mul ext2add ext2add padw mem_loadw.4294900077 movdn.3 movdn.3 drop drop padw mem_loadw.4294900081 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900078 movdn.3 movdn.3 drop drop padw mem_loadw.4294900082 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop padw mem_loadw.4294900083 movdn.3 movdn.3 drop drop ext2mul ext2add padw mem_loadw.4294900080 movdn.3 movdn.3 drop drop padw mem_loadw.4294900084 movdn.3 movdn.3 drop drop ext2mul ext2add ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900201 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-# Procedure to evaluate numerators of all boundary constraints.
-#
-# All the 0 main and 1 auxiliary constraints are computed.
-# The result constriants are evaluated in natural order, and their values are pushed to the stack.
-# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+# Procedure to evaluate the boundary constraint numerator for the first row of the auxiliary trace
 #
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
-# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
-#        This procedure pushes 1 quadratic elements to the stack
-proc.compute_evaluate_boundary_constraints
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_aux_first
     # boundary constraint 0 for aux
     padw mem_loadw.4294900079 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900202 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_aux_first
 
 # Procedure to evaluate all integrity constraints.
 #
@@ -114,7 +110,7 @@ end # END PROC compute_evaluate_boundary_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add
     # Divisor of the transition constraint polynomial
@@ -128,8 +124,11 @@ end # END PROC evaluate_integrity_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add
+    exec.compute_boundary_constraints_aux_first
+    # => [(aux_first1, aux_first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/periodic_columns/periodic_columns.masm
+++ b/air-script/tests/periodic_columns/periodic_columns.masm
@@ -158,6 +158,7 @@ proc.compute_integrity_constraint_divisor
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -177,8 +178,8 @@ end # END PROC compute_integrity_constraint_divisor
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
 # where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
-#        This procedure pushes 2 quadratic elements to the stack
-proc.compute_evaluate_integrity_constraints
+#        This procedure pushes 2 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.500000001 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2add ext2mul push.0 push.0 ext2sub
     # Multiply by the composition coefficient
@@ -187,24 +188,19 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.500000000 drop drop padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2sub ext2mul push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-# Procedure to evaluate numerators of all boundary constraints.
-#
-# All the 1 main and 0 auxiliary constraints are computed.
-# The result constriants are evaluated in natural order, and their values are pushed to the stack.
-# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+# Procedure to evaluate the boundary constraint numerator for the first row of the main trace
 #
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
-# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
-#        This procedure pushes 1 quadratic elements to the stack
-proc.compute_evaluate_boundary_constraints
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_main_first
     # boundary constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900201 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_main_first
 
 # Procedure to evaluate all integrity constraints.
 #
@@ -213,7 +209,7 @@ end # END PROC compute_evaluate_boundary_constraints
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.cache_periodic_polys
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add ext2add
     # Divisor of the transition constraint polynomial
@@ -227,8 +223,11 @@ end # END PROC evaluate_integrity_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add
+    exec.compute_boundary_constraints_main_first
+    # => [(first1, first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/pub_inputs/pub_inputs.masm
+++ b/air-script/tests/pub_inputs/pub_inputs.masm
@@ -52,6 +52,7 @@ proc.compute_integrity_constraint_divisor
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -71,25 +72,20 @@ end # END PROC compute_integrity_constraint_divisor
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
 # where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
-#        This procedure pushes 1 quadratic elements to the stack
-proc.compute_evaluate_integrity_constraints
+#        This procedure pushes 1 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-# Procedure to evaluate numerators of all boundary constraints.
-#
-# All the 8 main and 0 auxiliary constraints are computed.
-# The result constriants are evaluated in natural order, and their values are pushed to the stack.
-# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+# Procedure to evaluate the boundary constraint numerator for the first row of the main trace
 #
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
-# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
-#        This procedure pushes 8 quadratic elements to the stack
-proc.compute_evaluate_boundary_constraints
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_main_first
     # boundary constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop
     # Load public input stack_inputs pos 0 with final offset 8
@@ -114,6 +110,14 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294800005 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900202 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_boundary_constraints_main_first
+
+# Procedure to evaluate the boundary constraint numerator for the last row of the main trace
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_main_last
     # boundary constraint 4 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop
     # Load public input stack_outputs pos 0 with final offset 12
@@ -138,7 +142,7 @@ proc.compute_evaluate_boundary_constraints
     padw mem_loadw.4294800007 drop drop ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900204 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_main_last
 
 # Procedure to evaluate all integrity constraints.
 #
@@ -146,7 +150,7 @@ end # END PROC compute_evaluate_boundary_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add
     # Divisor of the transition constraint polynomial
@@ -160,8 +164,23 @@ end # END PROC evaluate_integrity_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add
+    exec.compute_boundary_constraints_main_last
+    # Accumulate the numerator for segment 0 LastRow
+    ext2add ext2add ext2add ext2add
+    # => [(last1, last0), ...]
+    # Compute the denominator for domain LastRow
+    padw mem_loadw.4294903304 drop drop mem_load.500000101 push.0 ext2sub
+    # Compute numerator/denominator for last row
+    ext2div
+    exec.compute_boundary_constraints_main_first
+    # Accumulate the numerator for segment 0 FirstRow
+    ext2add ext2add ext2add ext2add
+    # => [(first1, first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
+    # Add first and last row groups
+    ext2add
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/random_values/random_values_bindings.masm
+++ b/air-script/tests/random_values/random_values_bindings.masm
@@ -52,6 +52,7 @@ proc.compute_integrity_constraint_divisor
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -71,34 +72,37 @@ end # END PROC compute_integrity_constraint_divisor
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
 # where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
-#        This procedure pushes 1 quadratic elements to the stack
-proc.compute_evaluate_integrity_constraints
+#        This procedure pushes 1 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900072 drop drop padw mem_loadw.4294900157 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900151 drop drop ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-# Procedure to evaluate numerators of all boundary constraints.
-#
-# All the 0 main and 2 auxiliary constraints are computed.
-# The result constriants are evaluated in natural order, and their values are pushed to the stack.
-# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+# Procedure to evaluate the boundary constraint numerator for the first row of the auxiliary trace
 #
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
-# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
-#        This procedure pushes 2 quadratic elements to the stack
-proc.compute_evaluate_boundary_constraints
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_aux_first
     # boundary constraint 0 for aux
     padw mem_loadw.4294900072 movdn.3 movdn.3 drop drop padw mem_loadw.4294900152 drop drop padw mem_loadw.4294900151 drop drop ext2add padw mem_loadw.4294900157 drop drop ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 drop drop ext2mul
+end # END PROC compute_boundary_constraints_aux_first
+
+# Procedure to evaluate the boundary constraint numerator for the last row of the auxiliary trace
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_aux_last
     # boundary constraint 1 for aux
     padw mem_loadw.4294900072 movdn.3 movdn.3 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop padw mem_loadw.4294900157 drop drop ext2add padw mem_loadw.4294900155 drop drop ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900201 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_aux_last
 
 # Procedure to evaluate all integrity constraints.
 #
@@ -106,7 +110,7 @@ end # END PROC compute_evaluate_boundary_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add
     # Divisor of the transition constraint polynomial
@@ -120,8 +124,19 @@ end # END PROC evaluate_integrity_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add ext2add
+    exec.compute_boundary_constraints_aux_last
+    # => [(aux_last1, aux_last0), ...]
+    # Compute the denominator for domain LastRow
+    padw mem_loadw.4294903304 drop drop mem_load.500000101 push.0 ext2sub
+    # Compute numerator/denominator for last row
+    ext2div
+    exec.compute_boundary_constraints_aux_first
+    # => [(aux_first1, aux_first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
+    # Add first and last row groups
+    ext2add
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/random_values/random_values_simple.masm
+++ b/air-script/tests/random_values/random_values_simple.masm
@@ -52,6 +52,7 @@ proc.compute_integrity_constraint_divisor
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -71,34 +72,37 @@ end # END PROC compute_integrity_constraint_divisor
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
 # where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
-#        This procedure pushes 1 quadratic elements to the stack
-proc.compute_evaluate_integrity_constraints
+#        This procedure pushes 1 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for aux
     padw mem_loadw.4294900072 drop drop padw mem_loadw.4294900157 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900151 drop drop ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-# Procedure to evaluate numerators of all boundary constraints.
-#
-# All the 0 main and 2 auxiliary constraints are computed.
-# The result constriants are evaluated in natural order, and their values are pushed to the stack.
-# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+# Procedure to evaluate the boundary constraint numerator for the first row of the auxiliary trace
 #
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
-# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
-#        This procedure pushes 2 quadratic elements to the stack
-proc.compute_evaluate_boundary_constraints
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_aux_first
     # boundary constraint 0 for aux
     padw mem_loadw.4294900072 movdn.3 movdn.3 drop drop padw mem_loadw.4294900152 drop drop padw mem_loadw.4294900151 drop drop ext2add padw mem_loadw.4294900157 drop drop ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 drop drop ext2mul
+end # END PROC compute_boundary_constraints_aux_first
+
+# Procedure to evaluate the boundary constraint numerator for the last row of the auxiliary trace
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_aux_last
     # boundary constraint 1 for aux
     padw mem_loadw.4294900072 movdn.3 movdn.3 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop padw mem_loadw.4294900157 drop drop ext2add padw mem_loadw.4294900155 drop drop ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900201 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_aux_last
 
 # Procedure to evaluate all integrity constraints.
 #
@@ -106,7 +110,7 @@ end # END PROC compute_evaluate_boundary_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add
     # Divisor of the transition constraint polynomial
@@ -120,8 +124,19 @@ end # END PROC evaluate_integrity_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add ext2add
+    exec.compute_boundary_constraints_aux_last
+    # => [(aux_last1, aux_last0), ...]
+    # Compute the denominator for domain LastRow
+    padw mem_loadw.4294903304 drop drop mem_load.500000101 push.0 ext2sub
+    # Compute numerator/denominator for last row
+    ext2div
+    exec.compute_boundary_constraints_aux_first
+    # => [(aux_first1, aux_first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
+    # Add first and last row groups
+    ext2add
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/selectors/selectors.masm
+++ b/air-script/tests/selectors/selectors.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -16,16 +22,37 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
-    padw mem_loadw.500000100 drop drop
+    padw mem_loadw.500000100 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
     # => [zt_1, zt_0, ...]
     push.1 push.0 ext2sub
     # => [zt_1-1, zt_0-1, ...]
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -36,7 +63,17 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
-proc.compute_evaluate_integrity_constraints
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 3 main and 0 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 3 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900003 drop drop push.0 push.0 ext2sub padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul
     # Multiply by the composition coefficient
@@ -49,17 +86,27 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900003 drop drop push.1 push.0 ext2sub push.1 push.0 padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2sub push.1 push.0 padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul
     # Multiply by the composition coefficient
     padw mem_loadw.4294900201 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-proc.compute_evaluate_boundary_constraints
+# Procedure to evaluate the boundary constraint numerator for the first row of the main trace
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_main_first
     # boundary constraint 0 for main
     padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900201 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_main_first
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add
     # Divisor of the transition constraint polynomial
@@ -67,9 +114,17 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add
+    exec.compute_boundary_constraints_main_first
+    # => [(first1, first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/selectors/selectors_with_evaluators.masm
+++ b/air-script/tests/selectors/selectors_with_evaluators.masm
@@ -1,3 +1,9 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
 proc.cache_z_exp
     padw mem_loadw.4294903304 drop drop
     # => [z_1, z_0, ...]
@@ -16,16 +22,37 @@ proc.cache_z_exp
     dropw # Clean stack
 end # END PROC cache_z_exp
 
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
 proc.compute_integrity_constraint_divisor
-    padw mem_loadw.500000100 drop drop
+    padw mem_loadw.500000100 drop drop # load z^trace_len
     # Comments below use zt = `z^trace_len`
     # => [zt_1, zt_0, ...]
     push.1 push.0 ext2sub
     # => [zt_1-1, zt_0-1, ...]
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -36,30 +63,50 @@ proc.compute_integrity_constraint_divisor
     # => [divisor_1, divisor_0, ...]
 end # END PROC compute_integrity_constraint_divisor
 
-proc.compute_evaluate_integrity_constraints
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 3 main and 0 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 3 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900003 drop drop push.0 push.0 ext2sub padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 movdn.3 movdn.3 drop drop ext2mul
     # integrity constraint 1 for main
-    padw mem_loadw.4294900003 drop drop padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2mul ext2mul
+    padw mem_loadw.4294900003 drop drop padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2mul ext2mul ext2mul
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 drop drop ext2mul
     # integrity constraint 2 for main
     padw mem_loadw.4294900003 drop drop push.1 push.0 ext2sub push.1 push.0 padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2sub push.1 push.0 padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul
     # Multiply by the composition coefficient
     padw mem_loadw.4294900201 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-proc.compute_evaluate_boundary_constraints
+# Procedure to evaluate the boundary constraint numerator for the first row of the main trace
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_main_first
     # boundary constraint 0 for main
     padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900201 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_main_first
 
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add
     # Divisor of the transition constraint polynomial
@@ -67,9 +114,17 @@ proc.evaluate_integrity_constraints
     ext2div # divide the numerator by the divisor
 end # END PROC evaluate_integrity_constraints
 
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add
+    exec.compute_boundary_constraints_main_first
+    # => [(first1, first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/system/system.masm
+++ b/air-script/tests/system/system.masm
@@ -52,6 +52,7 @@ proc.compute_integrity_constraint_divisor
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -71,30 +72,25 @@ end # END PROC compute_integrity_constraint_divisor
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
 # where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
-#        This procedure pushes 1 quadratic elements to the stack
-proc.compute_evaluate_integrity_constraints
+#        This procedure pushes 1 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 drop drop padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-# Procedure to evaluate numerators of all boundary constraints.
-#
-# All the 1 main and 0 auxiliary constraints are computed.
-# The result constriants are evaluated in natural order, and their values are pushed to the stack.
-# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+# Procedure to evaluate the boundary constraint numerator for the first row of the main trace
 #
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
-# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
-#        This procedure pushes 1 quadratic elements to the stack
-proc.compute_evaluate_boundary_constraints
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_main_first
     # boundary constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_main_first
 
 # Procedure to evaluate all integrity constraints.
 #
@@ -102,7 +98,7 @@ end # END PROC compute_evaluate_boundary_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add
     # Divisor of the transition constraint polynomial
@@ -116,8 +112,11 @@ end # END PROC evaluate_integrity_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add
+    exec.compute_boundary_constraints_main_first
+    # => [(first1, first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/trace_col_groups/trace_col_groups.masm
+++ b/air-script/tests/trace_col_groups/trace_col_groups.masm
@@ -52,6 +52,7 @@ proc.compute_integrity_constraint_divisor
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -71,8 +72,8 @@ end # END PROC compute_integrity_constraint_divisor
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
 # where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
-#        This procedure pushes 2 quadratic elements to the stack
-proc.compute_evaluate_integrity_constraints
+#        This procedure pushes 2 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900002 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop push.1 push.0 ext2add ext2sub
     # Multiply by the composition coefficient
@@ -81,24 +82,19 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900001 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-# Procedure to evaluate numerators of all boundary constraints.
-#
-# All the 0 main and 1 auxiliary constraints are computed.
-# The result constriants are evaluated in natural order, and their values are pushed to the stack.
-# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+# Procedure to evaluate the boundary constraint numerator for the first row of the auxiliary trace
 #
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
-# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
-#        This procedure pushes 1 quadratic elements to the stack
-proc.compute_evaluate_boundary_constraints
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_aux_first
     # boundary constraint 0 for aux
     padw mem_loadw.4294900076 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900201 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_aux_first
 
 # Procedure to evaluate all integrity constraints.
 #
@@ -106,7 +102,7 @@ end # END PROC compute_evaluate_boundary_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add ext2add
     # Divisor of the transition constraint polynomial
@@ -120,8 +116,11 @@ end # END PROC evaluate_integrity_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add
+    exec.compute_boundary_constraints_aux_first
+    # => [(aux_first1, aux_first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
 end # END PROC evaluate_boundary_constraints
 

--- a/air-script/tests/variables/variables.masm
+++ b/air-script/tests/variables/variables.masm
@@ -120,6 +120,7 @@ proc.compute_integrity_constraint_divisor
     # => [z_1, z_0, zt_1-1, zt_0-1, ...]
     exec.get_exemptions_points
     # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
     dup.3 dup.3 movup.3 push.0 ext2sub
     # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
     movup.4 movup.4 movup.4 push.0 ext2sub
@@ -139,8 +140,8 @@ end # END PROC compute_integrity_constraint_divisor
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
 # where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
-#        This procedure pushes 5 quadratic elements to the stack
-proc.compute_evaluate_integrity_constraints
+#        This procedure pushes 5 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
     # integrity constraint 0 for main
     padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
@@ -175,28 +176,31 @@ proc.compute_evaluate_integrity_constraints
     padw mem_loadw.4294900072 drop drop padw mem_loadw.4294900072 movdn.3 movdn.3 drop drop padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop ext2add ext2mul ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900202 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_integrity_constraints
+end # END PROC compute_integrity_constraints
 
-# Procedure to evaluate numerators of all boundary constraints.
-#
-# All the 2 main and 0 auxiliary constraints are computed.
-# The result constriants are evaluated in natural order, and their values are pushed to the stack.
-# The natural order is defined by `(trace, row, column)`, and the final evaluation is in stack-order.
+# Procedure to evaluate the boundary constraint numerator for the first row of the main trace
 #
 # Input: [...]
 # Output: [(r_1, r_0)*, ...]
-# where: (r_1, r_0) is the quadratic extension element resulting from the boundary constraint evaluation.
-#        This procedure pushes 2 quadratic elements to the stack
-proc.compute_evaluate_boundary_constraints
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_main_first
     # boundary constraint 0 for main
     padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900202 drop drop ext2mul
+end # END PROC compute_boundary_constraints_main_first
+
+# Procedure to evaluate the boundary constraint numerator for the last row of the main trace
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_main_last
     # boundary constraint 1 for main
     padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop push.1 push.0 ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900203 movdn.3 movdn.3 drop drop ext2mul
-end # END PROC compute_evaluate_boundary_constraints
+end # END PROC compute_boundary_constraints_main_last
 
 # Procedure to evaluate all integrity constraints.
 #
@@ -205,7 +209,7 @@ end # END PROC compute_evaluate_boundary_constraints
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_integrity_constraints
     exec.cache_periodic_polys
-    exec.compute_evaluate_integrity_constraints
+    exec.compute_integrity_constraints
     # Numerator of the transition constraint polynomial
     ext2add ext2add ext2add ext2add ext2add
     # Divisor of the transition constraint polynomial
@@ -219,8 +223,19 @@ end # END PROC evaluate_integrity_constraints
 # Output: [(r_1, r_0), ...]
 # Where: (r_1, r_0) is the final result with the divisor applied
 proc.evaluate_boundary_constraints
-    exec.compute_evaluate_boundary_constraints
-    # Accumulate the numerator of the constraint polynomial
-    ext2add ext2add
+    exec.compute_boundary_constraints_main_last
+    # => [(last1, last0), ...]
+    # Compute the denominator for domain LastRow
+    padw mem_loadw.4294903304 drop drop mem_load.500000101 push.0 ext2sub
+    # Compute numerator/denominator for last row
+    ext2div
+    exec.compute_boundary_constraints_main_first
+    # => [(first1, first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
+    # Add first and last row groups
+    ext2add
 end # END PROC evaluate_boundary_constraints
 

--- a/codegen/masm/src/config.rs
+++ b/codegen/masm/src/config.rs
@@ -56,6 +56,10 @@ pub struct CodegenConfig {
     ///
     /// Note: `g_trace = g_lde^{blowup}`
     pub trace_domain_generator_address: u32,
+
+    /// Address to cache the point `g^{trace_len-2}`, which is used by the divisor of the boundary
+    /// constraints.
+    pub exemption_two_address: u32,
 }
 
 impl Default for CodegenConfig {
@@ -72,6 +76,7 @@ impl Default for CodegenConfig {
             periodic_values_address: constants::PERIODIC_VALUES_ADDRESS,
             z_exp_address: constants::Z_EXP_ADDRESS,
             trace_domain_generator_address: constants::TRACE_DOMAIN_GENERATOR_ADDRESS,
+            exemption_two_address: constants::EXEMPTION_TWO_ADDRESS,
         }
     }
 }

--- a/codegen/masm/src/constants.rs
+++ b/codegen/masm/src/constants.rs
@@ -31,3 +31,4 @@ pub const TRACE_DOMAIN_GENERATOR_ADDRESS: u32 = 4294799999;
 // CODEGEN CONSTANTS ------------------------------------------------------------------------------
 pub const PERIODIC_VALUES_ADDRESS: u32 = 500000000;
 pub const Z_EXP_ADDRESS: u32 = 500000100;
+pub const EXEMPTION_TWO_ADDRESS: u32 = 500000101;

--- a/codegen/masm/src/lib.rs
+++ b/codegen/masm/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod codegen;
 mod config;
 pub mod constants;
+mod utils;
 pub mod visitor;
 mod writer;
 

--- a/codegen/masm/src/utils.rs
+++ b/codegen/masm/src/utils.rs
@@ -1,0 +1,12 @@
+use air_ir::{ConstraintDomain, ConstraintRoot};
+
+/// Utility to order contraints roots w.r.t. their natural order.
+pub fn contraint_root_domain(boundary: &&ConstraintRoot) -> u8 {
+    // TODO: Sort by the column index. Issue #315
+    match boundary.domain() {
+        ConstraintDomain::FirstRow => 0,
+        ConstraintDomain::LastRow => 1,
+        ConstraintDomain::EveryRow => panic!("EveryRow is not supported"),
+        ConstraintDomain::EveryFrame(_) => panic!("EveryFrame is not supported"),
+    }
+}

--- a/codegen/masm/src/writer.rs
+++ b/codegen/masm/src/writer.rs
@@ -220,6 +220,10 @@ impl Writer {
         self.ins(format!("mem_loadw.{}", address));
     }
 
+    pub fn mem_store(&mut self, address: u32) {
+        self.ins(format!("mem_store.{}", address));
+    }
+
     pub fn mem_storew(&mut self, address: u32) {
         self.ins(format!("mem_storew.{}", address));
     }

--- a/codegen/masm/tests/test_aux.rs
+++ b/codegen/masm/tests/test_aux.rs
@@ -64,7 +64,7 @@ fn test_simple_aux() {
         ],
         trace_len,
         z,
-        &["compute_evaluate_integrity_constraints"],
+        &["compute_integrity_constraints"],
     );
     let program = Assembler::default().compile(code).unwrap();
 

--- a/codegen/masm/tests/test_basic_arithmetic.rs
+++ b/codegen/masm/tests/test_basic_arithmetic.rs
@@ -63,7 +63,7 @@ fn test_simple_arithmetic() {
         ],
         trace_len,
         z,
-        &["compute_evaluate_integrity_constraints"],
+        &["compute_integrity_constraints"],
     );
     let program = Assembler::default().compile(code).unwrap();
 
@@ -150,7 +150,7 @@ fn test_exp() {
         ],
         trace_len,
         z,
-        &["compute_evaluate_integrity_constraints"],
+        &["compute_integrity_constraints"],
     );
     let program = Assembler::default().compile(code).unwrap();
 
@@ -238,7 +238,7 @@ fn test_long_trace() {
         ],
         trace_len,
         z,
-        &["compute_evaluate_integrity_constraints"],
+        &["compute_integrity_constraints"],
     );
     let program = Assembler::default().compile(code).unwrap();
 
@@ -315,7 +315,7 @@ fn test_vector() {
         ],
         trace_len,
         z,
-        &["compute_evaluate_integrity_constraints"],
+        &["compute_integrity_constraints"],
     );
     let program = Assembler::default().compile(code).unwrap();
 
@@ -390,7 +390,7 @@ fn test_multiple_rows() {
         ],
         trace_len,
         z,
-        &["compute_evaluate_integrity_constraints"],
+        &["compute_integrity_constraints"],
     );
     let program = Assembler::default().compile(code).unwrap();
 

--- a/codegen/masm/tests/test_boundary.rs
+++ b/codegen/masm/tests/test_boundary.rs
@@ -63,7 +63,13 @@ fn test_simple_boundary() {
         ],
         trace_len,
         z,
-        &["compute_evaluate_boundary_constraints"],
+        &[
+            "compute_boundary_constraints_main_first",
+            "compute_boundary_constraints_main_last",
+            // there are no auxiliary boundary constraints on this AIR defnition
+            // "compute_boundary_constraints_aux_first",
+            // "compute_boundary_constraints_aux_last",
+        ],
     );
     let program = Assembler::default().compile(code).unwrap();
 
@@ -205,7 +211,12 @@ fn test_complex_boundary() {
         ],
         trace_len,
         z,
-        &["compute_evaluate_boundary_constraints"],
+        &[
+            "compute_boundary_constraints_main_first",
+            "compute_boundary_constraints_main_last",
+            "compute_boundary_constraints_aux_first",
+            "compute_boundary_constraints_aux_last",
+        ],
     );
     let program = Assembler::default().compile(code).unwrap();
 

--- a/codegen/masm/tests/test_constants.rs
+++ b/codegen/masm/tests/test_constants.rs
@@ -70,7 +70,7 @@ fn test_constants() {
         ],
         trace_len,
         z,
-        &["compute_evaluate_integrity_constraints"],
+        &["compute_integrity_constraints"],
     );
     let program = Assembler::default().compile(code).unwrap();
 

--- a/codegen/masm/tests/test_divisor.rs
+++ b/codegen/masm/tests/test_divisor.rs
@@ -4,13 +4,13 @@ use miden_processor::{
     math::{Felt, FieldElement},
     AdviceInputs, Kernel, MemAdviceProvider, Process, QuadExtension, StackInputs,
 };
-use winter_prover::ConstraintDivisor;
+use winter_prover::{Assertion, ConstraintDivisor};
 
 mod utils;
 use utils::{codegen, test_code, to_stack_order, Data};
 
-static SIMPLE_AIR: &str = "
-def SimpleAux
+static SIMPLE_INTEGRITY_AIR: &str = "
+def SimpleIntegrityAux
 
 trace_columns:
     main: [a]
@@ -27,7 +27,7 @@ integrity_constraints:
 
 #[test]
 fn test_integrity_divisor() {
-    let code = codegen(SIMPLE_AIR);
+    let code = codegen(SIMPLE_INTEGRITY_AIR);
 
     let exemptions = 2;
     let one = QuadExtension::new(Felt::new(1), Felt::ZERO);
@@ -47,7 +47,7 @@ fn test_integrity_divisor() {
                     descriptor: "main_trace",
                 },
                 Data {
-                    data: to_stack_order(&vec![one; 6]),
+                    data: to_stack_order(&vec![one; 2]),
                     address: constants::COMPOSITION_COEF_ADDRESS,
                     descriptor: "composition_coefficients",
                 },
@@ -74,6 +74,237 @@ fn test_integrity_divisor() {
         #[rustfmt::skip]
         let expected = to_stack_order(&[
             divisor,
+        ]);
+
+        assert!(
+            result_stack
+                .iter()
+                .zip(expected.iter())
+                .all(|(l, r)| l == r),
+            "results don't match trace_len={} power={} result={:?} expected={:?}",
+            trace_len,
+            power,
+            result_stack,
+            expected,
+        );
+    }
+}
+
+static SIMPLE_BOUNDARY_AIR: &str = "
+def SimpleBoundaryAux
+
+trace_columns:
+    main: [a]
+    aux: [b]
+
+public_inputs:
+    stack_inputs: [1]
+
+boundary_constraints:
+    enf a.first = 0
+    enf a.last = 0
+    enf b.first = 0
+    enf b.last = 0
+
+integrity_constraints:
+    enf a = 0
+";
+
+#[test]
+fn test_boundary_divisor() {
+    let code = codegen(SIMPLE_BOUNDARY_AIR);
+
+    let exemptions = 2;
+    let one = QuadExtension::new(Felt::new(1), Felt::ZERO);
+    let a = QuadExtension::new(Felt::new(13), Felt::ZERO);
+    let a_prime = a;
+    let a_column = 0;
+    let b = QuadExtension::new(Felt::new(17), Felt::ZERO);
+    let b_prime = b;
+    let b_column = 1;
+    let z = QuadExtension::new(Felt::new(19), Felt::new(23));
+
+    for power in 3..32 {
+        let trace_len = 2u64.pow(power);
+        let first_step = 0;
+        let last_step: usize = (trace_len - exemptions).try_into().unwrap();
+
+        let code = test_code(
+            code.clone(),
+            vec![
+                Data {
+                    data: to_stack_order(&[a, a_prime]),
+                    address: constants::OOD_FRAME_ADDRESS,
+                    descriptor: "main_trace",
+                },
+                Data {
+                    data: to_stack_order(&[b, b_prime]),
+                    address: constants::OOD_AUX_FRAME_ADDRESS,
+                    descriptor: "aux_trace",
+                },
+                Data {
+                    data: to_stack_order(&vec![one; 5]),
+                    address: constants::COMPOSITION_COEF_ADDRESS,
+                    descriptor: "composition_coefficients",
+                },
+            ],
+            trace_len,
+            z,
+            &[
+                "cache_z_exp",
+                // The exemption point is cached as part of the integrity constraint computation
+                "compute_integrity_constraint_divisor",
+                "evaluate_boundary_constraints",
+            ],
+        );
+        let program = Assembler::default().compile(code).unwrap();
+
+        let a_first_assertion = Assertion::<Felt>::single(a_column, first_step, Felt::new(3));
+        let a_last_assertion = Assertion::<Felt>::single(a_column, last_step, Felt::new(5));
+        let b_first_assertion = Assertion::<Felt>::single(b_column, first_step, Felt::new(7));
+        let b_last_assertion = Assertion::<Felt>::single(b_column, last_step, Felt::new(11));
+
+        let mut result = QuadExtension::ZERO;
+        for (assertion, numerator) in [
+            // Main
+            (a_first_assertion, a),
+            (a_last_assertion, a),
+            // Aux
+            (b_first_assertion, b),
+            (b_last_assertion, b),
+        ] {
+            let divisor = ConstraintDivisor::<Felt>::from_assertion(
+                &assertion,
+                trace_len.try_into().unwrap(),
+            );
+            result += numerator / divisor.evaluate_at(z);
+        }
+
+        let mut process: Process<MemAdviceProvider> = Process::new(
+            Kernel::new(&[]),
+            StackInputs::new(vec![]),
+            AdviceInputs::default().into(),
+        );
+        let program_outputs = process.execute(&program).expect("execution failed");
+        let result_stack = program_outputs.stack();
+
+        // results are in stack-order
+        #[rustfmt::skip]
+        let expected = to_stack_order(&[
+            result,
+        ]);
+
+        assert!(
+            result_stack
+                .iter()
+                .zip(expected.iter())
+                .all(|(l, r)| l == r),
+            "results don't match trace_len={} power={} result={:?} expected={:?}",
+            trace_len,
+            power,
+            result_stack,
+            expected,
+        );
+    }
+}
+
+static MIXED_BOUNDARY_AIR: &str = "
+def MixedBoundaryAux
+
+trace_columns:
+    main: [a]
+    aux: [b]
+
+public_inputs:
+    stack_inputs: [1]
+
+boundary_constraints:
+    enf a.first = 3
+    enf b.last = 5
+
+integrity_constraints:
+    enf a = 0
+";
+
+#[test]
+fn test_mixed_boundary_divisor() {
+    let code = codegen(MIXED_BOUNDARY_AIR);
+
+    let exemptions = 2;
+    let one = QuadExtension::new(Felt::new(1), Felt::ZERO);
+    let a = QuadExtension::new(Felt::new(13), Felt::ZERO);
+    let a_prime = a;
+    let a_column = 0;
+    let b = QuadExtension::new(Felt::new(17), Felt::ZERO);
+    let b_prime = b;
+    let b_column = 1;
+    let z = QuadExtension::new(Felt::new(19), Felt::new(23));
+
+    for power in 3..32 {
+        let trace_len = 2u64.pow(power);
+        let first_step = 0;
+        let last_step: usize = (trace_len - exemptions).try_into().unwrap();
+
+        let code = test_code(
+            code.clone(),
+            vec![
+                Data {
+                    data: to_stack_order(&[a, a_prime]),
+                    address: constants::OOD_FRAME_ADDRESS,
+                    descriptor: "main_trace",
+                },
+                Data {
+                    data: to_stack_order(&[b, b_prime]),
+                    address: constants::OOD_AUX_FRAME_ADDRESS,
+                    descriptor: "aux_trace",
+                },
+                Data {
+                    data: to_stack_order(&vec![one; 5]),
+                    address: constants::COMPOSITION_COEF_ADDRESS,
+                    descriptor: "composition_coefficients",
+                },
+            ],
+            trace_len,
+            z,
+            &[
+                "cache_z_exp",
+                // The exemption point is cached as part of the integrity constraint computation
+                "compute_integrity_constraint_divisor",
+                "evaluate_boundary_constraints",
+            ],
+        );
+        let program = Assembler::default().compile(code).unwrap();
+
+        let a_first_assertion = Assertion::<Felt>::single(a_column, first_step, Felt::new(3));
+        let b_last_assertion = Assertion::<Felt>::single(b_column, last_step, Felt::new(5));
+
+        let mut result = QuadExtension::ZERO;
+        for (assertion, numerator) in [
+            // Main
+            (a_first_assertion, a - QuadExtension::from(Felt::new(3))),
+            // Aux
+            (b_last_assertion, b - QuadExtension::from(Felt::new(5))),
+        ] {
+            let divisor = ConstraintDivisor::<Felt>::from_assertion(
+                &assertion,
+                trace_len.try_into().unwrap(),
+            );
+            let group_result = numerator / divisor.evaluate_at(z);
+            result += group_result;
+        }
+
+        let mut process: Process<MemAdviceProvider> = Process::new(
+            Kernel::new(&[]),
+            StackInputs::new(vec![]),
+            AdviceInputs::default().into(),
+        );
+        let program_outputs = process.execute(&program).expect("execution failed");
+        let result_stack = program_outputs.stack();
+
+        // results are in stack-order
+        #[rustfmt::skip]
+        let expected = to_stack_order(&[
+            result,
         ]);
 
         assert!(

--- a/codegen/masm/tests/test_periodic.rs
+++ b/codegen/masm/tests/test_periodic.rs
@@ -61,7 +61,7 @@ fn test_simple_periodic() {
         &[
             "cache_z_exp",
             "cache_periodic_polys",
-            "compute_evaluate_integrity_constraints",
+            "compute_integrity_constraints",
         ],
     );
     let program = Assembler::default().compile(code).unwrap();
@@ -152,7 +152,7 @@ fn test_multiple_periodic() {
         &[
             "cache_z_exp",
             "cache_periodic_polys",
-            "compute_evaluate_integrity_constraints",
+            "compute_integrity_constraints",
         ],
     );
     let program = Assembler::default().compile(code).unwrap();


### PR DESCRIPTION
- The procedure to evalute the boundary constraints has been split, since different boundary constraints groups have different divisors.
- The divisor is applied and the points are accumulated