### PR TITLE
feat: reintroduce match constraint syntax

### DIFF
--- a/air-script/tests/codegen/winterfell.rs
+++ b/air-script/tests/codegen/winterfell.rs
@@ -153,7 +153,6 @@ fn list_folding() {
 }
 
 #[test]
-#[ignore]
 fn selectors() {
     let generated_air = Test::new("tests/selectors/selectors.air".to_string())
         .transpile(Target::Winterfell)

--- a/air-script/tests/selectors/selectors.air
+++ b/air-script/tests/selectors/selectors.air
@@ -11,6 +11,6 @@ boundary_constraints:
 
 integrity_constraints:
     enf clk' = 0 when s[0] & !s[1]
-    match enf:
-        clk' = clk when s[0] & s[1] & s[2]
-        clk' = 1 when !s[1] & !s[2]
+    enf match:
+        case s[0] & s[1] & s[2]: clk' = clk
+        case !s[1] & !s[2]: clk' = 1

--- a/air-script/tests/selectors/selectors_with_evaluators.air
+++ b/air-script/tests/selectors/selectors_with_evaluators.air
@@ -20,6 +20,6 @@ boundary_constraints:
 
 integrity_constraints:
     enf next_is_zero([clk]) when s[0] & !s[1]
-    match enf:
-        is_unchanged([clk, s[0]]) when s[1] & s[2]
-        next_is_one([clk]) when !s[1] & !s[2]
+    enf match:
+        case s[1] & s[2]: is_unchanged([clk, s[0]])
+        case !s[1] & !s[2]: next_is_one([clk])

--- a/ir/src/tests/selectors.rs
+++ b/ir/src/tests/selectors.rs
@@ -39,7 +39,6 @@ fn chained_selectors() {
 }
 
 #[test]
-#[ignore]
 fn multiconstraint_selectors() {
     let source = "
     def test
@@ -54,9 +53,9 @@ fn multiconstraint_selectors() {
     
     integrity_constraints:
         enf clk' = 0 when s[0] & !s[1]
-        match enf:
-            clk' = clk when s[0] & s[1]
-            clk' = 1 when !s[0] & !s[1]";
+        enf match:
+            case s[0] & s[1]: clk' = clk
+            case !s[0] & !s[1]: clk' = 1";
 
     assert!(compile(source).is_ok());
 }
@@ -128,7 +127,6 @@ fn selector_with_evaluator_call() {
 }
 
 #[test]
-#[ignore]
 fn selectors_inside_match() {
     let source = "
     def test
@@ -152,9 +150,9 @@ fn selectors_inside_match() {
 
     integrity_constraints:
         enf next_is_zero([clk]) when s[0] & !s[1]
-        match enf:
-            is_unchanged([clk, s[0]]) when s[1] & s[2]
-            next_is_one([clk]) when !s[1] & !s[2]";
+        enf match:
+            case s[1] & s[2]: is_unchanged([clk, s[0]])
+            case !s[1] & !s[2]: next_is_one([clk])";
 
     assert!(compile(source).is_ok());
 }

--- a/parser/src/lexer/mod.rs
+++ b/parser/src/lexer/mod.rs
@@ -137,6 +137,8 @@ pub enum Token {
     // --------------------------------------------------------------------------------------------
     /// Keyword to signify that a constraint needs to be enforced
     Enf,
+    Match,
+    Case,
     When,
 
     // PUNCTUATION
@@ -182,6 +184,8 @@ impl Token {
             "for" => Self::For,
             "in" => Self::In,
             "enf" => Self::Enf,
+            "match" => Self::Match,
+            "case" => Self::Case,
             "when" => Self::When,
             other => Self::Ident(Symbol::intern(other)),
         }
@@ -250,6 +254,8 @@ impl fmt::Display for Token {
             Self::For => write!(f, "for"),
             Self::In => write!(f, "in"),
             Self::Enf => write!(f, "enf"),
+            Self::Match => write!(f, "match"),
+            Self::Case => write!(f, "case"),
             Self::When => write!(f, "when"),
             Self::Quote => write!(f, "'"),
             Self::Colon => write!(f, ":"),

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -279,19 +279,14 @@ IntegrityConstraints: Span<Vec<Statement>> = {
 // STATEMENTS
 // ================================================================================================
 
-Statement: Statement = {
-    <Let> => Statement::Let(<>),
-    ConstraintStatement,
-}
-
 StatementBlock: Vec<Statement> = {
     <Let> => vec![Statement::Let(<>)],
-    <stmts:ConstraintStatement+> <last:Let> => {
+    <stmts:ConstraintStatements> <last:Let> => {
         let mut stmts = stmts;
         stmts.push(Statement::Let(last));
         stmts
     },
-    <ConstraintStatement+>,
+    <ConstraintStatements>,
 }
 
 Let: Let = {
@@ -299,8 +294,25 @@ Let: Let = {
         => Let::new(span!(l, r), name, value, body)
 }
 
-ConstraintStatement: Statement = {
-    "enf" <ConstraintExpr> => <>,
+ConstraintStatements: Vec<Statement> = {
+    <stmts:ConstraintStatement+> => {
+        stmts.into_iter().flatten().collect::<Vec<_>>()
+    }
+}
+
+ConstraintStatement: Vec<Statement> = {
+    "enf" "match" ":" <MatchArm+> => <>,
+    "enf" <ConstraintExpr> => vec![<>],
+}
+
+MatchArm: Statement = {
+    <l:@L> "case" <selector:ScalarExpr> ":" <constraint:ScalarConstraintExpr> <r:@R> => {
+        let generated_name = format!("%{}", *next_var);
+        *next_var += 1;
+        let generated_binding = Identifier::new(SourceSpan::UNKNOWN, Symbol::intern(generated_name));
+        let context = vec![(generated_binding, Expr::Range(Span::new(SourceSpan::UNKNOWN, 0..1)))];
+        Statement::EnforceAll(ListComprehension::new(span!(l, r), constraint, context, Some(selector)))
+    }
 }
 
 // This grammar rules handles two types of constraints: simple and comprehension constraints.
@@ -580,6 +592,8 @@ extern {
         "integrity_constraints" => Token::IntegrityConstraints,
         "ev" => Token::Ev,
         "enf" => Token::Enf,
+        "match" => Token::Match,
+        "case" => Token::Case,
         "when" => Token::When,
         "'" => Token::Quote,
         "=" => Token::Equal,


### PR DESCRIPTION
This PR brings back the syntax for match constraints, modified to remove grammar ambiguities discovered with the previous syntax.

An example of the syntax is shown below:

```airscript
integrity_constraints:
    enf match:
        case s[0] & s[1]: clk' = clk
        case !s[0] & !s[1]: clk' = 1
```

The choice of `enf match` vs `match enf` is intentional, and is intended to make the declaration of a constraint uniform, i.e. a constraint statement always begins with `enf` whether it is a simple constraint, a constraint comprehension, or a match constraint.

The implementation of this syntax simply compiles to a flat set of constraints for now, as if every branch of the match was a separate constraint conditioned on the selector for the match. This is handled directly in the parser for now, since we don't actually do anything meaningful with match constraints yet. Once we do, we'll update the parser accordingly and introduce distinct AST nodes to represent the construct.

---

I think we should still plan on eventually switching to block syntax for all "blocks" in the language, which was also discussed alongside the match syntax changes, but we were able to implement the latter without the former, so it is strictly speaking not necessary, but would make the grammar more regular (beneficial for any future syntax changes) and would improve the clarity of the language (IMO). In any case, that's a topic for a different discussion, but I wanted to make a note about it here for future reference.
