### PR TITLE
add constraint evaluation export

### DIFF
--- a/air-script/tests/aux_trace/aux_trace.masm
+++ b/air-script/tests/aux_trace/aux_trace.masm
@@ -190,3 +190,14 @@ proc.evaluate_boundary_constraints
     ext2add
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/binary/binary.masm
+++ b/air-script/tests/binary/binary.masm
@@ -152,3 +152,14 @@ proc.evaluate_boundary_constraints
     ext2div
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/bitwise/bitwise.masm
+++ b/air-script/tests/bitwise/bitwise.masm
@@ -423,3 +423,14 @@ proc.evaluate_boundary_constraints
     ext2div
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/constants/constants.masm
+++ b/air-script/tests/constants/constants.masm
@@ -186,3 +186,14 @@ proc.evaluate_boundary_constraints
     ext2add
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
+++ b/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
@@ -132,3 +132,14 @@ proc.evaluate_boundary_constraints
     ext2div
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/constraint_comprehension/constraint_comprehension.masm
+++ b/air-script/tests/constraint_comprehension/constraint_comprehension.masm
@@ -132,3 +132,14 @@ proc.evaluate_boundary_constraints
     ext2div
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/evaluators/evaluators.masm
+++ b/air-script/tests/evaluators/evaluators.masm
@@ -200,3 +200,14 @@ proc.evaluate_boundary_constraints
     ext2div
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/indexed_trace_access/indexed_trace_access.masm
+++ b/air-script/tests/indexed_trace_access/indexed_trace_access.masm
@@ -124,3 +124,14 @@ proc.evaluate_boundary_constraints
     ext2div
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/list_comprehension/list_comprehension.masm
+++ b/air-script/tests/list_comprehension/list_comprehension.masm
@@ -136,3 +136,14 @@ proc.evaluate_boundary_constraints
     ext2div
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/list_folding/list_folding.masm
+++ b/air-script/tests/list_folding/list_folding.masm
@@ -132,3 +132,14 @@ proc.evaluate_boundary_constraints
     ext2div
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/periodic_columns/periodic_columns.masm
+++ b/air-script/tests/periodic_columns/periodic_columns.masm
@@ -231,3 +231,14 @@ proc.evaluate_boundary_constraints
     ext2div
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/pub_inputs/pub_inputs.masm
+++ b/air-script/tests/pub_inputs/pub_inputs.masm
@@ -184,3 +184,14 @@ proc.evaluate_boundary_constraints
     ext2add
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/random_values/random_values_bindings.masm
+++ b/air-script/tests/random_values/random_values_bindings.masm
@@ -140,3 +140,14 @@ proc.evaluate_boundary_constraints
     ext2add
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/random_values/random_values_simple.masm
+++ b/air-script/tests/random_values/random_values_simple.masm
@@ -140,3 +140,14 @@ proc.evaluate_boundary_constraints
     ext2add
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/selectors/selectors.masm
+++ b/air-script/tests/selectors/selectors.masm
@@ -128,3 +128,14 @@ proc.evaluate_boundary_constraints
     ext2div
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/selectors/selectors_with_evaluators.masm
+++ b/air-script/tests/selectors/selectors_with_evaluators.masm
@@ -128,3 +128,14 @@ proc.evaluate_boundary_constraints
     ext2div
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/system/system.masm
+++ b/air-script/tests/system/system.masm
@@ -120,3 +120,14 @@ proc.evaluate_boundary_constraints
     ext2div
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/trace_col_groups/trace_col_groups.masm
+++ b/air-script/tests/trace_col_groups/trace_col_groups.masm
@@ -124,3 +124,14 @@ proc.evaluate_boundary_constraints
     ext2div
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/variables/variables.masm
+++ b/air-script/tests/variables/variables.masm
@@ -239,3 +239,14 @@ proc.evaluate_boundary_constraints
     ext2add
 end # END PROC evaluate_boundary_constraints
 
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/codegen/masm/src/writer.rs
+++ b/codegen/masm/src/writer.rs
@@ -131,6 +131,20 @@ impl Writer {
         self.new_line();
     }
 
+    /// Starts the codegen for an exported procedure.
+    pub fn export(&mut self, name: impl Into<Cow<'static, str>>) {
+        assert!(
+            self.procedure.is_none(),
+            "Can not nest procedures, currently writing {:?}",
+            self.procedure
+        );
+
+        let name = name.into();
+        self.code.push_str(&format!("export.{}", name));
+        self.procedure = Some(name);
+        self.new_line();
+    }
+
     pub fn exec(&mut self, name: impl Into<Cow<'static, str>>) {
         self.maybe_new_line_and_indent();
         self.code.push_str(&format!("exec.{}", name.into()));

--- a/codegen/masm/tests/utils.rs
+++ b/codegen/masm/tests/utils.rs
@@ -36,7 +36,9 @@ pub fn codegen(source: &str) -> String {
         .expect("lowering failed");
 
     let codegen = air_codegen_masm::CodeGenerator::default();
-    codegen.generate(&air).expect("codegen failed")
+    let code = codegen.generate(&air).expect("codegen failed");
+
+    code.replace("export", "proc")
 }
 
 pub fn to_stack_order(values: &[QuadExtension<Felt>]) -> Vec<u64> {


### PR DESCRIPTION
~Review/Merge after https://github.com/0xPolygonMiden/air-script/pull/326~

This adds an export that performs the evaluation of both transition and boundary constraints, to be called by the stark verifier in the Miden's stdlib.