### PR TITLE
Tidy up masm codegen

### DIFF
--- a/air-script/tests/aux_trace/aux_trace.masm
+++ b/air-script/tests/aux_trace/aux_trace.masm
@@ -13,9 +13,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/aux_trace/aux_trace.masm
+++ b/air-script/tests/aux_trace/aux_trace.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Exponentiate z trace_len times
     mem_load.4294903307 neg
@@ -169,7 +169,8 @@ proc.evaluate_boundary_constraints
     ext2add ext2add
     # => [(aux_last1, aux_last0), ...]
     # Compute the denominator for domain LastRow
-    padw mem_loadw.4294903304 drop drop mem_load.500000101 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    mem_load.500000101 push.0 ext2sub
     # Compute numerator/denominator for last row
     ext2div
     exec.compute_boundary_constraints_aux_first
@@ -183,7 +184,8 @@ proc.evaluate_boundary_constraints
     ext2add
     # => [(first1, first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
     # Add first and last row groups

--- a/air-script/tests/binary/binary.masm
+++ b/air-script/tests/binary/binary.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Exponentiate z trace_len times
     mem_load.4294903307 neg
@@ -147,7 +147,8 @@ proc.evaluate_boundary_constraints
     exec.compute_boundary_constraints_main_first
     # => [(first1, first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
 end # END PROC evaluate_boundary_constraints

--- a/air-script/tests/binary/binary.masm
+++ b/air-script/tests/binary/binary.masm
@@ -13,9 +13,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/bitwise/bitwise.masm
+++ b/air-script/tests/bitwise/bitwise.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Find number exponentiations required to get for a period of length 8
     mem_load.4294903307 neg add.3
@@ -418,7 +418,8 @@ proc.evaluate_boundary_constraints
     exec.compute_boundary_constraints_main_first
     # => [(first1, first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
 end # END PROC evaluate_boundary_constraints

--- a/air-script/tests/bitwise/bitwise.masm
+++ b/air-script/tests/bitwise/bitwise.masm
@@ -14,9 +14,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^8
     # => [0, 0, (z_1, z_0)^n, ...] where n = trace_len-8
@@ -27,9 +27,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000101 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/constants/constants.masm
+++ b/air-script/tests/constants/constants.masm
@@ -13,9 +13,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/constants/constants.masm
+++ b/air-script/tests/constants/constants.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Exponentiate z trace_len times
     mem_load.4294903307 neg
@@ -167,7 +167,8 @@ proc.evaluate_boundary_constraints
     exec.compute_boundary_constraints_aux_last
     # => [(aux_last1, aux_last0), ...]
     # Compute the denominator for domain LastRow
-    padw mem_loadw.4294903304 drop drop mem_load.500000101 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    mem_load.500000101 push.0 ext2sub
     # Compute numerator/denominator for last row
     ext2div
     exec.compute_boundary_constraints_aux_first
@@ -179,7 +180,8 @@ proc.evaluate_boundary_constraints
     ext2add
     # => [(first1, first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
     # Add first and last row groups

--- a/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
+++ b/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
@@ -13,9 +13,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
+++ b/air-script/tests/constraint_comprehension/cc_with_evaluators.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Exponentiate z trace_len times
     mem_load.4294903307 neg
@@ -127,7 +127,8 @@ proc.evaluate_boundary_constraints
     exec.compute_boundary_constraints_aux_first
     # => [(aux_first1, aux_first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
 end # END PROC evaluate_boundary_constraints

--- a/air-script/tests/constraint_comprehension/constraint_comprehension.masm
+++ b/air-script/tests/constraint_comprehension/constraint_comprehension.masm
@@ -13,9 +13,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/constraint_comprehension/constraint_comprehension.masm
+++ b/air-script/tests/constraint_comprehension/constraint_comprehension.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Exponentiate z trace_len times
     mem_load.4294903307 neg
@@ -127,7 +127,8 @@ proc.evaluate_boundary_constraints
     exec.compute_boundary_constraints_aux_first
     # => [(aux_first1, aux_first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
 end # END PROC evaluate_boundary_constraints

--- a/air-script/tests/evaluators/evaluators.masm
+++ b/air-script/tests/evaluators/evaluators.masm
@@ -13,9 +13,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/evaluators/evaluators.masm
+++ b/air-script/tests/evaluators/evaluators.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Exponentiate z trace_len times
     mem_load.4294903307 neg
@@ -195,7 +195,8 @@ proc.evaluate_boundary_constraints
     exec.compute_boundary_constraints_main_first
     # => [(first1, first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
 end # END PROC evaluate_boundary_constraints

--- a/air-script/tests/indexed_trace_access/indexed_trace_access.masm
+++ b/air-script/tests/indexed_trace_access/indexed_trace_access.masm
@@ -13,9 +13,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/indexed_trace_access/indexed_trace_access.masm
+++ b/air-script/tests/indexed_trace_access/indexed_trace_access.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Exponentiate z trace_len times
     mem_load.4294903307 neg
@@ -119,7 +119,8 @@ proc.evaluate_boundary_constraints
     exec.compute_boundary_constraints_main_first
     # => [(first1, first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
 end # END PROC evaluate_boundary_constraints

--- a/air-script/tests/list_comprehension/list_comprehension.masm
+++ b/air-script/tests/list_comprehension/list_comprehension.masm
@@ -13,9 +13,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/list_comprehension/list_comprehension.masm
+++ b/air-script/tests/list_comprehension/list_comprehension.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Exponentiate z trace_len times
     mem_load.4294903307 neg
@@ -131,7 +131,8 @@ proc.evaluate_boundary_constraints
     exec.compute_boundary_constraints_aux_first
     # => [(aux_first1, aux_first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
 end # END PROC evaluate_boundary_constraints

--- a/air-script/tests/list_folding/list_folding.masm
+++ b/air-script/tests/list_folding/list_folding.masm
@@ -13,9 +13,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/list_folding/list_folding.masm
+++ b/air-script/tests/list_folding/list_folding.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Exponentiate z trace_len times
     mem_load.4294903307 neg
@@ -127,7 +127,8 @@ proc.evaluate_boundary_constraints
     exec.compute_boundary_constraints_aux_first
     # => [(aux_first1, aux_first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
 end # END PROC evaluate_boundary_constraints

--- a/air-script/tests/periodic_columns/periodic_columns.masm
+++ b/air-script/tests/periodic_columns/periodic_columns.masm
@@ -14,9 +14,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^8
     # => [0, 0, (z_1, z_0)^n, ...] where n = trace_len-8
@@ -28,9 +28,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000101 # z^4
     # => [0, 0, (z_1, z_0)^n, ...] where n = trace_len-4
@@ -41,9 +41,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000102 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/periodic_columns/periodic_columns.masm
+++ b/air-script/tests/periodic_columns/periodic_columns.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Find number exponentiations required to get for a period of length 8
     mem_load.4294903307 neg add.3
@@ -226,7 +226,8 @@ proc.evaluate_boundary_constraints
     exec.compute_boundary_constraints_main_first
     # => [(first1, first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
 end # END PROC evaluate_boundary_constraints

--- a/air-script/tests/pub_inputs/pub_inputs.masm
+++ b/air-script/tests/pub_inputs/pub_inputs.masm
@@ -13,9 +13,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/pub_inputs/pub_inputs.masm
+++ b/air-script/tests/pub_inputs/pub_inputs.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Exponentiate z trace_len times
     mem_load.4294903307 neg
@@ -169,7 +169,8 @@ proc.evaluate_boundary_constraints
     ext2add ext2add ext2add ext2add
     # => [(last1, last0), ...]
     # Compute the denominator for domain LastRow
-    padw mem_loadw.4294903304 drop drop mem_load.500000101 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    mem_load.500000101 push.0 ext2sub
     # Compute numerator/denominator for last row
     ext2div
     exec.compute_boundary_constraints_main_first
@@ -177,7 +178,8 @@ proc.evaluate_boundary_constraints
     ext2add ext2add ext2add ext2add
     # => [(first1, first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
     # Add first and last row groups

--- a/air-script/tests/random_values/random_values_bindings.masm
+++ b/air-script/tests/random_values/random_values_bindings.masm
@@ -13,9 +13,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/random_values/random_values_bindings.masm
+++ b/air-script/tests/random_values/random_values_bindings.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Exponentiate z trace_len times
     mem_load.4294903307 neg
@@ -127,13 +127,15 @@ proc.evaluate_boundary_constraints
     exec.compute_boundary_constraints_aux_last
     # => [(aux_last1, aux_last0), ...]
     # Compute the denominator for domain LastRow
-    padw mem_loadw.4294903304 drop drop mem_load.500000101 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    mem_load.500000101 push.0 ext2sub
     # Compute numerator/denominator for last row
     ext2div
     exec.compute_boundary_constraints_aux_first
     # => [(aux_first1, aux_first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
     # Add first and last row groups

--- a/air-script/tests/random_values/random_values_simple.masm
+++ b/air-script/tests/random_values/random_values_simple.masm
@@ -13,9 +13,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/random_values/random_values_simple.masm
+++ b/air-script/tests/random_values/random_values_simple.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Exponentiate z trace_len times
     mem_load.4294903307 neg
@@ -127,13 +127,15 @@ proc.evaluate_boundary_constraints
     exec.compute_boundary_constraints_aux_last
     # => [(aux_last1, aux_last0), ...]
     # Compute the denominator for domain LastRow
-    padw mem_loadw.4294903304 drop drop mem_load.500000101 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    mem_load.500000101 push.0 ext2sub
     # Compute numerator/denominator for last row
     ext2div
     exec.compute_boundary_constraints_aux_first
     # => [(aux_first1, aux_first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
     # Add first and last row groups

--- a/air-script/tests/selectors/selectors.masm
+++ b/air-script/tests/selectors/selectors.masm
@@ -13,9 +13,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/selectors/selectors.masm
+++ b/air-script/tests/selectors/selectors.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Exponentiate z trace_len times
     mem_load.4294903307 neg
@@ -123,7 +123,8 @@ proc.evaluate_boundary_constraints
     exec.compute_boundary_constraints_main_first
     # => [(first1, first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
 end # END PROC evaluate_boundary_constraints

--- a/air-script/tests/selectors/selectors_with_evaluators.masm
+++ b/air-script/tests/selectors/selectors_with_evaluators.masm
@@ -13,9 +13,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/selectors/selectors_with_evaluators.masm
+++ b/air-script/tests/selectors/selectors_with_evaluators.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Exponentiate z trace_len times
     mem_load.4294903307 neg
@@ -123,7 +123,8 @@ proc.evaluate_boundary_constraints
     exec.compute_boundary_constraints_main_first
     # => [(first1, first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
 end # END PROC evaluate_boundary_constraints

--- a/air-script/tests/system/system.masm
+++ b/air-script/tests/system/system.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Exponentiate z trace_len times
     mem_load.4294903307 neg
@@ -115,7 +115,8 @@ proc.evaluate_boundary_constraints
     exec.compute_boundary_constraints_main_first
     # => [(first1, first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
 end # END PROC evaluate_boundary_constraints

--- a/air-script/tests/system/system.masm
+++ b/air-script/tests/system/system.masm
@@ -13,9 +13,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/trace_col_groups/trace_col_groups.masm
+++ b/air-script/tests/trace_col_groups/trace_col_groups.masm
@@ -13,9 +13,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/air-script/tests/trace_col_groups/trace_col_groups.masm
+++ b/air-script/tests/trace_col_groups/trace_col_groups.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Exponentiate z trace_len times
     mem_load.4294903307 neg
@@ -119,7 +119,8 @@ proc.evaluate_boundary_constraints
     exec.compute_boundary_constraints_aux_first
     # => [(aux_first1, aux_first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
 end # END PROC evaluate_boundary_constraints

--- a/air-script/tests/variables/variables.masm
+++ b/air-script/tests/variables/variables.masm
@@ -5,7 +5,7 @@
 # Input: [...]
 # Output: [...]
 proc.cache_z_exp
-    padw mem_loadw.4294903304 drop drop
+    padw mem_loadw.4294903304 drop drop # load z
     # => [z_1, z_0, ...]
     # Find number exponentiations required to get for a period of length 8
     mem_load.4294903307 neg add.3
@@ -226,13 +226,15 @@ proc.evaluate_boundary_constraints
     exec.compute_boundary_constraints_main_last
     # => [(last1, last0), ...]
     # Compute the denominator for domain LastRow
-    padw mem_loadw.4294903304 drop drop mem_load.500000101 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    mem_load.500000101 push.0 ext2sub
     # Compute numerator/denominator for last row
     ext2div
     exec.compute_boundary_constraints_main_first
     # => [(first1, first0), ...]
     # Compute the denominator for domain FirstRow
-    padw mem_loadw.4294903304 drop drop push.1 push.0 ext2sub
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
     # Compute numerator/denominator for first row
     ext2div
     # Add first and last row groups

--- a/air-script/tests/variables/variables.masm
+++ b/air-script/tests/variables/variables.masm
@@ -14,9 +14,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000100 # z^8
     # => [0, 0, (z_1, z_0)^n, ...] where n = trace_len-8
@@ -27,9 +27,9 @@ proc.cache_z_exp
     dup.0 neq.0
     while.true
         movdn.2 dup.1 dup.1 ext2mul
-        # => [(z_1, z_0)^n, i, ...]
+        # => [(e_1, e_0)^n, i, ...]
         movup.2 add.1 dup.0 neq.0
-        # => [b, i+1, (z_1, z_0)^n, ...]
+        # => [b, i+1, (e_1, e_0)^n, ...]
     end # END while
     push.0 mem_storew.500000101 # z^trace_len
     # => [0, 0, (z_1, z_0)^trace_len, ...]

--- a/codegen/masm/src/codegen.rs
+++ b/codegen/masm/src/codegen.rs
@@ -232,25 +232,7 @@ impl<'ast> Backend<'ast> {
             }
 
             self.writer.header("Exponentiate z");
-
-            // The trace length and the period may have the same size, so it is necessary to perform
-            // the test before entering the loop.
-            self.writer.dup(0);
-            self.writer.neq(0);
-
-            self.writer.r#while();
-            self.writer.movdn(2);
-            self.writer.dup(1);
-            self.writer.dup(1);
-            self.writer.ext2mul();
-            self.writer.header("=> [(z_1, z_0)^n, i, ...]");
-
-            self.writer.movup(2);
-            self.writer.add(1);
-            self.writer.dup(0);
-            self.writer.neq(0);
-            self.writer.header("=> [b, i+1, (z_1, z_0)^n, ...]");
-            self.writer.end();
+            self.writer.ext2_exponentiate();
 
             let idx: u32 = idx.try_into().expect("periodic column length is too large");
             let addr = self.config.z_exp_address + idx;
@@ -294,24 +276,7 @@ impl<'ast> Backend<'ast> {
             }
         }
 
-        // The trace length and the period may have the same size, so it is necessary to perform
-        // the test before entering the loop.
-        self.writer.dup(0);
-        self.writer.neq(0);
-
-        self.writer.r#while();
-        self.writer.movdn(2);
-        self.writer.dup(1);
-        self.writer.dup(1);
-        self.writer.ext2mul();
-        self.writer.header("=> [(z_1, z_0)^n, i, ...]");
-
-        self.writer.movup(2);
-        self.writer.add(1);
-        self.writer.dup(0);
-        self.writer.neq(0);
-        self.writer.header("=> [b, i+1, (z_1, z_0)^n, ...]");
-        self.writer.end();
+        self.writer.ext2_exponentiate();
 
         let idx: u32 = self
             .periods

--- a/codegen/masm/src/codegen.rs
+++ b/codegen/masm/src/codegen.rs
@@ -6,13 +6,12 @@ use crate::utils::{
     quadratic_element_square,
 };
 use crate::visitor::{
-    walk_boundary_constraints, walk_integrity_constraint_degrees, walk_integrity_constraints,
-    walk_periodic_columns, walk_public_inputs, AirVisitor,
+    walk_boundary_constraints, walk_integrity_constraints, walk_periodic_columns, AirVisitor,
 };
 use crate::writer::Writer;
 use air_ir::{
-    Air, ConstraintDomain, ConstraintRoot, Identifier, IntegrityConstraintDegree, NodeIndex,
-    Operation, PeriodicColumn, PublicInput, TraceAccess, TraceSegmentId, Value,
+    Air, ConstraintDomain, ConstraintRoot, Identifier, NodeIndex, Operation, PeriodicColumn,
+    TraceSegmentId, Value,
 };
 use miden_processor::math::{Felt, StarkField};
 use std::collections::btree_map::BTreeMap;
@@ -890,10 +889,6 @@ impl<'ast> AirVisitor<'ast> for Backend<'ast> {
     }
 
     fn visit_air(&mut self) -> Result<Self::Value, Self::Error> {
-        walk_public_inputs(self, self.ir)?;
-        walk_integrity_constraint_degrees(self, self.ir, MAIN_TRACE)?;
-        walk_integrity_constraint_degrees(self, self.ir, AUX_TRACE)?;
-
         self.gen_cache_z_exp()?;
         self.gen_get_exemptions_points()?;
 
@@ -918,14 +913,6 @@ impl<'ast> AirVisitor<'ast> for Backend<'ast> {
         self.gen_evaluate_constraints();
 
         Ok(())
-    }
-
-    fn visit_integrity_constraint_degree(
-        &mut self,
-        _constraint: IntegrityConstraintDegree,
-        _trace_segment: TraceSegmentId,
-    ) -> Result<Self::Value, Self::Error> {
-        Ok(()) // TODO
     }
 
     fn visit_node_index(
@@ -1085,20 +1072,6 @@ impl<'ast> AirVisitor<'ast> for Backend<'ast> {
 
         self.periodic_column += 1;
         Ok(())
-    }
-
-    fn visit_public_input(
-        &mut self,
-        _constant: &'ast PublicInput,
-    ) -> Result<Self::Value, Self::Error> {
-        Ok(())
-    }
-
-    fn visit_trace_access(
-        &mut self,
-        _trace_access: &'ast TraceAccess,
-    ) -> Result<Self::Value, Self::Error> {
-        Ok(()) // TODO
     }
 
     fn visit_value(&mut self, value: &'ast Value) -> Result<Self::Value, Self::Error> {

--- a/codegen/masm/src/codegen.rs
+++ b/codegen/masm/src/codegen.rs
@@ -387,13 +387,7 @@ impl<'ast> Backend<'ast> {
         self.writer.header("=> [zt_1-1, zt_0-1, ...]");
 
         // Compute the denominator of the divisor
-        // Load the point `z` to the stack
-        self.writer.padw();
-        self.writer.mem_loadw(self.config.z_address);
-        self.writer.drop();
-        self.writer.drop();
-        self.writer.comment("load z");
-
+        self.load_z();
         self.writer.header("=> [z_1, z_0, zt_1-1, zt_0-1, ...]");
 
         self.writer.exec("get_exemptions_points");
@@ -795,6 +789,7 @@ impl<'ast> Backend<'ast> {
         self.writer.mem_loadw(self.config.z_address);
         self.writer.drop();
         self.writer.drop();
+        self.writer.comment("load z");
     }
 
     /// Emits code to load `g`, the trace domain generator.

--- a/codegen/masm/src/error.rs
+++ b/codegen/masm/src/error.rs
@@ -1,0 +1,15 @@
+#[derive(Debug, thiserror::Error)]
+pub enum CodegenError {
+    #[error("invalid access type")]
+    InvalidAccessType,
+    #[error("invalid row offset")]
+    InvalidRowOffset,
+    #[error("invalid size")]
+    InvalidSize,
+    #[error("invalid index")]
+    InvalidIndex,
+    #[error("invalid boundary constraint")]
+    InvalidBoundaryConstraint,
+    #[error("invalid integrity constraint")]
+    InvalidIntegrityConstraint,
+}

--- a/codegen/masm/src/lib.rs
+++ b/codegen/masm/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod codegen;
 mod config;
 pub mod constants;
+pub mod error;
 mod utils;
 pub mod visitor;
 mod writer;

--- a/codegen/masm/src/utils.rs
+++ b/codegen/masm/src/utils.rs
@@ -1,4 +1,7 @@
-use air_ir::{ConstraintDomain, ConstraintRoot};
+use crate::constants::AUX_TRACE;
+use crate::writer::Writer;
+use crate::{constants::MAIN_TRACE, error::CodegenError};
+use air_ir::{ConstraintDomain, ConstraintRoot, TraceSegmentId};
 
 /// Utility to order contraints roots w.r.t. their natural order.
 pub fn contraint_root_domain(boundary: &&ConstraintRoot) -> u8 {
@@ -8,5 +11,75 @@ pub fn contraint_root_domain(boundary: &&ConstraintRoot) -> u8 {
         ConstraintDomain::LastRow => 1,
         ConstraintDomain::EveryRow => panic!("EveryRow is not supported"),
         ConstraintDomain::EveryFrame(_) => panic!("EveryFrame is not supported"),
+    }
+}
+
+/// Given a periodic column group position, returns a memory offset.
+///
+/// Periodic columns are grouped based on their length, this is done so that only a single z value
+/// needs to be cached per group. The grouping is based on unique lengths, sorted from highest to
+/// lowest. Given a periodic group, this function will return a memory offset, which can be used to
+/// load the corresponding z value.
+pub fn periodic_group_to_memory_offset(group: u32) -> u32 {
+    // Each memory address contains a quadratic field extension element, this makes the code to
+    // store/load the data more efficient, since it is easier to push/pop the high values of a
+    // word. So below we have to multiply the group by 2, to account for the zero padding, and add
+    // 1, to account for the data being at the low and not high part of the word.
+    group * 2 + 1
+}
+
+/// Loads the `element` from a memory range starting at `base_addr`.
+///
+/// This function is used to load a qudratic element from memory, and discard the other value. Even
+/// values are store in higher half of the word, while odd values are stored in the lower half.
+pub fn load_quadratic_element(
+    writer: &mut Writer,
+    base_addr: u32,
+    element: u32,
+) -> Result<(), CodegenError> {
+    let target_word: u32 = element / 2;
+    let address = base_addr + target_word;
+
+    // Load data from memory
+    writer.padw();
+    writer.mem_loadw(address);
+
+    // Discard the other value
+    match element % 2 {
+        0 => {
+            writer.movdn(3);
+            writer.movdn(3);
+            writer.drop();
+            writer.drop();
+        }
+        1 => {
+            writer.drop();
+            writer.drop();
+        }
+        _ => unreachable!(),
+    }
+
+    Ok(())
+}
+
+/// Assumes a quadratic extension field element is at the top of the stack and square it `n` times.
+pub fn quadratic_element_square(writer: &mut Writer, n: u32) {
+    for _ in 0..n {
+        writer.dup(1);
+        writer.dup(1);
+        writer.ext2mul();
+    }
+}
+
+pub fn boundary_group_to_procedure_name(
+    trace: TraceSegmentId,
+    domain: ConstraintDomain,
+) -> &'static str {
+    match (trace, domain) {
+        (MAIN_TRACE, ConstraintDomain::FirstRow) => "compute_boundary_constraints_main_first",
+        (MAIN_TRACE, ConstraintDomain::LastRow) => "compute_boundary_constraints_main_last",
+        (AUX_TRACE, ConstraintDomain::FirstRow) => "compute_boundary_constraints_aux_first",
+        (AUX_TRACE, ConstraintDomain::LastRow) => "compute_boundary_constraints_aux_last",
+        _ => panic!("Invalid boundary constraint"),
     }
 }

--- a/codegen/masm/src/visitor.rs
+++ b/codegen/masm/src/visitor.rs
@@ -1,7 +1,7 @@
 use crate::utils::contraint_root_domain;
 use air_ir::{
-    Air, ConstraintDomain, ConstraintRoot, IntegrityConstraintDegree, NodeIndex, Operation,
-    PeriodicColumn, PublicInput, TraceAccess, TraceSegmentId, Value,
+    Air, ConstraintDomain, ConstraintRoot, NodeIndex, Operation, PeriodicColumn, TraceSegmentId,
+    Value,
 };
 
 pub trait AirVisitor<'ast> {
@@ -15,12 +15,6 @@ pub trait AirVisitor<'ast> {
     ) -> Result<Self::Value, Self::Error>;
 
     fn visit_air(&mut self) -> Result<Self::Value, Self::Error>;
-
-    fn visit_integrity_constraint_degree(
-        &mut self,
-        constraint: IntegrityConstraintDegree,
-        trace_segment: TraceSegmentId,
-    ) -> Result<Self::Value, Self::Error>;
 
     fn visit_integrity_constraint(
         &mut self,
@@ -38,40 +32,7 @@ pub trait AirVisitor<'ast> {
         columns: &'ast PeriodicColumn,
     ) -> Result<Self::Value, Self::Error>;
 
-    fn visit_public_input(
-        &mut self,
-        constant: &'ast PublicInput,
-    ) -> Result<Self::Value, Self::Error>;
-
-    fn visit_trace_access(
-        &mut self,
-        trace_access: &'ast TraceAccess,
-    ) -> Result<Self::Value, Self::Error>;
-
     fn visit_value(&mut self, value: &'ast Value) -> Result<Self::Value, Self::Error>;
-}
-
-pub fn walk_public_inputs<'ast, V: AirVisitor<'ast>>(
-    visitor: &mut V,
-    ir: &'ast Air,
-) -> Result<(), V::Error> {
-    for input in ir.public_inputs() {
-        visitor.visit_public_input(input)?;
-    }
-
-    Ok(())
-}
-
-pub fn walk_integrity_constraint_degrees<'ast, V: AirVisitor<'ast>>(
-    visitor: &mut V,
-    ir: &'ast Air,
-    trace_segment: TraceSegmentId,
-) -> Result<(), V::Error> {
-    for constraint in ir.integrity_constraint_degrees(trace_segment) {
-        visitor.visit_integrity_constraint_degree(constraint, trace_segment)?;
-    }
-
-    Ok(())
 }
 
 pub fn walk_periodic_columns<'ast, V: AirVisitor<'ast>>(

--- a/codegen/masm/src/writer.rs
+++ b/codegen/masm/src/writer.rs
@@ -289,4 +289,26 @@ impl Writer {
         self.new_line();
         self.stack.push(ControlFlow::While);
     }
+
+    // Emits code to exponentiate a quadratic extension field element `n` times.
+    //
+    // The stack state must be `[-n, (e_1, e_0), ...]`, the result stack will be `[0, (e_1, e_0)^n, ...]`
+    pub fn ext2_exponentiate(&mut self) {
+        self.dup(0);
+        self.neq(0);
+
+        self.r#while();
+        self.movdn(2);
+        self.dup(1);
+        self.dup(1);
+        self.ext2mul();
+        self.header("=> [(e_1, e_0)^n, i, ...]");
+
+        self.movup(2);
+        self.add(1);
+        self.dup(0);
+        self.neq(0);
+        self.header("=> [b, i+1, (e_1, e_0)^n, ...]");
+        self.end();
+    }
 }


### PR DESCRIPTION
Best reviewed/merged after https://github.com/0xPolygonMiden/air-script/pull/336

This removes a bit of code duplication, and split the code a bit into separate modules to make `codegen.rs` smaller.