### PR TITLE
chore: enable resolver 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ members = [
   "codegen/masm",
   "codegen/winterfell",
 ]
+resolver = "2"


### PR DESCRIPTION
Doing this preemptively following the changes on miden-vm.