### PR TITLE
fix: incorrect propagation of constraint flag during inlining

### DIFF
--- a/parser/src/parser/tests/mod.rs
+++ b/parser/src/parser/tests/mod.rs
@@ -360,6 +360,13 @@ macro_rules! int {
             $value,
         ))
     };
+
+    ($value:expr) => {
+        ScalarExpr::Const(miden_diagnostics::Span::new(
+            miden_diagnostics::SourceSpan::UNKNOWN,
+            $value,
+        ))
+    };
 }
 
 macro_rules! call {
@@ -497,7 +504,7 @@ macro_rules! lc {
 
 macro_rules! range {
     ($range:expr) => {
-        Expr::Range(Span::new(SourceSpan::UNKNOWN, $range))
+        Expr::Range(miden_diagnostics::Span::new(SourceSpan::UNKNOWN, $range))
     };
 }
 

--- a/parser/src/parser/tests/modules.rs
+++ b/parser/src/parser/tests/modules.rs
@@ -1,4 +1,4 @@
-use miden_diagnostics::{SourceSpan, Span};
+use miden_diagnostics::SourceSpan;
 
 use crate::ast::*;
 

--- a/parser/src/parser/tests/variables.rs
+++ b/parser/src/parser/tests/variables.rs
@@ -1,4 +1,4 @@
-use miden_diagnostics::{SourceSpan, Span};
+use miden_diagnostics::SourceSpan;
 
 use crate::ast::*;
 

--- a/parser/src/transforms/inlining.rs
+++ b/parser/src/transforms/inlining.rs
@@ -448,7 +448,11 @@ impl<'a> Inlining<'a> {
                 Ok(vec![Statement::Expr(folded)])
             }
             Expr::ListComprehension(lc) => {
+                // Expand the comprehension, but ensure we don't treat it like a comprehension constraint
+                let in_cc = core::mem::replace(&mut self.in_comprehension_constraint, false);
                 let mut expanded = self.expand_comprehension(lc)?;
+                self.in_comprehension_constraint = in_cc;
+                // Apply the fold to the expanded comprehension in the bottom of the let tree
                 with_let_result(self, &mut expanded, |inliner, value| {
                     match value {
                         // The result value of expanding a comprehension _must_ be a vector


### PR DESCRIPTION
This fixes an issue which caused expansion of a folded comprehension within the context of a constraint to be improperly treated as a constraint comprehension. This expansion occurs during the inlining phase.

This bug occurred because a flag determines whether a given comprehension is a constraint comprehension or a regular list
comprehension, and is set to true when expanding a constraint. However, while expanding a constraint, we may encounter a call to a function, such as one of the list folding builtins, in which case a comprehension passed as an argument to those builtins is not expressing a constraint, so the flag should be false while expanding it.

We already manage this flag correctly in other contexts, but this one was missed during development.
