### PR TITLE
feat: implement support for functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, repoened, synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
   test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,14 @@
 [workspace]
 members = [
-  "air-script",
-  "parser",
-  "pass",
-  "ir",
-  "codegen/masm",
-  "codegen/winterfell",
+    "air-script",
+    "parser",
+    "pass",
+    "ir",
+    "codegen/masm",
+    "codegen/winterfell",
 ]
 resolver = "2"
+
+[workspace.package]
+edition = "2021"
+rust-version = "1.78"

--- a/air-script/Cargo.toml
+++ b/air-script/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/0xPolygonMiden/air-script"
 documentation = "https://0xpolygonmiden.github.io/air-script/"
 categories = ["compilers", "cryptography"]
 keywords = ["air", "stark", "zero-knowledge", "zkp"]
-edition = "2021"
-rust-version = "1.67"
+edition.workspace = true
+rust-version.workspace = true
 
 [[bin]]
 name = "airc"
@@ -22,7 +22,7 @@ air-parser = { package = "air-parser", path = "../parser", version = "0.4" }
 air-pass = { package = "air-pass", path = "../pass", version = "0.1" }
 air-codegen-masm = { package = "air-codegen-masm", path = "../codegen/masm", version = "0.4" }
 air-codegen-winter = { package = "air-codegen-winter", path = "../codegen/winterfell", version = "0.4" }
-clap = {version = "4.2", features = ["derive"] }
+clap = { version = "4.2", features = ["derive"] }
 env_logger = "0.10"
 log = { version = "0.4", default-features = false }
 miden-diagnostics = "0.1"

--- a/air-script/tests/codegen/masm.rs
+++ b/air-script/tests/codegen/masm.rs
@@ -85,14 +85,17 @@ fn evaluators() {
 }
 
 #[test]
-fn functions() {
+fn functions_simple() {
     let generated_masm = Test::new("tests/functions/functions_simple.air".to_string())
         .transpile(Target::Masm)
         .unwrap();
 
     let expected = expect_file!["../functions/functions_simple.masm"];
     expected.assert_eq(&generated_masm);
+}
 
+#[test]
+fn functions_simple_inlined() {
     // make sure that the constraints generated using inlined functions are the same as the ones
     // generated using regular functions
     let generated_masm = Test::new("tests/functions/inlined_functions_simple.air".to_string())
@@ -100,13 +103,16 @@ fn functions() {
         .unwrap();
     let expected = expect_file!["../functions/functions_simple.masm"];
     expected.assert_eq(&generated_masm);
+}
 
-    // let generated_masm = Test::new("tests/functions/functions_complex.air".to_string())
-    //     .transpile(Target::Masm)
-    //     .unwrap();
+#[test]
+fn functions_complex() {
+    let generated_masm = Test::new("tests/functions/functions_complex.air".to_string())
+        .transpile(Target::Masm)
+        .unwrap();
 
-    // let expected = expect_file!["../functions/functions_complex.masm"];
-    // expected.assert_eq(&generated_masm);
+    let expected = expect_file!["../functions/functions_complex.masm"];
+    expected.assert_eq(&generated_masm);
 }
 
 #[test]

--- a/air-script/tests/codegen/masm.rs
+++ b/air-script/tests/codegen/masm.rs
@@ -85,6 +85,31 @@ fn evaluators() {
 }
 
 #[test]
+fn functions() {
+    let generated_masm = Test::new("tests/functions/functions_simple.air".to_string())
+        .transpile(Target::Masm)
+        .unwrap();
+
+    let expected = expect_file!["../functions/functions_simple.masm"];
+    expected.assert_eq(&generated_masm);
+
+    // make sure that the constraints generated using inlined functions are the same as the ones
+    // generated using regular functions
+    let generated_masm = Test::new("tests/functions/inlined_functions_simple.air".to_string())
+        .transpile(Target::Masm)
+        .unwrap();
+    let expected = expect_file!["../functions/functions_simple.masm"];
+    expected.assert_eq(&generated_masm);
+
+    // let generated_masm = Test::new("tests/functions/functions_complex.air".to_string())
+    //     .transpile(Target::Masm)
+    //     .unwrap();
+
+    // let expected = expect_file!["../functions/functions_complex.masm"];
+    // expected.assert_eq(&generated_masm);
+}
+
+#[test]
 fn variables() {
     let generated_masm = Test::new("tests/variables/variables.air".to_string())
         .transpile(Target::Masm)

--- a/air-script/tests/codegen/winterfell.rs
+++ b/air-script/tests/codegen/winterfell.rs
@@ -85,14 +85,17 @@ fn evaluators() {
 }
 
 #[test]
-fn functions() {
+fn functions_simple() {
     let generated_air = Test::new("tests/functions/functions_simple.air".to_string())
         .transpile(Target::Winterfell)
         .unwrap();
 
     let expected = expect_file!["../functions/functions_simple.rs"];
     expected.assert_eq(&generated_air);
+}
 
+#[test]
+fn functions_simple_inlined() {
     // make sure that the constraints generated using inlined functions are the same as the ones
     // generated using regular functions
     let generated_air = Test::new("tests/functions/inlined_functions_simple.air".to_string())
@@ -101,13 +104,16 @@ fn functions() {
 
     let expected = expect_file!["../functions/functions_simple.rs"];
     expected.assert_eq(&generated_air);
+}
 
-    // let generated_air = Test::new("tests/functions/functions_complex.air".to_string())
-    //     .transpile(Target::Winterfell)
-    //     .unwrap();
+#[test]
+fn functions_complex() {
+    let generated_air = Test::new("tests/functions/functions_complex.air".to_string())
+        .transpile(Target::Winterfell)
+        .unwrap();
 
-    // let expected = expect_file!["../functions/functions_complex.rs"];
-    // expected.assert_eq(&generated_air);
+    let expected = expect_file!["../functions/functions_complex.rs"];
+    expected.assert_eq(&generated_air);
 }
 
 #[test]

--- a/air-script/tests/codegen/winterfell.rs
+++ b/air-script/tests/codegen/winterfell.rs
@@ -85,6 +85,32 @@ fn evaluators() {
 }
 
 #[test]
+fn functions() {
+    let generated_air = Test::new("tests/functions/functions_simple.air".to_string())
+        .transpile(Target::Winterfell)
+        .unwrap();
+
+    let expected = expect_file!["../functions/functions_simple.rs"];
+    expected.assert_eq(&generated_air);
+
+    // make sure that the constraints generated using inlined functions are the same as the ones
+    // generated using regular functions
+    let generated_air = Test::new("tests/functions/inlined_functions_simple.air".to_string())
+        .transpile(Target::Winterfell)
+        .unwrap();
+
+    let expected = expect_file!["../functions/functions_simple.rs"];
+    expected.assert_eq(&generated_air);
+
+    // let generated_air = Test::new("tests/functions/functions_complex.air".to_string())
+    //     .transpile(Target::Winterfell)
+    //     .unwrap();
+
+    // let expected = expect_file!["../functions/functions_complex.rs"];
+    // expected.assert_eq(&generated_air);
+}
+
+#[test]
 fn variables() {
     let generated_air = Test::new("tests/variables/variables.air".to_string())
         .transpile(Target::Winterfell)

--- a/air-script/tests/functions/functions_complex.air
+++ b/air-script/tests/functions/functions_complex.air
@@ -37,9 +37,9 @@ integrity_constraints {
     let f = get_multiplicity_flags(s0, s1)
     let z = v^4 * f[3] + v^2 * f[2] + v * f[1] + f[0]
     # let folded_value = fold_scalar_and_vec(v, b)
-    # enf b_range' = b_range * (z * t - t + 1)
-    enf b_range' = b_range * 2
-    # let y = fold_scalar_and_vec(v, b)
+    enf b_range' = b_range * (z * t - t + 1)
+    # enf b_range' = b_range * 2
+    let y = fold_scalar_and_vec(v, b)
     # let c = fold_scalar_and_vec(t, b)
-    # enf v' = y
+    enf v' = y
 }

--- a/air-script/tests/functions/functions_complex.air
+++ b/air-script/tests/functions/functions_complex.air
@@ -1,0 +1,45 @@
+def FunctionsAir
+
+fn get_multiplicity_flags(s0: felt, s1: felt) -> felt[4] {
+    return [!s0 & !s1, s0 & !s1, !s0 & s1, s0 & s1]
+}
+
+fn fold_vec(a: felt[12]) -> felt {
+   return sum([x for x in a])
+}
+
+fn fold_scalar_and_vec(a: felt, b: felt[12]) -> felt {
+    let m = fold_vec(b)
+    let n = m + 1
+    let o = n * 2
+    return o
+}
+
+trace_columns {
+    main: [t, s0, s1, v, b[12]]
+    aux: [b_range]
+}
+
+public_inputs {
+    stack_inputs: [16]
+}
+
+random_values {
+    alpha: [16]
+}
+
+boundary_constraints {
+    enf v.first = 0
+}
+
+integrity_constraints {
+    # let val = $alpha[0] + v
+    let f = get_multiplicity_flags(s0, s1)
+    let z = v^4 * f[3] + v^2 * f[2] + v * f[1] + f[0]
+    # let folded_value = fold_scalar_and_vec(v, b)
+    # enf b_range' = b_range * (z * t - t + 1)
+    enf b_range' = b_range * 2
+    # let y = fold_scalar_and_vec(v, b)
+    # let c = fold_scalar_and_vec(t, b)
+    # enf v' = y
+}

--- a/air-script/tests/functions/functions_complex.masm
+++ b/air-script/tests/functions/functions_complex.masm
@@ -1,0 +1,166 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(e_1, e_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (e_1, e_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 1 main and 1 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 2 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
+    # integrity constraint 0 for main
+    padw mem_loadw.4294900003 drop drop padw mem_loadw.4294900004 movdn.3 movdn.3 drop drop padw mem_loadw.4294900005 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900006 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900007 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900008 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900009 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900010 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900011 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900012 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900013 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900014 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900015 movdn.3 movdn.3 drop drop ext2add push.1 push.0 ext2add push.2 push.0 ext2mul ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294900200 movdn.3 movdn.3 drop drop ext2mul
+    # integrity constraint 0 for aux
+    padw mem_loadw.4294900072 drop drop padw mem_loadw.4294900072 movdn.3 movdn.3 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop ext2add
+    # push the accumulator to the stack
+    push.1 movdn.2 push.0 movdn.2
+    # => [b1, b0, r1, r0, ...]
+    # square 2 times
+    dup.1 dup.1 ext2mul dup.1 dup.1 ext2mul
+    # multiply
+    dup.1 dup.1 movdn.5 movdn.5
+    # => [b1, b0, r1, r0, b1, b0, ...] (4 cycles)
+    ext2mul movdn.3 movdn.3
+    # => [b1, b0, r1', r0', ...] (5 cycles)
+    # clean stack
+    drop drop
+    # => [r1, r0, ...] (2 cycles)
+    padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2mul ext2mul padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop ext2add
+    # push the accumulator to the stack
+    push.1 movdn.2 push.0 movdn.2
+    # => [b1, b0, r1, r0, ...]
+    # square 1 times
+    dup.1 dup.1 ext2mul
+    # multiply
+    dup.1 dup.1 movdn.5 movdn.5
+    # => [b1, b0, r1, r0, b1, b0, ...] (4 cycles)
+    ext2mul movdn.3 movdn.3
+    # => [b1, b0, r1', r0', ...] (5 cycles)
+    # clean stack
+    drop drop
+    # => [r1, r0, ...] (2 cycles)
+    push.1 push.0 padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2mul ext2mul ext2add padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop push.1 push.0 padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul ext2add push.1 push.0 padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2sub push.1 push.0 padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2add padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2sub push.1 push.0 ext2add ext2mul ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294900200 drop drop ext2mul
+end # END PROC compute_integrity_constraints
+
+# Procedure to evaluate the boundary constraint numerator for the first row of the main trace
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_main_first
+    # boundary constraint 0 for main
+    padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294900201 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_boundary_constraints_main_first
+
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
+proc.evaluate_integrity_constraints
+    exec.compute_integrity_constraints
+    # Numerator of the transition constraint polynomial
+    ext2add ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
+end # END PROC evaluate_integrity_constraints
+
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
+proc.evaluate_boundary_constraints
+    exec.compute_boundary_constraints_main_first
+    # => [(first1, first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
+end # END PROC evaluate_boundary_constraints
+
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/functions/functions_complex.masm
+++ b/air-script/tests/functions/functions_complex.masm
@@ -79,7 +79,7 @@ proc.compute_integrity_constraints
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 movdn.3 movdn.3 drop drop ext2mul
     # integrity constraint 0 for aux
-    padw mem_loadw.4294900072 drop drop padw mem_loadw.4294900072 movdn.3 movdn.3 drop drop padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop ext2add
+    padw mem_loadw.4294900072 drop drop padw mem_loadw.4294900072 movdn.3 movdn.3 drop drop padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
     # => [b1, b0, r1, r0, ...]
@@ -93,7 +93,7 @@ proc.compute_integrity_constraints
     # clean stack
     drop drop
     # => [r1, r0, ...] (2 cycles)
-    padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2mul ext2mul padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop ext2add
+    padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2mul ext2mul padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop
     # push the accumulator to the stack
     push.1 movdn.2 push.0 movdn.2
     # => [b1, b0, r1, r0, ...]
@@ -107,7 +107,7 @@ proc.compute_integrity_constraints
     # clean stack
     drop drop
     # => [r1, r0, ...] (2 cycles)
-    push.1 push.0 padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2mul ext2mul ext2add padw mem_loadw.4294900150 movdn.3 movdn.3 drop drop padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop push.1 push.0 padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul ext2add push.1 push.0 padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2sub push.1 push.0 padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2add padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2sub push.1 push.0 ext2add ext2mul ext2sub
+    push.1 push.0 padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2sub padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2mul ext2mul ext2add padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop push.1 push.0 padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2mul ext2add push.1 push.0 padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop ext2sub push.1 push.0 padw mem_loadw.4294900002 movdn.3 movdn.3 drop drop ext2sub ext2mul ext2add padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop ext2sub push.1 push.0 ext2add ext2mul ext2sub
     # Multiply by the composition coefficient
     padw mem_loadw.4294900200 drop drop ext2mul
 end # END PROC compute_integrity_constraints

--- a/air-script/tests/functions/functions_complex.rs
+++ b/air-script/tests/functions/functions_complex.rs
@@ -86,6 +86,6 @@ impl Air for FunctionsAir {
         let main_next = main_frame.next();
         let aux_current = aux_frame.current();
         let aux_next = aux_frame.next();
-        result[0] = aux_next[0] - aux_current[0] * (((aux_rand_elements.get_segment_elements(0)[0] + E::from(main_current[3])).exp(E::PositiveInteger::from(4_u64)) * E::from(main_current[1]) * E::from(main_current[2]) + (aux_rand_elements.get_segment_elements(0)[0] + E::from(main_current[3])).exp(E::PositiveInteger::from(2_u64)) * (E::ONE - E::from(main_current[1])) * E::from(main_current[2]) + (aux_rand_elements.get_segment_elements(0)[0] + E::from(main_current[3])) * E::from(main_current[1]) * (E::ONE - E::from(main_current[2])) + (E::ONE - E::from(main_current[1])) * (E::ONE - E::from(main_current[2]))) * E::from(main_current[0]) - E::from(main_current[0]) + E::ONE);
+        result[0] = aux_next[0] - aux_current[0] * ((E::from(main_current[3]).exp(E::PositiveInteger::from(4_u64)) * E::from(main_current[1]) * E::from(main_current[2]) + E::from(main_current[3]).exp(E::PositiveInteger::from(2_u64)) * (E::ONE - E::from(main_current[1])) * E::from(main_current[2]) + E::from(main_current[3]) * E::from(main_current[1]) * (E::ONE - E::from(main_current[2])) + (E::ONE - E::from(main_current[1])) * (E::ONE - E::from(main_current[2]))) * E::from(main_current[0]) - E::from(main_current[0]) + E::ONE);
     }
 }

--- a/air-script/tests/functions/functions_complex.rs
+++ b/air-script/tests/functions/functions_complex.rs
@@ -1,0 +1,91 @@
+use winter_air::{Air, AirContext, Assertion, AuxTraceRandElements, EvaluationFrame, ProofOptions as WinterProofOptions, TransitionConstraintDegree, TraceInfo};
+use winter_math::fields::f64::BaseElement as Felt;
+use winter_math::{ExtensionOf, FieldElement};
+use winter_utils::collections::Vec;
+use winter_utils::{ByteWriter, Serializable};
+
+pub struct PublicInputs {
+    stack_inputs: [Felt; 16],
+}
+
+impl PublicInputs {
+    pub fn new(stack_inputs: [Felt; 16]) -> Self {
+        Self { stack_inputs }
+    }
+}
+
+impl Serializable for PublicInputs {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write(self.stack_inputs.as_slice());
+    }
+}
+
+pub struct FunctionsAir {
+    context: AirContext<Felt>,
+    stack_inputs: [Felt; 16],
+}
+
+impl FunctionsAir {
+    pub fn last_step(&self) -> usize {
+        self.trace_length() - self.context().num_transition_exemptions()
+    }
+}
+
+impl Air for FunctionsAir {
+    type BaseField = Felt;
+    type PublicInputs = PublicInputs;
+
+    fn context(&self) -> &AirContext<Felt> {
+        &self.context
+    }
+
+    fn new(trace_info: TraceInfo, public_inputs: PublicInputs, options: WinterProofOptions) -> Self {
+        let main_degrees = vec![TransitionConstraintDegree::new(1)];
+        let aux_degrees = vec![TransitionConstraintDegree::new(8)];
+        let num_main_assertions = 1;
+        let num_aux_assertions = 0;
+
+        let context = AirContext::new_multi_segment(
+            trace_info,
+            main_degrees,
+            aux_degrees,
+            num_main_assertions,
+            num_aux_assertions,
+            options,
+        )
+        .set_num_transition_exemptions(2);
+        Self { context, stack_inputs: public_inputs.stack_inputs }
+    }
+
+    fn get_periodic_column_values(&self) -> Vec<Vec<Felt>> {
+        vec![]
+    }
+
+    fn get_assertions(&self) -> Vec<Assertion<Felt>> {
+        let mut result = Vec::new();
+        result.push(Assertion::single(3, 0, Felt::ZERO));
+        result
+    }
+
+    fn get_aux_assertions<E: FieldElement<BaseField = Felt>>(&self, aux_rand_elements: &AuxTraceRandElements<E>) -> Vec<Assertion<E>> {
+        let mut result = Vec::new();
+        result
+    }
+
+    fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
+        let main_current = frame.current();
+        let main_next = frame.next();
+        result[0] = main_next[3] - (main_current[4] + main_current[5] + main_current[6] + main_current[7] + main_current[8] + main_current[9] + main_current[10] + main_current[11] + main_current[12] + main_current[13] + main_current[14] + main_current[15] + E::ONE) * E::from(2_u64);
+    }
+
+    fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])
+    where F: FieldElement<BaseField = Felt>,
+          E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
+    {
+        let main_current = main_frame.current();
+        let main_next = main_frame.next();
+        let aux_current = aux_frame.current();
+        let aux_next = aux_frame.next();
+        result[0] = aux_next[0] - aux_current[0] * (((aux_rand_elements.get_segment_elements(0)[0] + E::from(main_current[3])).exp(E::PositiveInteger::from(4_u64)) * E::from(main_current[1]) * E::from(main_current[2]) + (aux_rand_elements.get_segment_elements(0)[0] + E::from(main_current[3])).exp(E::PositiveInteger::from(2_u64)) * (E::ONE - E::from(main_current[1])) * E::from(main_current[2]) + (aux_rand_elements.get_segment_elements(0)[0] + E::from(main_current[3])) * E::from(main_current[1]) * (E::ONE - E::from(main_current[2])) + (E::ONE - E::from(main_current[1])) * (E::ONE - E::from(main_current[2]))) * E::from(main_current[0]) - E::from(main_current[0]) + E::ONE);
+    }
+}

--- a/air-script/tests/functions/functions_simple.air
+++ b/air-script/tests/functions/functions_simple.air
@@ -1,0 +1,90 @@
+def FunctionsAir
+
+fn fold_sum(a: felt[4]) -> felt {
+    return a[0] + a[1] + a[2] + a[3]
+}
+
+fn fold_vec(a: felt[4]) -> felt {
+    let m = a[0] * a[1]
+    let n = m * a[2]
+    let o = n * a[3]
+    return o
+}
+
+fn cube(base: felt) -> felt {
+    return base^3
+}
+
+fn cube_vec(base: felt[4]) -> felt[4] {
+    let cubed_vec = [x^3 for x in base]
+    return cubed_vec
+}
+
+fn func_return(a: felt[4]) -> felt {
+    return fold_sum(a)
+}
+
+fn func_func_return(a: felt[4]) -> felt {
+    return fold_sum(a) * fold_vec(a)
+}
+
+fn bin_return(a: felt[4]) -> felt {
+    return fold_sum(a) * 4
+}
+
+trace_columns {
+    main: [t, s0, s1, v, b[4]]
+    aux: [b_range]
+}
+
+public_inputs {
+    stack_inputs: [16]
+}
+
+random_values {
+    alpha: [16]
+}
+
+boundary_constraints {
+    enf v.first = 0
+}
+
+integrity_constraints {
+    # -------- function call is assigned to a variable and used in a binary expression ------------
+
+    # binary expression invloving scalar expressions
+    let simple_expression = t * v
+    enf simple_expression = 1
+
+    # binary expression involving one function call
+    let folded_vec = fold_vec(b) * v
+    enf folded_vec = 1
+
+    # binary expression involving two function calls
+    let complex_fold = fold_sum(b) * fold_vec(b)
+    enf complex_fold = 1
+
+
+    # -------- function calls used in constraint ------------
+    enf fold_vec(b) = 1
+    enf t * fold_vec(b) = 1
+    enf s0 + fold_sum(b) * fold_vec(b) = 1
+
+    # -------- functions with function calls as return statements ------------
+    enf func_return(b) = 1
+    enf func_func_return(b) = 1
+    enf bin_return(b) = 1
+
+    # -------- different types of arguments in a function call ------------
+
+    # function call with a function call as an argument
+    # enf fold_vec(cube_vec(b)) = 1
+
+    # function call as value in list comprehension
+    # let folded_vec = sum([cube(x) for x in b])
+    # enf t * folded_vec = 1
+
+    # function call as iterable in list comprehension
+    # let folded_vec = sum([x + 1 for x in cube_vec(b)])
+    # enf t * folded_vec = 1
+}

--- a/air-script/tests/functions/functions_simple.masm
+++ b/air-script/tests/functions/functions_simple.masm
@@ -1,0 +1,166 @@
+# Procedure to efficiently compute the required exponentiations of the out-of-domain point `z` and cache them for later use.
+#
+# This computes the power of `z` needed to evaluate the periodic polynomials and the constraint divisors
+#
+# Input: [...]
+# Output: [...]
+proc.cache_z_exp
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, ...]
+    # Exponentiate z trace_len times
+    mem_load.4294903307 neg
+    # => [count, z_1, z_0, ...] where count = -log2(trace_len)
+    dup.0 neq.0
+    while.true
+        movdn.2 dup.1 dup.1 ext2mul
+        # => [(e_1, e_0)^n, i, ...]
+        movup.2 add.1 dup.0 neq.0
+        # => [b, i+1, (e_1, e_0)^n, ...]
+    end # END while
+    push.0 mem_storew.500000100 # z^trace_len
+    # => [0, 0, (z_1, z_0)^trace_len, ...]
+    dropw # Clean stack
+end # END PROC cache_z_exp
+
+# Procedure to compute the exemption points.
+#
+# Input: [...]
+# Output: [g^{-2}, g^{-1}, ...]
+proc.get_exemptions_points
+    mem_load.4294799999
+    # => [g, ...]
+    push.1 swap div
+    # => [g^{-1}, ...]
+    dup.0 dup.0 mul
+    # => [g^{-2}, g^{-1}, ...]
+end # END PROC get_exemptions_points
+
+# Procedure to compute the integrity constraint divisor.
+#
+# The divisor is defined as `(z^trace_len - 1) / ((z - g^{trace_len-2}) * (z - g^{trace_len-1}))`
+# Procedure `cache_z_exp` must have been called prior to this.
+#
+# Input: [...]
+# Output: [divisor_1, divisor_0, ...]
+proc.compute_integrity_constraint_divisor
+    padw mem_loadw.500000100 drop drop # load z^trace_len
+    # Comments below use zt = `z^trace_len`
+    # => [zt_1, zt_0, ...]
+    push.1 push.0 ext2sub
+    # => [zt_1-1, zt_0-1, ...]
+    padw mem_loadw.4294903304 drop drop # load z
+    # => [z_1, z_0, zt_1-1, zt_0-1, ...]
+    exec.get_exemptions_points
+    # => [g^{trace_len-2}, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    dup.0 mem_store.500000101 # Save a copy of `g^{trace_len-2} to be used by the boundary divisor
+    dup.3 dup.3 movup.3 push.0 ext2sub
+    # => [e_1, e_0, g^{trace_len-1}, z_1, z_0, zt_1-1, zt_0-1, ...]
+    movup.4 movup.4 movup.4 push.0 ext2sub
+    # => [e_3, e_2, e_1, e_0, zt_1-1, zt_0-1, ...]
+    ext2mul
+    # => [denominator_1, denominator_0, zt_1-1, zt_0-1, ...]
+    ext2div
+    # => [divisor_1, divisor_0, ...]
+end # END PROC compute_integrity_constraint_divisor
+
+# Procedure to evaluate numerators of all integrity constraints.
+#
+# All the 9 main and 0 auxiliary constraints are evaluated.
+# The result of each evaluation is kept on the stack, with the top of the stack
+# containing the evaluations for the auxiliary trace (if any) followed by the main trace.
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# where: (r_1, r_0) is the quadratic extension element resulting from the integrity constraint evaluation.
+#        This procedure pushes 9 quadratic extension field elements to the stack
+proc.compute_integrity_constraints
+    # integrity constraint 0 for main
+    padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop ext2mul push.1 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294900200 movdn.3 movdn.3 drop drop ext2mul
+    # integrity constraint 1 for main
+    padw mem_loadw.4294900004 movdn.3 movdn.3 drop drop padw mem_loadw.4294900005 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900006 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900007 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop ext2mul push.1 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294900200 drop drop ext2mul
+    # integrity constraint 2 for main
+    padw mem_loadw.4294900004 movdn.3 movdn.3 drop drop padw mem_loadw.4294900005 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900006 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900007 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900004 movdn.3 movdn.3 drop drop padw mem_loadw.4294900005 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900006 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900007 movdn.3 movdn.3 drop drop ext2mul ext2mul push.1 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294900201 movdn.3 movdn.3 drop drop ext2mul
+    # integrity constraint 3 for main
+    padw mem_loadw.4294900004 movdn.3 movdn.3 drop drop padw mem_loadw.4294900005 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900006 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900007 movdn.3 movdn.3 drop drop ext2mul push.1 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294900201 drop drop ext2mul
+    # integrity constraint 4 for main
+    padw mem_loadw.4294900000 movdn.3 movdn.3 drop drop padw mem_loadw.4294900004 movdn.3 movdn.3 drop drop padw mem_loadw.4294900005 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900006 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900007 movdn.3 movdn.3 drop drop ext2mul ext2mul push.1 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294900202 movdn.3 movdn.3 drop drop ext2mul
+    # integrity constraint 5 for main
+    padw mem_loadw.4294900001 movdn.3 movdn.3 drop drop padw mem_loadw.4294900004 movdn.3 movdn.3 drop drop padw mem_loadw.4294900005 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900006 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900007 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900004 movdn.3 movdn.3 drop drop padw mem_loadw.4294900005 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900006 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900007 movdn.3 movdn.3 drop drop ext2mul ext2mul ext2add push.1 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294900202 drop drop ext2mul
+    # integrity constraint 6 for main
+    padw mem_loadw.4294900004 movdn.3 movdn.3 drop drop padw mem_loadw.4294900005 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900006 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900007 movdn.3 movdn.3 drop drop ext2add push.1 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294900203 movdn.3 movdn.3 drop drop ext2mul
+    # integrity constraint 7 for main
+    padw mem_loadw.4294900004 movdn.3 movdn.3 drop drop padw mem_loadw.4294900005 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900006 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900007 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900004 movdn.3 movdn.3 drop drop padw mem_loadw.4294900005 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900006 movdn.3 movdn.3 drop drop ext2mul padw mem_loadw.4294900007 movdn.3 movdn.3 drop drop ext2mul ext2mul push.1 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294900203 drop drop ext2mul
+    # integrity constraint 8 for main
+    padw mem_loadw.4294900004 movdn.3 movdn.3 drop drop padw mem_loadw.4294900005 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900006 movdn.3 movdn.3 drop drop ext2add padw mem_loadw.4294900007 movdn.3 movdn.3 drop drop ext2add push.4 push.0 ext2mul push.1 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294900204 movdn.3 movdn.3 drop drop ext2mul
+end # END PROC compute_integrity_constraints
+
+# Procedure to evaluate the boundary constraint numerator for the first row of the main trace
+#
+# Input: [...]
+# Output: [(r_1, r_0)*, ...]
+# Where: (r_1, r_0) is one quadratic extension field element for each constraint
+proc.compute_boundary_constraints_main_first
+    # boundary constraint 0 for main
+    padw mem_loadw.4294900003 movdn.3 movdn.3 drop drop push.0 push.0 ext2sub
+    # Multiply by the composition coefficient
+    padw mem_loadw.4294900204 drop drop ext2mul
+end # END PROC compute_boundary_constraints_main_first
+
+# Procedure to evaluate all integrity constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
+proc.evaluate_integrity_constraints
+    exec.compute_integrity_constraints
+    # Numerator of the transition constraint polynomial
+    ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add ext2add
+    # Divisor of the transition constraint polynomial
+    exec.compute_integrity_constraint_divisor
+    ext2div # divide the numerator by the divisor
+end # END PROC evaluate_integrity_constraints
+
+# Procedure to evaluate all boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+# Where: (r_1, r_0) is the final result with the divisor applied
+proc.evaluate_boundary_constraints
+    exec.compute_boundary_constraints_main_first
+    # => [(first1, first0), ...]
+    # Compute the denominator for domain FirstRow
+    padw mem_loadw.4294903304 drop drop # load z
+    push.1 push.0 ext2sub
+    # Compute numerator/denominator for first row
+    ext2div
+end # END PROC evaluate_boundary_constraints
+
+# Procedure to evaluate the integrity and boundary constraints.
+#
+# Input: [...]
+# Output: [(r_1, r_0), ...]
+export.evaluate_constraints
+    exec.cache_z_exp
+    exec.evaluate_integrity_constraints
+    exec.evaluate_boundary_constraints
+    ext2add
+end # END PROC evaluate_constraints
+

--- a/air-script/tests/functions/functions_simple.rs
+++ b/air-script/tests/functions/functions_simple.rs
@@ -1,0 +1,98 @@
+use winter_air::{Air, AirContext, Assertion, AuxTraceRandElements, EvaluationFrame, ProofOptions as WinterProofOptions, TransitionConstraintDegree, TraceInfo};
+use winter_math::fields::f64::BaseElement as Felt;
+use winter_math::{ExtensionOf, FieldElement};
+use winter_utils::collections::Vec;
+use winter_utils::{ByteWriter, Serializable};
+
+pub struct PublicInputs {
+    stack_inputs: [Felt; 16],
+}
+
+impl PublicInputs {
+    pub fn new(stack_inputs: [Felt; 16]) -> Self {
+        Self { stack_inputs }
+    }
+}
+
+impl Serializable for PublicInputs {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write(self.stack_inputs.as_slice());
+    }
+}
+
+pub struct FunctionsAir {
+    context: AirContext<Felt>,
+    stack_inputs: [Felt; 16],
+}
+
+impl FunctionsAir {
+    pub fn last_step(&self) -> usize {
+        self.trace_length() - self.context().num_transition_exemptions()
+    }
+}
+
+impl Air for FunctionsAir {
+    type BaseField = Felt;
+    type PublicInputs = PublicInputs;
+
+    fn context(&self) -> &AirContext<Felt> {
+        &self.context
+    }
+
+    fn new(trace_info: TraceInfo, public_inputs: PublicInputs, options: WinterProofOptions) -> Self {
+        let main_degrees = vec![TransitionConstraintDegree::new(2), TransitionConstraintDegree::new(5), TransitionConstraintDegree::new(5), TransitionConstraintDegree::new(4), TransitionConstraintDegree::new(5), TransitionConstraintDegree::new(5), TransitionConstraintDegree::new(1), TransitionConstraintDegree::new(5), TransitionConstraintDegree::new(1)];
+        let aux_degrees = vec![];
+        let num_main_assertions = 1;
+        let num_aux_assertions = 0;
+
+        let context = AirContext::new_multi_segment(
+            trace_info,
+            main_degrees,
+            aux_degrees,
+            num_main_assertions,
+            num_aux_assertions,
+            options,
+        )
+        .set_num_transition_exemptions(2);
+        Self { context, stack_inputs: public_inputs.stack_inputs }
+    }
+
+    fn get_periodic_column_values(&self) -> Vec<Vec<Felt>> {
+        vec![]
+    }
+
+    fn get_assertions(&self) -> Vec<Assertion<Felt>> {
+        let mut result = Vec::new();
+        result.push(Assertion::single(3, 0, Felt::ZERO));
+        result
+    }
+
+    fn get_aux_assertions<E: FieldElement<BaseField = Felt>>(&self, aux_rand_elements: &AuxTraceRandElements<E>) -> Vec<Assertion<E>> {
+        let mut result = Vec::new();
+        result
+    }
+
+    fn evaluate_transition<E: FieldElement<BaseField = Felt>>(&self, frame: &EvaluationFrame<E>, periodic_values: &[E], result: &mut [E]) {
+        let main_current = frame.current();
+        let main_next = frame.next();
+        result[0] = main_current[0] * main_current[3] - E::ONE;
+        result[1] = main_current[4] * main_current[5] * main_current[6] * main_current[7] * main_current[3] - E::ONE;
+        result[2] = (main_current[4] + main_current[5] + main_current[6] + main_current[7]) * main_current[4] * main_current[5] * main_current[6] * main_current[7] - E::ONE;
+        result[3] = main_current[4] * main_current[5] * main_current[6] * main_current[7] - E::ONE;
+        result[4] = main_current[0] * main_current[4] * main_current[5] * main_current[6] * main_current[7] - E::ONE;
+        result[5] = main_current[1] + (main_current[4] + main_current[5] + main_current[6] + main_current[7]) * main_current[4] * main_current[5] * main_current[6] * main_current[7] - E::ONE;
+        result[6] = main_current[4] + main_current[5] + main_current[6] + main_current[7] - E::ONE;
+        result[7] = (main_current[4] + main_current[5] + main_current[6] + main_current[7]) * main_current[4] * main_current[5] * main_current[6] * main_current[7] - E::ONE;
+        result[8] = (main_current[4] + main_current[5] + main_current[6] + main_current[7]) * E::from(4_u64) - E::ONE;
+    }
+
+    fn evaluate_aux_transition<F, E>(&self, main_frame: &EvaluationFrame<F>, aux_frame: &EvaluationFrame<E>, _periodic_values: &[F], aux_rand_elements: &AuxTraceRandElements<E>, result: &mut [E])
+    where F: FieldElement<BaseField = Felt>,
+          E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
+    {
+        let main_current = main_frame.current();
+        let main_next = main_frame.next();
+        let aux_current = aux_frame.current();
+        let aux_next = aux_frame.next();
+    }
+}

--- a/air-script/tests/functions/inlined_functions_simple.air
+++ b/air-script/tests/functions/inlined_functions_simple.air
@@ -1,0 +1,52 @@
+# This file is added as a sanity check to make sure the constraints generated with inlined
+# functions is the same as those with functions
+def FunctionsAir
+
+trace_columns {
+    main: [t, s0, s1, v, b[4]]
+    aux: [b_range]
+}
+
+public_inputs {
+    stack_inputs: [16]
+}
+
+random_values {
+    alpha: [16]
+}
+
+boundary_constraints {
+    enf v.first = 0
+}
+
+integrity_constraints {
+    # -------- function call is assigned to a variable and used in a binary expression ------------
+
+    # binary expression invloving scalar expressions
+    let simple_expression = t * v
+    enf simple_expression = 1
+
+    # binary expression involving one function call
+
+    # fold_vec function body where o is the return value of the function
+    let m = b[0] * b[1]
+    let n = m * b[2]
+    let o = n * b[3]
+
+    let folded_vec = o * v
+    enf folded_vec = 1
+
+    # binary expression involving two function calls
+    let complex_fold = (b[0] + b[1] + b[2] + b[3]) * o
+    enf complex_fold = 1
+
+    # function calls used in constraints
+    enf o = 1
+    enf t * o = 1
+    enf s0 + (b[0] + b[1] + b[2] + b[3]) * o = 1
+
+    # -------- functions with function calls as return statements ------------
+    enf b[0] + b[1] + b[2] + b[3] = 1
+    enf (b[0] + b[1] + b[2] + b[3]) * o = 1
+    enf (b[0] + b[1] + b[2] + b[3]) * 4 = 1
+}

--- a/codegen/masm/Cargo.toml
+++ b/codegen/masm/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 repository = "https://github.com/0xPolygonMiden/air-script"
 categories = ["compilers", "cryptography"]
 keywords = ["air", "stark", "winterfell", "zero-knowledge", "zkp"]
-edition = "2021"
-rust-version = "1.67"
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 air-ir = { package = "air-ir", path = "../../ir", version = "0.4" }
@@ -22,6 +22,8 @@ winter-math = { package = "winter-math", version = "0.6", default-features = fal
 air-parser = { path = "../../parser" }
 air-pass = { path = "../../pass" }
 miden-assembly = { package = "miden-assembly", version = "0.6", default-features = false }
-miden-processor = { package = "miden-processor", version = "0.6", features = ["internals"], default-features = false }
+miden-processor = { package = "miden-processor", version = "0.6", features = [
+    "internals",
+], default-features = false }
 miden-diagnostics = "0.1"
 winter-air = { package = "winter-air", version = "0.6", default-features = false }

--- a/codegen/masm/tests/test_aux.rs
+++ b/codegen/masm/tests/test_aux.rs
@@ -40,7 +40,7 @@ fn test_simple_aux() {
 
     let trace_len = 2u64.pow(4);
     let one = QuadExtension::new(Felt::new(1), Felt::ZERO);
-    let z = one.clone();
+    let z = one;
     let a = QuadExtension::new(Felt::new(3), Felt::ZERO);
     let b = QuadExtension::new(Felt::new(7), Felt::ZERO);
     let a_prime = a;
@@ -60,7 +60,7 @@ fn test_simple_aux() {
                 descriptor: "aux_trace",
             },
             Data {
-                data: to_stack_order(&vec![one; 6]),
+                data: to_stack_order(&[one; 6]),
                 address: constants::COMPOSITION_COEF_ADDRESS,
                 descriptor: "composition_coefficients",
             },

--- a/codegen/masm/tests/test_boundary.rs
+++ b/codegen/masm/tests/test_boundary.rs
@@ -38,18 +38,18 @@ fn test_simple_boundary() {
 
     let trace_len = 32u64;
     let one = QuadExtension::ONE;
-    let z = one.clone();
+    let z = one;
     let a = QuadExtension::new(Felt::new(514229), Felt::ZERO);
     let b = QuadExtension::new(Felt::new(317811), Felt::ZERO);
     let len = QuadExtension::new(Felt::new(27), Felt::ZERO);
     let a_prime = QuadExtension::new(Felt::new(514229 + 317811), Felt::ZERO);
-    let b_prime = a.clone();
+    let b_prime = a;
 
     let code = test_code(
         code,
         vec![
             Data {
-                data: to_stack_order(&[a, a_prime, b, b_prime, len.clone(), len.clone()]),
+                data: to_stack_order(&[a, a_prime, b, b_prime, len, len]),
                 address: constants::OOD_FRAME_ADDRESS,
                 descriptor: "main_trace",
             },
@@ -151,7 +151,7 @@ fn test_complex_boundary() {
 
     let trace_len = 32u64;
     let one = QuadExtension::new(Felt::new(1), Felt::ZERO);
-    let z = one.clone();
+    let z = one;
 
     let public_inputs = [
         // stack_inputs

--- a/codegen/masm/tests/test_constants.rs
+++ b/codegen/masm/tests/test_constants.rs
@@ -66,7 +66,7 @@ fn test_constants() {
                 descriptor: "aux_trace",
             },
             Data {
-                data: to_stack_order(&vec![one; 3]),
+                data: to_stack_order(&[one; 3]),
                 address: constants::COMPOSITION_COEF_ADDRESS,
                 descriptor: "composition_coefficients",
             },

--- a/codegen/masm/tests/test_divisor.rs
+++ b/codegen/masm/tests/test_divisor.rs
@@ -50,7 +50,7 @@ fn test_integrity_divisor() {
                     descriptor: "main_trace",
                 },
                 Data {
-                    data: to_stack_order(&vec![one; 2]),
+                    data: to_stack_order(&[one; 2]),
                     address: constants::COMPOSITION_COEF_ADDRESS,
                     descriptor: "composition_coefficients",
                 },
@@ -149,7 +149,7 @@ fn test_boundary_divisor() {
                     descriptor: "aux_trace",
                 },
                 Data {
-                    data: to_stack_order(&vec![one; 5]),
+                    data: to_stack_order(&[one; 5]),
                     address: constants::COMPOSITION_COEF_ADDRESS,
                     descriptor: "composition_coefficients",
                 },
@@ -268,7 +268,7 @@ fn test_mixed_boundary_divisor() {
                     descriptor: "aux_trace",
                 },
                 Data {
-                    data: to_stack_order(&vec![one; 5]),
+                    data: to_stack_order(&[one; 5]),
                     address: constants::COMPOSITION_COEF_ADDRESS,
                     descriptor: "composition_coefficients",
                 },

--- a/codegen/masm/tests/test_periodic.rs
+++ b/codegen/masm/tests/test_periodic.rs
@@ -55,7 +55,7 @@ fn test_simple_periodic() {
                 descriptor: "aux_trace",
             },
             Data {
-                data: to_stack_order(&vec![one; 1]),
+                data: to_stack_order(&[one; 1]),
                 address: constants::COMPOSITION_COEF_ADDRESS,
                 descriptor: "composition_coefficients",
             },
@@ -150,7 +150,7 @@ fn test_multiple_periodic() {
                 descriptor: "aux_trace",
             },
             Data {
-                data: to_stack_order(&vec![one; 3]),
+                data: to_stack_order(&[one; 3]),
                 address: constants::COMPOSITION_COEF_ADDRESS,
                 descriptor: "composition_coefficients",
             },

--- a/codegen/winterfell/Cargo.toml
+++ b/codegen/winterfell/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 repository = "https://github.com/0xPolygonMiden/air-script"
 categories = ["compilers", "cryptography"]
 keywords = ["air", "stark", "winterfell", "zero-knowledge", "zkp"]
-edition = "2021"
-rust-version = "1.67"
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 air-ir = { package = "air-ir", path = "../../ir", version = "0.4" }

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 repository = "https://github.com/0xPolygonMiden/air-script"
 categories = ["compilers", "cryptography"]
 keywords = ["air", "stark", "zero-knowledge", "zkp"]
-edition = "2021"
-rust-version = "1.67"
+rust-version.workspace = true
+edition.workspace = true
 
 [dependencies]
 air-parser = { package = "air-parser", path = "../parser", version = "0.4" }

--- a/ir/src/passes/translate.rs
+++ b/ir/src/passes/translate.rs
@@ -23,6 +23,8 @@ impl<'p> Pass for AstToAir<'p> {
     type Error = CompileError;
 
     fn run<'a>(&mut self, program: Self::Input<'a>) -> Result<Self::Output<'a>, Self::Error> {
+        dbg!(&program);
+
         let mut air = Air::new(program.name);
 
         let random_values = program.random_values;
@@ -47,8 +49,8 @@ impl<'p> Pass for AstToAir<'p> {
             builder.build_boundary_constraint(bc)?;
         }
 
-        for bc in integrity_constraints.iter() {
-            builder.build_integrity_constraint(bc)?;
+        for ic in integrity_constraints.iter() {
+            builder.build_integrity_constraint(ic)?;
         }
 
         Ok(air)
@@ -98,8 +100,8 @@ impl<'a> AirBuilder<'a> {
         }
     }
 
-    fn build_integrity_constraint(&mut self, bc: &ast::Statement) -> Result<(), CompileError> {
-        match bc {
+    fn build_integrity_constraint(&mut self, ic: &ast::Statement) -> Result<(), CompileError> {
+        match ic {
             ast::Statement::Enforce(ast::ScalarExpr::Binary(ast::BinaryExpr {
                 op: ast::BinaryOp::Eq,
                 ref lhs,

--- a/ir/src/passes/translate.rs
+++ b/ir/src/passes/translate.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use air_parser::ast;
+use air_parser::{ast, LexicalScope};
 use air_pass::Pass;
 
 use miden_diagnostics::{DiagnosticsHandler, Severity, Span, Spanned};
@@ -23,8 +21,6 @@ impl<'p> Pass for AstToAir<'p> {
     type Error = CompileError;
 
     fn run<'a>(&mut self, program: Self::Input<'a>) -> Result<Self::Output<'a>, Self::Error> {
-        dbg!(&program);
-
         let mut air = Air::new(program.name);
 
         let random_values = program.random_values;
@@ -57,7 +53,7 @@ impl<'p> Pass for AstToAir<'p> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 enum MemoizedBinding {
     /// The binding was reduced to a node in the graph
     Scalar(NodeIndex),
@@ -72,7 +68,7 @@ struct AirBuilder<'a> {
     air: &'a mut Air,
     random_values: Option<ast::RandomValues>,
     trace_columns: Vec<ast::TraceSegment>,
-    bindings: HashMap<Identifier, MemoizedBinding>,
+    bindings: LexicalScope<Identifier, MemoizedBinding>,
 }
 impl<'a> AirBuilder<'a> {
     fn build_boundary_constraint(&mut self, bc: &ast::Statement) -> Result<(), CompileError> {
@@ -142,145 +138,13 @@ impl<'a> AirBuilder<'a> {
     where
         F: FnMut(&mut AirBuilder, &ast::Statement) -> Result<(), CompileError>,
     {
-        let prev = self.bindings.clone();
-        match expr.value {
-            ast::Expr::Const(ref constant) => match &constant.item {
-                ast::ConstantExpr::Scalar(value) => {
-                    let value = self.insert_constant(*value);
-                    self.bindings
-                        .insert(expr.name, MemoizedBinding::Scalar(value));
-                }
-                ast::ConstantExpr::Vector(values) => {
-                    let values = self.insert_constants(values.as_slice());
-                    self.bindings
-                        .insert(expr.name, MemoizedBinding::Vector(values));
-                }
-                ast::ConstantExpr::Matrix(values) => {
-                    let values = values
-                        .iter()
-                        .map(|vs| self.insert_constants(vs.as_slice()))
-                        .collect();
-                    self.bindings
-                        .insert(expr.name, MemoizedBinding::Matrix(values));
-                }
-            },
-            ast::Expr::Range(ref values) => {
-                let values = values
-                    .item
-                    .clone()
-                    .map(|v| self.insert_constant(v as u64))
-                    .collect();
-                self.bindings
-                    .insert(expr.name, MemoizedBinding::Vector(values));
-            }
-            ast::Expr::Vector(ref values) => match values[0].ty().unwrap() {
-                ast::Type::Felt => {
-                    let mut nodes = vec![];
-                    for value in values.iter().cloned() {
-                        let value = value.try_into().unwrap();
-                        nodes.push(self.insert_scalar_expr(&value));
-                    }
-                    self.bindings
-                        .insert(expr.name, MemoizedBinding::Vector(nodes));
-                }
-                ast::Type::Vector(n) => {
-                    let mut nodes = vec![];
-                    for row in values.iter().cloned() {
-                        match row {
-                            ast::Expr::Const(Span {
-                                item: ast::ConstantExpr::Vector(vs),
-                                ..
-                            }) => {
-                                nodes.push(self.insert_constants(vs.as_slice()));
-                            }
-                            ast::Expr::SymbolAccess(access) => {
-                                let mut cols = vec![];
-                                for i in 0..n {
-                                    let access = ast::ScalarExpr::SymbolAccess(
-                                        access.access(AccessType::Index(i)).unwrap(),
-                                    );
-                                    let node = self.insert_scalar_expr(&access);
-                                    cols.push(node);
-                                }
-                                nodes.push(cols);
-                            }
-                            ast::Expr::Vector(ref elems) => {
-                                let mut cols = vec![];
-                                for elem in elems.iter().cloned() {
-                                    let elem: ast::ScalarExpr = elem.try_into().unwrap();
-                                    let node = self.insert_scalar_expr(&elem);
-                                    cols.push(node);
-                                }
-                                nodes.push(cols);
-                            }
-                            _ => unreachable!(),
-                        }
-                    }
-                    self.bindings
-                        .insert(expr.name, MemoizedBinding::Matrix(nodes));
-                }
-                _ => unreachable!(),
-            },
-            ast::Expr::Matrix(ref values) => {
-                let values = values
-                    .iter()
-                    .map(|vs| vs.iter().map(|v| self.insert_scalar_expr(v)).collect())
-                    .collect();
-                self.bindings
-                    .insert(expr.name, MemoizedBinding::Matrix(values));
-            }
-            ast::Expr::Binary(ref bexpr) => {
-                let value = self.insert_binary_expr(bexpr);
-                self.bindings
-                    .insert(expr.name, MemoizedBinding::Scalar(value));
-            }
-            ast::Expr::SymbolAccess(ref access) => {
-                match self.bindings.get(access.name.as_ref()) {
-                    None => {
-                        // Must be a reference to a declaration
-                        let value = self.insert_symbol_access(access);
-                        self.bindings
-                            .insert(expr.name, MemoizedBinding::Scalar(value));
-                    }
-                    Some(MemoizedBinding::Scalar(node)) => {
-                        assert_eq!(access.access_type, AccessType::Default);
-                        self.bindings
-                            .insert(expr.name, MemoizedBinding::Scalar(*node));
-                    }
-                    Some(MemoizedBinding::Vector(nodes)) => {
-                        let value = match &access.access_type {
-                            AccessType::Default => MemoizedBinding::Vector(nodes.clone()),
-                            AccessType::Index(idx) => MemoizedBinding::Scalar(nodes[*idx]),
-                            AccessType::Slice(range) => {
-                                MemoizedBinding::Vector(nodes[range.start..range.end].to_vec())
-                            }
-                            AccessType::Matrix(_, _) => unreachable!(),
-                        };
-                        self.bindings.insert(expr.name, value);
-                    }
-                    Some(MemoizedBinding::Matrix(nodes)) => {
-                        let value = match &access.access_type {
-                            AccessType::Default => MemoizedBinding::Matrix(nodes.clone()),
-                            AccessType::Index(idx) => MemoizedBinding::Vector(nodes[*idx].clone()),
-                            AccessType::Slice(range) => {
-                                MemoizedBinding::Matrix(nodes[range.start..range.end].to_vec())
-                            }
-                            AccessType::Matrix(row, col) => {
-                                MemoizedBinding::Scalar(nodes[*row][*col])
-                            }
-                        };
-                        self.bindings.insert(expr.name, value);
-                    }
-                }
-            }
-            ast::Expr::Call(_) | ast::Expr::ListComprehension(_) => unreachable!(),
+        let bound = self.eval_expr(&expr.value)?;
+        self.bindings.enter();
+        self.bindings.insert(expr.name, bound);
+        for stmt in expr.body.iter() {
+            statement_builder(self, stmt)?;
         }
-
-        for statement in expr.body.iter() {
-            statement_builder(self, statement)?;
-        }
-
-        self.bindings = prev;
+        self.bindings.exit();
         Ok(())
     }
 
@@ -328,7 +192,7 @@ impl<'a> AirBuilder<'a> {
 
         let lhs = self.insert_op(Operation::Value(Value::TraceAccess(trace_access)));
         // Insert the right-hand expression into the graph
-        let rhs = self.insert_scalar_expr(rhs);
+        let rhs = self.insert_scalar_expr(rhs)?;
         // Compare the inferred trace segment and domain of the operands
         let domain = access.boundary.into();
         {
@@ -374,9 +238,12 @@ impl<'a> AirBuilder<'a> {
         rhs: &ast::ScalarExpr,
         condition: Option<&ast::ScalarExpr>,
     ) -> Result<(), CompileError> {
-        let lhs = self.insert_scalar_expr(lhs);
-        let rhs = self.insert_scalar_expr(rhs);
-        let condition = condition.as_ref().map(|cond| self.insert_scalar_expr(cond));
+        let lhs = self.insert_scalar_expr(lhs)?;
+        let rhs = self.insert_scalar_expr(rhs)?;
+        let condition = match condition {
+            Some(cond) => Some(self.insert_scalar_expr(cond)?),
+            None => None,
+        };
         let root = self.merge_equal_exprs(lhs, rhs, condition);
         // Get the trace segment and domain of the constraint.
         //
@@ -407,34 +274,197 @@ impl<'a> AirBuilder<'a> {
         }
     }
 
-    fn insert_scalar_expr(&mut self, expr: &ast::ScalarExpr) -> NodeIndex {
+    fn eval_let_expr(&mut self, expr: &ast::Let) -> Result<MemoizedBinding, CompileError> {
+        let mut next_let = Some(expr);
+        let snapshot = self.bindings.clone();
+        loop {
+            let let_expr = next_let.take().expect("invalid empty let body");
+            let bound = self.eval_expr(&let_expr.value)?;
+            self.bindings.enter();
+            self.bindings.insert(let_expr.name, bound);
+            match let_expr.body.last().unwrap() {
+                ast::Statement::Let(ref inner_let) => {
+                    next_let = Some(inner_let);
+                }
+                ast::Statement::Expr(ref expr) => {
+                    let value = self.eval_expr(expr);
+                    self.bindings = snapshot;
+                    break value;
+                }
+                ast::Statement::Enforce(_)
+                | ast::Statement::EnforceIf(_, _)
+                | ast::Statement::EnforceAll(_) => {
+                    unreachable!()
+                }
+            }
+        }
+    }
+
+    fn eval_expr(&mut self, expr: &ast::Expr) -> Result<MemoizedBinding, CompileError> {
+        match expr {
+            ast::Expr::Const(ref constant) => match &constant.item {
+                ast::ConstantExpr::Scalar(value) => {
+                    let value = self.insert_constant(*value);
+                    Ok(MemoizedBinding::Scalar(value))
+                }
+                ast::ConstantExpr::Vector(values) => {
+                    let values = self.insert_constants(values.as_slice());
+                    Ok(MemoizedBinding::Vector(values))
+                }
+                ast::ConstantExpr::Matrix(values) => {
+                    let values = values
+                        .iter()
+                        .map(|vs| self.insert_constants(vs.as_slice()))
+                        .collect();
+                    Ok(MemoizedBinding::Matrix(values))
+                }
+            },
+            ast::Expr::Range(ref values) => {
+                let values = values
+                    .item
+                    .clone()
+                    .map(|v| self.insert_constant(v as u64))
+                    .collect();
+                Ok(MemoizedBinding::Vector(values))
+            }
+            ast::Expr::Vector(ref values) => match values[0].ty().unwrap() {
+                ast::Type::Felt => {
+                    let mut nodes = vec![];
+                    for value in values.iter().cloned() {
+                        let value = value.try_into().unwrap();
+                        nodes.push(self.insert_scalar_expr(&value)?);
+                    }
+                    Ok(MemoizedBinding::Vector(nodes))
+                }
+                ast::Type::Vector(n) => {
+                    let mut nodes = vec![];
+                    for row in values.iter().cloned() {
+                        match row {
+                            ast::Expr::Const(Span {
+                                item: ast::ConstantExpr::Vector(vs),
+                                ..
+                            }) => {
+                                nodes.push(self.insert_constants(vs.as_slice()));
+                            }
+                            ast::Expr::SymbolAccess(access) => {
+                                let mut cols = vec![];
+                                for i in 0..n {
+                                    let access = ast::ScalarExpr::SymbolAccess(
+                                        access.access(AccessType::Index(i)).unwrap(),
+                                    );
+                                    let node = self.insert_scalar_expr(&access)?;
+                                    cols.push(node);
+                                }
+                                nodes.push(cols);
+                            }
+                            ast::Expr::Vector(ref elems) => {
+                                let mut cols = vec![];
+                                for elem in elems.iter().cloned() {
+                                    let elem: ast::ScalarExpr = elem.try_into().unwrap();
+                                    let node = self.insert_scalar_expr(&elem)?;
+                                    cols.push(node);
+                                }
+                                nodes.push(cols);
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                    Ok(MemoizedBinding::Matrix(nodes))
+                }
+                _ => unreachable!(),
+            },
+            ast::Expr::Matrix(ref values) => {
+                let mut rows = Vec::with_capacity(values.len());
+                for vs in values.iter() {
+                    let mut cols = Vec::with_capacity(vs.len());
+                    for value in vs {
+                        cols.push(self.insert_scalar_expr(value)?);
+                    }
+                    rows.push(cols);
+                }
+                Ok(MemoizedBinding::Matrix(rows))
+            }
+            ast::Expr::Binary(ref bexpr) => {
+                let value = self.insert_binary_expr(bexpr)?;
+                Ok(MemoizedBinding::Scalar(value))
+            }
+            ast::Expr::SymbolAccess(ref access) => {
+                match self.bindings.get(access.name.as_ref()) {
+                    None => {
+                        // Must be a reference to a declaration
+                        let value = self.insert_symbol_access(access);
+                        Ok(MemoizedBinding::Scalar(value))
+                    }
+                    Some(MemoizedBinding::Scalar(node)) => {
+                        assert_eq!(access.access_type, AccessType::Default);
+                        Ok(MemoizedBinding::Scalar(*node))
+                    }
+                    Some(MemoizedBinding::Vector(nodes)) => {
+                        let value = match &access.access_type {
+                            AccessType::Default => MemoizedBinding::Vector(nodes.clone()),
+                            AccessType::Index(idx) => MemoizedBinding::Scalar(nodes[*idx]),
+                            AccessType::Slice(range) => {
+                                MemoizedBinding::Vector(nodes[range.start..range.end].to_vec())
+                            }
+                            AccessType::Matrix(_, _) => unreachable!(),
+                        };
+                        Ok(value)
+                    }
+                    Some(MemoizedBinding::Matrix(nodes)) => {
+                        let value = match &access.access_type {
+                            AccessType::Default => MemoizedBinding::Matrix(nodes.clone()),
+                            AccessType::Index(idx) => MemoizedBinding::Vector(nodes[*idx].clone()),
+                            AccessType::Slice(range) => {
+                                MemoizedBinding::Matrix(nodes[range.start..range.end].to_vec())
+                            }
+                            AccessType::Matrix(row, col) => {
+                                MemoizedBinding::Scalar(nodes[*row][*col])
+                            }
+                        };
+                        Ok(value)
+                    }
+                }
+            }
+            ast::Expr::Let(ref let_expr) => self.eval_let_expr(let_expr),
+            // These node types should not exist at this point
+            ast::Expr::Call(_) | ast::Expr::ListComprehension(_) => unreachable!(),
+        }
+    }
+
+    fn insert_scalar_expr(&mut self, expr: &ast::ScalarExpr) -> Result<NodeIndex, CompileError> {
         match expr {
             ast::ScalarExpr::Const(value) => {
-                self.insert_op(Operation::Value(Value::Constant(value.item)))
+                Ok(self.insert_op(Operation::Value(Value::Constant(value.item))))
             }
-            ast::ScalarExpr::SymbolAccess(access) => self.insert_symbol_access(access),
+            ast::ScalarExpr::SymbolAccess(access) => Ok(self.insert_symbol_access(access)),
             ast::ScalarExpr::Binary(expr) => self.insert_binary_expr(expr),
+            ast::ScalarExpr::Let(ref let_expr) => match self.eval_let_expr(let_expr)? {
+                MemoizedBinding::Scalar(node) => Ok(node),
+                invalid => {
+                    panic!("expected scalar expression to produce scalar value, got: {invalid:?}")
+                }
+            },
             ast::ScalarExpr::Call(_) | ast::ScalarExpr::BoundedSymbolAccess(_) => unreachable!(),
         }
     }
 
-    fn insert_binary_expr(&mut self, expr: &ast::BinaryExpr) -> NodeIndex {
+    fn insert_binary_expr(&mut self, expr: &ast::BinaryExpr) -> Result<NodeIndex, CompileError> {
         if expr.op == ast::BinaryOp::Exp {
-            let lhs = self.insert_scalar_expr(expr.lhs.as_ref());
+            let lhs = self.insert_scalar_expr(expr.lhs.as_ref())?;
             let ast::ScalarExpr::Const(rhs) = expr.rhs.as_ref() else {
                 unreachable!();
             };
-            return self.insert_op(Operation::Exp(lhs, rhs.item as usize));
+            return Ok(self.insert_op(Operation::Exp(lhs, rhs.item as usize)));
         }
 
-        let lhs = self.insert_scalar_expr(expr.lhs.as_ref());
-        let rhs = self.insert_scalar_expr(expr.rhs.as_ref());
-        match expr.op {
+        let lhs = self.insert_scalar_expr(expr.lhs.as_ref())?;
+        let rhs = self.insert_scalar_expr(expr.rhs.as_ref())?;
+        Ok(match expr.op {
             ast::BinaryOp::Add => self.insert_op(Operation::Add(lhs, rhs)),
             ast::BinaryOp::Sub => self.insert_op(Operation::Sub(lhs, rhs)),
             ast::BinaryOp::Mul => self.insert_op(Operation::Mul(lhs, rhs)),
             _ => unreachable!(),
-        }
+        })
     }
 
     fn insert_symbol_access(&mut self, access: &ast::SymbolAccess) -> NodeIndex {

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -16,9 +16,10 @@ lalrpop = { version = "0.20", default-features = false }
 
 [dependencies]
 air-pass = { package = "air-pass", path = "../pass", version = "0.1" }
+either = "1.12"
 miden-diagnostics = "0.1"
 miden-parsing = "0.1"
-lalrpop-util="0.20"
+lalrpop-util = "0.20"
 lazy_static = "1.4"
 petgraph = "0.6"
 regex = "1"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 repository = "https://github.com/0xPolygonMiden/air-script"
 categories = ["compilers", "cryptography", "parser-implementations"]
 keywords = ["air", "stark", "zero-knowledge", "zkp"]
-edition = "2021"
-rust-version = "1.67"
+rust-version.workspace = true
+edition.workspace = true
 
 [build-dependencies]
 lalrpop = { version = "0.20", default-features = false }

--- a/parser/src/ast/declarations.rs
+++ b/parser/src/ast/declarations.rs
@@ -41,6 +41,10 @@ pub enum Declaration {
     ///
     /// Evaluator functions can be defined in any module of the program
     EvaluatorFunction(EvaluatorFunction),
+    /// A pure function definition
+    ///
+    /// Pure functions can be defined in any module of the program
+    Function(Function),
     /// A `periodic_columns` section declaration
     ///
     /// This may appear any number of times in the program, and may be declared in any module.
@@ -523,5 +527,52 @@ impl Eq for EvaluatorFunction {}
 impl PartialEq for EvaluatorFunction {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name && self.params == other.params && self.body == other.body
+    }
+}
+
+/// Functions take a group of expressions as parameters and returns a value.
+///
+/// The result value of a function may be a felt, vector, or a matrix.
+///
+/// NOTE: Functions do not take trace bindings as parameters.
+#[derive(Debug, Clone, Spanned)]
+pub struct Function {
+    #[span]
+    pub span: SourceSpan,
+    pub name: Identifier,
+    pub params: Vec<(Identifier, Type)>,
+    pub return_type: Type,
+    pub body: Vec<Statement>,
+}
+impl Function {
+    /// Creates a new function.
+    pub const fn new(
+        span: SourceSpan,
+        name: Identifier,
+        params: Vec<(Identifier, Type)>,
+        return_type: Type,
+        body: Vec<Statement>,
+    ) -> Self {
+        Self {
+            span,
+            name,
+            params,
+            return_type,
+            body,
+        }
+    }
+
+    pub fn param_types(&self) -> Vec<Type> {
+        self.params.iter().map(|(_, ty)| *ty).collect::<Vec<_>>()
+    }
+}
+
+impl Eq for Function {}
+impl PartialEq for Function {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.params == other.params
+            && self.return_type == other.return_type
+            && self.body == other.body
     }
 }

--- a/parser/src/ast/display.rs
+++ b/parser/src/ast/display.rs
@@ -10,7 +10,7 @@ impl<T: fmt::Display> fmt::Display for DisplayBracketed<T> {
     }
 }
 
-/// Displays a slice of items surrounded by brackets, e.g. `[foo]`
+/// Displays a slice of items surrounded by brackets, e.g. `[foo, bar]`
 pub struct DisplayList<'a, T>(pub &'a [T]);
 impl<'a, T: fmt::Display> fmt::Display for DisplayList<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -26,11 +26,24 @@ impl<T: fmt::Display> fmt::Display for DisplayParenthesized<T> {
     }
 }
 
-/// Displays a slice of items surrounded by parentheses, e.g. `(foo)`
+/// Displays a slice of items surrounded by parentheses, e.g. `(foo, bar)`
 pub struct DisplayTuple<'a, T>(pub &'a [T]);
 impl<'a, T: fmt::Display> fmt::Display for DisplayTuple<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({})", DisplayCsv::new(self.0.iter()))
+    }
+}
+
+/// Displays a slice of items with their types surrounded by parentheses,
+/// e.g. `(foo: felt, bar: felt[12])`
+pub struct DisplayTypedTuple<'a, V, T>(pub &'a [(V, T)]);
+impl<'a, V: fmt::Display, T: fmt::Display> fmt::Display for DisplayTypedTuple<'a, V, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "({})",
+            DisplayCsv::new(self.0.iter().map(|(v, t)| format!("{}: {}", v, t)))
+        )
     }
 }
 
@@ -96,7 +109,7 @@ impl<'a> fmt::Display for DisplayStatement<'a> {
             Statement::EnforceAll(ref expr) => {
                 write!(f, "enf {}", expr)
             }
-            Statement::Expr(ref expr) => write!(f, "{}", expr),
+            Statement::Expr(ref expr) => write!(f, "return {}", expr),
         }
     }
 }

--- a/parser/src/ast/errors.rs
+++ b/parser/src/ast/errors.rs
@@ -11,6 +11,10 @@ pub enum InvalidExprError {
     BoundedSymbolAccess(SourceSpan),
     #[error("expected scalar expression")]
     InvalidScalarExpr(SourceSpan),
+    #[error("invalid let in expression position: body produces no value, or the type of that value is unknown")]
+    InvalidLetExpr(SourceSpan),
+    #[error("syntax does not represent a valid expression")]
+    NotAnExpr(SourceSpan),
 }
 impl Eq for InvalidExprError {}
 impl PartialEq for InvalidExprError {
@@ -22,11 +26,6 @@ impl ToDiagnostic for InvalidExprError {
     fn to_diagnostic(self) -> Diagnostic {
         let message = format!("{}", &self);
         match self {
-            Self::InvalidExponent(span) => Diagnostic::error()
-                .with_message("invalid expression")
-                .with_labels(vec![
-                    Label::primary(span.source_id(), span).with_message(message)
-                ]),
             Self::NonConstantExponent(span) => Diagnostic::error()
                 .with_message("invalid expression")
                 .with_labels(vec![
@@ -36,12 +35,11 @@ impl ToDiagnostic for InvalidExprError {
                     "Only constant powers are supported with the exponentiation operator currently"
                         .to_string(),
                 ]),
-            Self::BoundedSymbolAccess(span) => Diagnostic::error()
-                .with_message("invalid expression")
-                .with_labels(vec![
-                    Label::primary(span.source_id(), span).with_message(message)
-                ]),
-            Self::InvalidScalarExpr(span) => Diagnostic::error()
+            Self::InvalidExponent(span)
+            | Self::BoundedSymbolAccess(span)
+            | Self::InvalidScalarExpr(span)
+            | Self::InvalidLetExpr(span)
+            | Self::NotAnExpr(span) => Diagnostic::error()
                 .with_message("invalid expression")
                 .with_labels(vec![
                     Label::primary(span.source_id(), span).with_message(message)

--- a/parser/src/ast/errors.rs
+++ b/parser/src/ast/errors.rs
@@ -49,3 +49,29 @@ impl ToDiagnostic for InvalidExprError {
         }
     }
 }
+
+/// Represents an invalid type for use in a `BindingType` context
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidTypeError {
+    #[error("expected iterable to be a vector")]
+    NonVectorIterable(SourceSpan),
+}
+impl Eq for InvalidTypeError {}
+impl PartialEq for InvalidTypeError {
+    fn eq(&self, other: &Self) -> bool {
+        core::mem::discriminant(self) == core::mem::discriminant(other)
+    }
+}
+impl ToDiagnostic for InvalidTypeError {
+    fn to_diagnostic(self) -> Diagnostic {
+        let message = format!("{}", &self);
+        match self {
+            Self::NonVectorIterable(span) => Diagnostic::error()
+                .with_message("invalid type")
+                .with_labels(vec![
+                    Label::primary(span.source_id(), span).with_message(message)
+                ])
+                .with_notes(vec!["Only vectors can be used as iterables".to_string()]),
+        }
+    }
+}

--- a/parser/src/ast/expression.rs
+++ b/parser/src/ast/expression.rs
@@ -472,7 +472,7 @@ pub enum ScalarExpr {
     ///
     /// 1. The call is the top-level expression of a constraint, and is to an evaluator function
     /// 2. The call is not the top-level expression of a constraint, and is to a pure function
-    /// that produces a scalar value type.
+    ///    that produces a scalar value type.
     ///
     /// If neither of the above are true, the call is invalid in a `ScalarExpr` context
     Call(Call),
@@ -1138,8 +1138,8 @@ pub struct Call {
     ///
     /// * Calls to evaluators produce no value, and thus have no type
     /// * When parsed, the callee has not yet been resolved, so we don't know the
-    /// type of the function being called. During semantic analysis, the callee is
-    /// resolved and this field is set to the result type of that function.
+    ///   type of the function being called. During semantic analysis, the callee is
+    ///   resolved and this field is set to the result type of that function.
     pub ty: Option<Type>,
 }
 impl Call {

--- a/parser/src/ast/expression.rs
+++ b/parser/src/ast/expression.rs
@@ -445,6 +445,15 @@ impl ScalarExpr {
         matches!(self, Self::Const(_))
     }
 
+    /// Returns true if this scalar expression could expand to a block, e.g. due to a function call being inlined.
+    pub fn has_block_like_expansion(&self) -> bool {
+        match self {
+            Self::Binary(ref expr) => expr.has_block_like_expansion(),
+            Self::Call(_) => true,
+            _ => false,
+        }
+    }
+
     /// Returns the resolved type of this expression, if known.
     ///
     /// Returns `Ok(Some)` if the type could be resolved without conflict.
@@ -526,6 +535,12 @@ impl BinaryExpr {
             lhs: Box::new(lhs),
             rhs: Box::new(rhs),
         }
+    }
+
+    /// Returns true if this binary expression could expand to a block, e.g. due to a function call being inlined.
+    #[inline]
+    pub fn has_block_like_expansion(&self) -> bool {
+        self.lhs.has_block_like_expansion() || self.rhs.has_block_like_expansion()
     }
 }
 impl Eq for BinaryExpr {}

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -71,6 +71,8 @@ pub struct Program {
     pub constants: BTreeMap<QualifiedIdentifier, Constant>,
     /// The set of used evaluator functions referenced in this program.
     pub evaluators: BTreeMap<QualifiedIdentifier, EvaluatorFunction>,
+    /// The set of used pure functions referenced in this program.
+    pub functions: BTreeMap<QualifiedIdentifier, Function>,
     /// The set of used periodic columns referenced in this program.
     pub periodic_columns: BTreeMap<QualifiedIdentifier, PeriodicColumn>,
     /// The set of public inputs defined in the root module
@@ -115,6 +117,7 @@ impl Program {
             name,
             constants: Default::default(),
             evaluators: Default::default(),
+            functions: Default::default(),
             periodic_columns: Default::default(),
             public_inputs: Default::default(),
             random_values: None,
@@ -265,7 +268,12 @@ impl Program {
                             .entry(referenced)
                             .or_insert_with(|| referenced_module.evaluators[&id].clone());
                     }
-                    DependencyType::Function => unimplemented!(),
+                    DependencyType::Function => {
+                        program
+                            .functions
+                            .entry(referenced)
+                            .or_insert_with(|| referenced_module.functions[&id].clone());
+                    }
                     DependencyType::PeriodicColumn => {
                         program
                             .periodic_columns
@@ -288,6 +296,7 @@ impl PartialEq for Program {
         self.name == other.name
             && self.constants == other.constants
             && self.evaluators == other.evaluators
+            && self.functions == other.functions
             && self.periodic_columns == other.periodic_columns
             && self.public_inputs == other.public_inputs
             && self.random_values == other.random_values
@@ -382,6 +391,29 @@ impl fmt::Display for Program {
             }
             f.write_str("}}")?;
             f.write_str("\n")?;
+        }
+
+        for (qid, function) in self.functions.iter() {
+            f.write_str("fn ")?;
+            if qid.module == self.name {
+                writeln!(
+                    f,
+                    "{}{}",
+                    &qid.item,
+                    DisplayTypedTuple(function.params.as_slice())
+                )?;
+            } else {
+                writeln!(
+                    f,
+                    "{}{}",
+                    qid,
+                    DisplayTypedTuple(function.params.as_slice())
+                )?;
+            }
+
+            for statement in function.body.iter() {
+                writeln!(f, "{}", statement.display(1))?;
+            }
         }
 
         Ok(())

--- a/parser/src/ast/module.rs
+++ b/parser/src/ast/module.rs
@@ -54,6 +54,7 @@ pub struct Module {
     pub imports: BTreeMap<ModuleId, Import>,
     pub constants: BTreeMap<Identifier, Constant>,
     pub evaluators: BTreeMap<Identifier, EvaluatorFunction>,
+    pub functions: BTreeMap<Identifier, Function>,
     pub periodic_columns: BTreeMap<Identifier, PeriodicColumn>,
     pub public_inputs: BTreeMap<Identifier, PublicInput>,
     pub random_values: Option<RandomValues>,
@@ -79,6 +80,7 @@ impl Module {
             imports: Default::default(),
             constants: Default::default(),
             evaluators: Default::default(),
+            functions: Default::default(),
             periodic_columns: Default::default(),
             public_inputs: Default::default(),
             random_values: None,
@@ -120,6 +122,9 @@ impl Module {
                 }
                 Declaration::EvaluatorFunction(evaluator) => {
                     module.declare_evaluator(diagnostics, &mut names, evaluator)?;
+                }
+                Declaration::Function(function) => {
+                    module.declare_function(diagnostics, &mut names, function)?;
                 }
                 Declaration::PeriodicColumns(mut columns) => {
                     for column in columns.drain(..) {
@@ -395,6 +400,22 @@ impl Module {
         Ok(())
     }
 
+    fn declare_function(
+        &mut self,
+        diagnostics: &DiagnosticsHandler,
+        names: &mut HashSet<NamespacedIdentifier>,
+        function: Function,
+    ) -> Result<(), SemanticAnalysisError> {
+        if let Some(prev) = names.replace(NamespacedIdentifier::Function(function.name)) {
+            conflicting_declaration(diagnostics, "function", prev.span(), function.name.span());
+            return Err(SemanticAnalysisError::NameConflict(function.name.span()));
+        }
+
+        self.functions.insert(function.name, function);
+
+        Ok(())
+    }
+
     fn declare_periodic_column(
         &mut self,
         diagnostics: &DiagnosticsHandler,
@@ -621,6 +642,7 @@ impl PartialEq for Module {
             && self.imports == other.imports
             && self.constants == other.constants
             && self.evaluators == other.evaluators
+            && self.functions == other.functions
             && self.periodic_columns == other.periodic_columns
             && self.public_inputs == other.public_inputs
             && self.random_values == other.random_values

--- a/parser/src/ast/module.rs
+++ b/parser/src/ast/module.rs
@@ -35,8 +35,8 @@ pub enum ModuleType {
 ///
 /// * Fields which are only allowed in root modules are empty/unset in library modules
 /// * Fields which must be present in root modules are guaranteed to be present in a root module
-/// * It is guaranteed that at least one boundary constraint and one integrity constraint are present
-/// in a root module
+/// * It is guaranteed that at least one boundary constraint and one integrity constraint are
+///   present in a root module
 /// * No duplicate module-level declarations were present
 /// * All globally-visible declarations are unique
 ///

--- a/parser/src/ast/statement.rs
+++ b/parser/src/ast/statement.rs
@@ -82,6 +82,24 @@ impl Statement {
         }
     }
 }
+impl From<Expr> for Statement {
+    fn from(expr: Expr) -> Self {
+        match expr {
+            Expr::Let(let_expr) => Self::Let(*let_expr),
+            expr => Self::Expr(expr),
+        }
+    }
+}
+impl TryFrom<ScalarExpr> for Statement {
+    type Error = ();
+
+    fn try_from(expr: ScalarExpr) -> Result<Self, Self::Error> {
+        match expr {
+            ScalarExpr::Let(let_expr) => Ok(Self::Let(*let_expr)),
+            expr => Expr::try_from(expr).map_err(|_| ()).map(Self::Expr),
+        }
+    }
+}
 
 /// A `let` statement binds `name` to the value of `expr` in `body`.
 #[derive(Clone, Spanned)]

--- a/parser/src/ast/types.rs
+++ b/parser/src/ast/types.rs
@@ -72,9 +72,9 @@ impl Type {
 impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Felt => f.write_str("field element"),
-            Self::Vector(n) => write!(f, "vector of length {}", n),
-            Self::Matrix(rows, cols) => write!(f, "matrix of {} rows and {} columns", rows, cols),
+            Self::Felt => f.write_str("felt"),
+            Self::Vector(n) => write!(f, "felt[{}]", n),
+            Self::Matrix(rows, cols) => write!(f, "felt[{}, {}]", rows, cols),
         }
     }
 }
@@ -86,7 +86,6 @@ pub enum FunctionType {
     /// a complex type signature due to the nature of trace bindings
     Evaluator(Vec<TraceSegment>),
     /// A standard function with one or more inputs, and a result
-    #[allow(dead_code)]
     Function(Vec<Type>, Type),
 }
 impl FunctionType {

--- a/parser/src/ast/visit.rs
+++ b/parser/src/ast/visit.rs
@@ -601,6 +601,7 @@ where
         ast::Expr::Binary(ref mut expr) => visitor.visit_mut_binary_expr(expr),
         ast::Expr::Call(ref mut expr) => visitor.visit_mut_call(expr),
         ast::Expr::ListComprehension(ref mut expr) => visitor.visit_mut_list_comprehension(expr),
+        ast::Expr::Let(ref mut expr) => visitor.visit_mut_let(expr),
     }
 }
 
@@ -616,6 +617,7 @@ where
         }
         ast::ScalarExpr::Binary(ref mut expr) => visitor.visit_mut_binary_expr(expr),
         ast::ScalarExpr::Call(ref mut expr) => visitor.visit_mut_call(expr),
+        ast::ScalarExpr::Let(ref mut expr) => visitor.visit_mut_let(expr),
     }
 }
 

--- a/parser/src/lexer/mod.rs
+++ b/parser/src/lexer/mod.rs
@@ -113,6 +113,8 @@ pub enum Token {
     RandomValues,
     /// Keyword to declare the evaluator function section in the AIR constraints module.
     Ev,
+    /// Keyword to declare the function section in the AIR constraints module.
+    Fn,
 
     // BOUNDARY CONSTRAINT KEYWORDS
     // --------------------------------------------------------------------------------------------
@@ -137,9 +139,11 @@ pub enum Token {
     // --------------------------------------------------------------------------------------------
     /// Keyword to signify that a constraint needs to be enforced
     Enf,
+    Return,
     Match,
     Case,
     When,
+    Felt,
 
     // PUNCTUATION
     // --------------------------------------------------------------------------------------------
@@ -163,6 +167,7 @@ pub enum Token {
     Ampersand,
     Bar,
     Bang,
+    Arrow,
 }
 impl Token {
     pub fn from_keyword_or_ident(s: &str) -> Self {
@@ -179,6 +184,8 @@ impl Token {
             "periodic_columns" => Self::PeriodicColumns,
             "random_values" => Self::RandomValues,
             "ev" => Self::Ev,
+            "fn" => Self::Fn,
+            "felt" => Self::Felt,
             "boundary_constraints" => Self::BoundaryConstraints,
             "integrity_constraints" => Self::IntegrityConstraints,
             "first" => Self::First,
@@ -186,6 +193,7 @@ impl Token {
             "for" => Self::For,
             "in" => Self::In,
             "enf" => Self::Enf,
+            "return" => Self::Return,
             "match" => Self::Match,
             "case" => Self::Case,
             "when" => Self::When,
@@ -249,6 +257,8 @@ impl fmt::Display for Token {
             Self::PeriodicColumns => write!(f, "periodic_columns"),
             Self::RandomValues => write!(f, "random_values"),
             Self::Ev => write!(f, "ev"),
+            Self::Fn => write!(f, "fn"),
+            Self::Felt => write!(f, "felt"),
             Self::BoundaryConstraints => write!(f, "boundary_constraints"),
             Self::First => write!(f, "first"),
             Self::Last => write!(f, "last"),
@@ -256,6 +266,7 @@ impl fmt::Display for Token {
             Self::For => write!(f, "for"),
             Self::In => write!(f, "in"),
             Self::Enf => write!(f, "enf"),
+            Self::Return => write!(f, "return"),
             Self::Match => write!(f, "match"),
             Self::Case => write!(f, "case"),
             Self::When => write!(f, "when"),
@@ -279,6 +290,7 @@ impl fmt::Display for Token {
             Self::Ampersand => write!(f, "&"),
             Self::Bar => write!(f, "|"),
             Self::Bang => write!(f, "!"),
+            Self::Arrow => write!(f, "->"),
         }
     }
 }
@@ -492,7 +504,10 @@ where
             '}' => pop!(self, Token::RBrace),
             '=' => pop!(self, Token::Equal),
             '+' => pop!(self, Token::Plus),
-            '-' => pop!(self, Token::Minus),
+            '-' => match self.peek() {
+                '>' => pop2!(self, Token::Arrow),
+                _ => pop!(self, Token::Minus),
+            },
             '*' => pop!(self, Token::Star),
             '^' => pop!(self, Token::Caret),
             '&' => pop!(self, Token::Ampersand),

--- a/parser/src/lexer/tests/functions.rs
+++ b/parser/src/lexer/tests/functions.rs
@@ -1,0 +1,87 @@
+use super::{expect_valid_tokenization, Symbol, Token};
+
+// FUNCTION VALID TOKENIZATION
+// ================================================================================================
+
+#[test]
+fn fn_with_scalars() {
+    let source = "fn fn_name(a: felt, b: felt) -> felt {
+        return a + b
+    }";
+
+    let tokens = [
+        Token::Fn,
+        Token::FunctionIdent(Symbol::intern("fn_name")),
+        Token::LParen,
+        Token::Ident(Symbol::intern("a")),
+        Token::Colon,
+        Token::Felt,
+        Token::Comma,
+        Token::Ident(Symbol::intern("b")),
+        Token::Colon,
+        Token::Felt,
+        Token::RParen,
+        Token::Arrow,
+        Token::Felt,
+        Token::LBrace,
+        Token::Return,
+        Token::Ident(Symbol::intern("a")),
+        Token::Plus,
+        Token::Ident(Symbol::intern("b")),
+        Token::RBrace,
+    ];
+
+    expect_valid_tokenization(source, tokens.to_vec());
+}
+
+#[test]
+fn fn_with_vectors() {
+    let source = "fn fn_name(a: felt[12], b: felt[12]) -> felt[12] {
+        return [x + y for x, y in (a, b)]
+    }";
+
+    let tokens = [
+        Token::Fn,
+        Token::FunctionIdent(Symbol::intern("fn_name")),
+        Token::LParen,
+        Token::Ident(Symbol::intern("a")),
+        Token::Colon,
+        Token::Felt,
+        Token::LBracket,
+        Token::Num(12),
+        Token::RBracket,
+        Token::Comma,
+        Token::Ident(Symbol::intern("b")),
+        Token::Colon,
+        Token::Felt,
+        Token::LBracket,
+        Token::Num(12),
+        Token::RBracket,
+        Token::RParen,
+        Token::Arrow,
+        Token::Felt,
+        Token::LBracket,
+        Token::Num(12),
+        Token::RBracket,
+        Token::LBrace,
+        Token::Return,
+        Token::LBracket,
+        Token::Ident(Symbol::intern("x")),
+        Token::Plus,
+        Token::Ident(Symbol::intern("y")),
+        Token::For,
+        Token::Ident(Symbol::intern("x")),
+        Token::Comma,
+        Token::Ident(Symbol::intern("y")),
+        Token::In,
+        Token::LParen,
+        Token::Ident(Symbol::intern("a")),
+        Token::Comma,
+        Token::Ident(Symbol::intern("b")),
+        Token::RParen,
+        Token::RBracket,
+        Token::RBrace,
+    ];
+
+    expect_valid_tokenization(source, tokens.to_vec());
+}

--- a/parser/src/lexer/tests/mod.rs
+++ b/parser/src/lexer/tests/mod.rs
@@ -6,6 +6,7 @@ mod arithmetic_ops;
 mod boundary_constraints;
 mod constants;
 mod evaluator_functions;
+mod functions;
 mod identifiers;
 mod list_comprehension;
 mod modules;

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -75,6 +75,7 @@ Declaration: Declaration = {
     PeriodicColumns => Declaration::PeriodicColumns(<>),
     RandomValues => Declaration::RandomValues(<>),
     EvaluatorFunction => Declaration::EvaluatorFunction(<>),
+    Function => Declaration::Function(<>),
     <l:@L> <trace:Trace> <r:@R> => Declaration::Trace(Span::new(span!(l, r), trace)),
     <PublicInputs> => Declaration::PublicInputs(<>),
     <BoundaryConstraints> => Declaration::BoundaryConstraints(<>),
@@ -256,6 +257,42 @@ EvaluatorSegmentBindings: (SourceSpan, Vec<Span<(Identifier, usize)>>) = {
     <l:@L> "[" "]" <r:@R> => (span!(l, r), vec![]),
 }
 
+// FUNCTIONS
+// ================================================================================================
+
+Function: Function = {
+    <l:@L> "fn" <name: FunctionIdentifier> "(" <params: FunctionBindings> ")" "->" <ty: FunctionBindingType> "{" <body: FunctionBody> "}" <r:@R>
+        => Function::new(span!(l, r), name, params, ty, body)
+}
+
+FunctionBindings: Vec<(Identifier, Type)> = {
+    <l:@L> <params: Comma<FunctionBinding>> <r:@R> => params,
+}
+
+FunctionBinding: (Identifier, Type) = {
+    <name: Identifier> ":" <ty: FunctionBindingType> => (name, ty),
+}
+
+FunctionBindingType: Type = {
+    <l:@L> "felt" <r:@R> => Type::Felt,
+    <l:@L> "felt" <size: Size> <r:@R> => Type::Vector(size as usize),
+    <l:@L> "felt" "[" <row_size: Num_u64> "," <col_size: Num_u64> "]" <r:@R> => Type::Matrix(row_size as usize, col_size as usize),
+}
+
+FunctionBody: Vec<Statement> = {
+    // TODO: validate
+    <l:@L> <stmts: StatementBlock> <r:@R> =>? {
+        if stmts.len() > 1 {
+            diagnostics.diagnostic(Severity::Error)
+            .with_message("invalid function definition")
+            .with_primary_label(span!(l, r), "function should have 0 or more let statements followed by a return statement.")
+            .emit();
+            return Err(ParseError::Failed.into());
+        }
+        Ok(stmts)
+    },
+}
+
 // BOUNDARY CONSTRAINTS
 // ================================================================================================
 
@@ -287,6 +324,7 @@ StatementBlock: Vec<Statement> = {
         stmts
     },
     <ConstraintStatements>,
+    <ReturnStatement> => vec![Statement::Expr(<>)],
 }
 
 Let: Let = {
@@ -303,6 +341,10 @@ ConstraintStatements: Vec<Statement> = {
 ConstraintStatement: Vec<Statement> = {
     "enf" "match" "{" <MatchArm+> "}" => <>,
     "enf" <ConstraintExpr> => vec![<>],
+}
+
+ReturnStatement: Expr = {
+    <l:@L> "return" <expr: Expr> <r:@R> => expr,
 }
 
 MatchArm: Statement = {
@@ -516,6 +558,11 @@ Iterable: Expr = {
     <ident: Identifier> => Expr::SymbolAccess(SymbolAccess::new(ident.span(), ident, AccessType::Default, 0)),
     <l:@L> <range: Range> <r:@R> => Expr::Range(Span::new(span!(l, r), range)),
     <l:@L> <ident: Identifier> "[" <range: Range> "]" <r:@R> => Expr::SymbolAccess(SymbolAccess::new(span!(l, r), ident, AccessType::Slice(range), 0)),
+    <l:@L> <function_call: FunctionCall> <r:@R> => if let ScalarExpr::Call(call) = function_call {
+        Expr::Call(call)
+    } else {
+        unreachable!()
+    }
 }
 
 Range: Range = {
@@ -532,6 +579,15 @@ Vector<T>: Vec<T> = {
 Matrix<T>: Vec<Vec<T>> = {
     Vector<Vector<T>>,
 }
+
+Tuple<T>: Vec<T> = {
+    "(" <v1:T> "," <v2:T> <v:("," <T>)*> ")" => {
+        let mut v = v;
+        v.insert(0, v2);
+        v.insert(0, v1);
+        v
+    }
+};
 
 Size: u64 = {
     "[" <Num_u64> "]" => <>
@@ -591,10 +647,13 @@ extern {
         "last" => Token::Last,
         "integrity_constraints" => Token::IntegrityConstraints,
         "ev" => Token::Ev,
+        "fn" => Token::Fn,
         "enf" => Token::Enf,
+        "return" => Token::Return,
         "match" => Token::Match,
         "case" => Token::Case,
         "when" => Token::When,
+        "felt" => Token::Felt,
         "'" => Token::Quote,
         "=" => Token::Equal,
         "+" => Token::Plus,
@@ -615,5 +674,6 @@ extern {
         "}" => Token::RBrace,
         "." => Token::Dot,
         ".." => Token::DotDot,
+        "->" => Token::Arrow,
     }
 }

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -280,7 +280,6 @@ FunctionBindingType: Type = {
 }
 
 FunctionBody: Vec<Statement> = {
-    // TODO: validate
     <l:@L> <stmts: StatementBlock> <r:@R> =>? {
         if stmts.len() > 1 {
             diagnostics.diagnostic(Severity::Error)

--- a/parser/src/parser/tests/functions.rs
+++ b/parser/src/parser/tests/functions.rs
@@ -1,0 +1,539 @@
+use miden_diagnostics::{SourceSpan, Span};
+
+use crate::ast::*;
+
+use super::ParseTest;
+
+// PURE FUNCTIONS
+// ================================================================================================
+
+#[test]
+fn fn_def_with_scalars() {
+    let source = "
+    mod test
+
+    fn fn_with_scalars(a: felt, b: felt) -> felt {
+        return a + b
+    }";
+
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    expected.functions.insert(
+        ident!(fn_with_scalars),
+        Function::new(
+            SourceSpan::UNKNOWN,
+            function_ident!(fn_with_scalars),
+            vec![(ident!(a), Type::Felt), (ident!(b), Type::Felt)],
+            Type::Felt,
+            vec![return_!(expr!(add!(access!(a), access!(b))))],
+        ),
+    );
+    ParseTest::new().expect_module_ast(source, expected);
+}
+
+#[test]
+fn fn_def_with_vectors() {
+    let source = "
+    mod test
+
+    fn fn_with_vectors(a: felt[12], b: felt[12]) -> felt[12] {
+        return [x + y for (x, y) in (a, b)]
+    }";
+
+    let mut expected = Module::new(ModuleType::Library, SourceSpan::UNKNOWN, ident!(test));
+    expected.functions.insert(
+        ident!(fn_with_vectors),
+        Function::new(
+            SourceSpan::UNKNOWN,
+            function_ident!(fn_with_vectors),
+            vec![(ident!(a), Type::Vector(12)), (ident!(b), Type::Vector(12))],
+            Type::Vector(12),
+            vec![return_!(expr!(
+                lc!(((x, expr!(access!(a))), (y, expr!(access!(b)))) =>
+                add!(access!(x), access!(y)))
+            ))],
+        ),
+    );
+    ParseTest::new().expect_module_ast(source, expected);
+}
+
+#[test]
+fn fn_use_scalars_and_vectors() {
+    let source = "
+        def root
+
+        public_inputs {
+            stack_inputs: [16]
+        }
+
+        trace_columns {
+            main: [a, b[12]]
+        }
+
+        fn fn_with_scalars_and_vectors(a: felt, b: felt[12]) -> felt {
+            return sum([a + x for x in b])
+        }
+
+        boundary_constraints {
+            enf a.first = 0
+        }
+
+        integrity_constraints {
+            enf a' = fn_with_scalars_and_vectors(a, b)
+        }";
+
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(root));
+
+    expected.functions.insert(
+        ident!(fn_with_scalars_and_vectors),
+        Function::new(
+            SourceSpan::UNKNOWN,
+            function_ident!(fn_with_scalars_and_vectors),
+            vec![(ident!(a), Type::Felt), (ident!(b), Type::Vector(12))],
+            Type::Felt,
+            vec![return_!(expr!(call!(sum(expr!(
+                lc!(((x, expr!(access!(b)))) => add!(access!(a), access!(x)))
+            )))))],
+        ),
+    );
+
+    expected
+        .trace_columns
+        .push(trace_segment!(0, "$main", [(a, 1), (b, 12)]));
+
+    expected.public_inputs.insert(
+        ident!(stack_inputs),
+        PublicInput::new(SourceSpan::UNKNOWN, ident!(stack_inputs), 16),
+    );
+
+    expected.boundary_constraints = Some(Span::new(
+        SourceSpan::UNKNOWN,
+        vec![enforce!(eq!(bounded_access!(a, Boundary::First), int!(0)))],
+    ));
+    expected.integrity_constraints = Some(Span::new(
+        SourceSpan::UNKNOWN,
+        vec![enforce!(eq!(
+            access!(a, 1),
+            call!(fn_with_scalars_and_vectors(
+                expr!(access!(a)),
+                expr!(access!(b))
+            ))
+        ))],
+    ));
+    ParseTest::new().expect_module_ast(source, expected);
+}
+
+#[test]
+fn fn_call_in_fn() {
+    let source = "
+    def root
+
+    public_inputs {
+        stack_inputs: [16]
+    }
+
+    trace_columns {
+        main: [a, b[12]]
+    }
+
+    fn fold_vec(a: felt[12]) -> felt {
+        return sum([x for x in a])
+    }
+
+    fn fold_scalar_and_vec(a: felt, b: felt[12]) -> felt {
+        return a + fold_vec(b)
+    }
+
+    boundary_constraints {
+        enf a.first = 0
+    }
+
+    integrity_constraints {
+        enf a' = fold_scalar_and_vec(a, b)
+    }";
+
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(root));
+
+    expected.functions.insert(
+        ident!(fold_vec),
+        Function::new(
+            SourceSpan::UNKNOWN,
+            function_ident!(fold_vec),
+            vec![(ident!(a), Type::Vector(12))],
+            Type::Felt,
+            vec![return_!(expr!(call!(sum(expr!(
+                lc!(((x, expr!(access!(a)))) => access!(x))
+            )))))],
+        ),
+    );
+
+    expected.functions.insert(
+        ident!(fold_scalar_and_vec),
+        Function::new(
+            SourceSpan::UNKNOWN,
+            function_ident!(fold_scalar_and_vec),
+            vec![(ident!(a), Type::Felt), (ident!(b), Type::Vector(12))],
+            Type::Felt,
+            vec![return_!(expr!(add!(
+                access!(a),
+                call!(fold_vec(expr!(access!(b))))
+            )))],
+        ),
+    );
+
+    expected
+        .trace_columns
+        .push(trace_segment!(0, "$main", [(a, 1), (b, 12)]));
+
+    expected.public_inputs.insert(
+        ident!(stack_inputs),
+        PublicInput::new(SourceSpan::UNKNOWN, ident!(stack_inputs), 16),
+    );
+
+    expected.boundary_constraints = Some(Span::new(
+        SourceSpan::UNKNOWN,
+        vec![enforce!(eq!(bounded_access!(a, Boundary::First), int!(0)))],
+    ));
+
+    expected.integrity_constraints = Some(Span::new(
+        SourceSpan::UNKNOWN,
+        vec![enforce!(eq!(
+            access!(a, 1),
+            call!(fold_scalar_and_vec(expr!(access!(a)), expr!(access!(b))))
+        ))],
+    ));
+
+    ParseTest::new().expect_module_ast(source, expected);
+}
+
+#[test]
+fn fn_call_in_ev() {
+    let source = "
+    def root
+
+    public_inputs {
+        stack_inputs: [16]
+    }
+
+    trace_columns {
+        main: [a, b[12]]
+    }
+
+    fn fold_vec(a: felt[12]) -> felt {
+        return sum([x for x in a])
+    }
+
+    fn fold_scalar_and_vec(a: felt, b: felt[12]) -> felt {
+        return a + fold_vec(b)
+    }
+
+    ev evaluator([a, b[12]]) {
+        enf a' = fold_scalar_and_vec(a, b)
+    }
+
+    boundary_constraints {
+        enf a.first = 0
+    }
+
+    integrity_constraints {
+        enf evaluator(a, b)
+    }";
+
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(root));
+
+    expected.functions.insert(
+        ident!(fold_vec),
+        Function::new(
+            SourceSpan::UNKNOWN,
+            function_ident!(fold_vec),
+            vec![(ident!(a), Type::Vector(12))],
+            Type::Felt,
+            vec![return_!(expr!(call!(sum(expr!(
+                lc!(((x, expr!(access!(a)))) => access!(x))
+            )))))],
+        ),
+    );
+
+    expected.functions.insert(
+        ident!(fold_scalar_and_vec),
+        Function::new(
+            SourceSpan::UNKNOWN,
+            function_ident!(fold_scalar_and_vec),
+            vec![(ident!(a), Type::Felt), (ident!(b), Type::Vector(12))],
+            Type::Felt,
+            vec![return_!(expr!(add!(
+                access!(a),
+                call!(fold_vec(expr!(access!(b))))
+            )))],
+        ),
+    );
+
+    expected.evaluators.insert(
+        ident!(evaluator),
+        EvaluatorFunction::new(
+            SourceSpan::UNKNOWN,
+            ident!(evaluator),
+            vec![trace_segment!(0, "%0", [(a, 1), (b, 12)])],
+            vec![enforce!(eq!(
+                access!(a, 1),
+                call!(fold_scalar_and_vec(expr!(access!(a)), expr!(access!(b))))
+            ))],
+        ),
+    );
+
+    expected
+        .trace_columns
+        .push(trace_segment!(0, "$main", [(a, 1), (b, 12)]));
+
+    expected.public_inputs.insert(
+        ident!(stack_inputs),
+        PublicInput::new(SourceSpan::UNKNOWN, ident!(stack_inputs), 16),
+    );
+
+    expected.boundary_constraints = Some(Span::new(
+        SourceSpan::UNKNOWN,
+        vec![enforce!(eq!(bounded_access!(a, Boundary::First), int!(0)))],
+    ));
+
+    expected.integrity_constraints = Some(Span::new(
+        SourceSpan::UNKNOWN,
+        vec![enforce!(call!(evaluator(
+            expr!(access!(a)),
+            expr!(access!(b))
+        )))],
+    ));
+
+    ParseTest::new().expect_module_ast(source, expected);
+}
+
+#[test]
+fn fn_as_lc_iterables() {
+    let source = "
+    def root
+
+    public_inputs {
+        stack_inputs: [16]
+    }
+
+    trace_columns {
+        main: [a[12], b[12]]
+    }
+
+    fn operation(a: felt, b: felt) -> felt {
+        let x = a^b + 1
+        return b^x
+    }
+
+    boundary_constraints {
+        enf a.first = 0
+    }
+
+    integrity_constraints {
+        enf a' = sum([operation(x, y) for (x, y) in (a, b)])
+    }";
+
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(root));
+
+    expected.functions.insert(
+        ident!(operation),
+        Function::new(
+            SourceSpan::UNKNOWN,
+            function_ident!(operation),
+            vec![(ident!(a), Type::Felt), (ident!(b), Type::Felt)],
+            Type::Felt,
+            vec![
+                let_!(x = expr!(add!(exp!(access!(a), access!(b)), int!(1))) =>
+                return_!(expr!(exp!(access!(b), access!(x))))),
+            ],
+        ),
+    );
+
+    expected
+        .trace_columns
+        .push(trace_segment!(0, "$main", [(a, 12), (b, 12)]));
+
+    expected.public_inputs.insert(
+        ident!(stack_inputs),
+        PublicInput::new(SourceSpan::UNKNOWN, ident!(stack_inputs), 16),
+    );
+
+    expected.boundary_constraints = Some(Span::new(
+        SourceSpan::UNKNOWN,
+        vec![enforce!(eq!(bounded_access!(a, Boundary::First), int!(0)))],
+    ));
+
+    expected.integrity_constraints = Some(Span::new(
+        SourceSpan::UNKNOWN,
+        vec![enforce!(eq!(
+            access!(a, 1),
+            call!(sum(expr!(
+                lc!(((x, expr!(access!(a))), (y, expr!(access!(b)))) => call!(operation(
+                        expr!(access!(x)),
+                        expr!(access!(y))
+                    ))
+                )
+            )))
+        ))],
+    ));
+
+    ParseTest::new().expect_module_ast(source, expected);
+}
+
+#[test]
+fn fn_call_in_binary_ops() {
+    let source = "
+    def root
+
+    public_inputs {
+        stack_inputs: [16]
+    }
+
+    trace_columns {
+        main: [a[12], b[12]]
+    }
+
+    fn operation(a: felt[12], b: felt[12]) -> felt {
+        return sum([x + y for (x, y) in (a, b)])
+    }
+
+    boundary_constraints {
+        enf a[0].first = 0
+    }
+
+    integrity_constraints {
+        enf a[0]' = a[0] * operation(a, b)
+        enf b[0]' = b[0] * operation(a, b)
+    }";
+
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(root));
+
+    expected.functions.insert(
+        ident!(operation),
+        Function::new(
+            SourceSpan::UNKNOWN,
+            function_ident!(operation),
+            vec![(ident!(a), Type::Vector(12)), (ident!(b), Type::Vector(12))],
+            Type::Felt,
+            vec![return_!(expr!(call!(sum(expr!(
+                lc!(((x, expr!(access!(a))), (y, expr!(access!(b)))) => add!(
+                    access!(x),
+                    access!(y)
+                ))
+            )))))],
+        ),
+    );
+
+    expected
+        .trace_columns
+        .push(trace_segment!(0, "$main", [(a, 12), (b, 12)]));
+
+    expected.public_inputs.insert(
+        ident!(stack_inputs),
+        PublicInput::new(SourceSpan::UNKNOWN, ident!(stack_inputs), 16),
+    );
+
+    expected.boundary_constraints = Some(Span::new(
+        SourceSpan::UNKNOWN,
+        vec![enforce!(eq!(
+            bounded_access!(a[0], Boundary::First),
+            int!(0)
+        ))],
+    ));
+
+    expected.integrity_constraints = Some(Span::new(
+        SourceSpan::UNKNOWN,
+        vec![
+            enforce!(eq!(
+                access!(a[0], 1),
+                mul!(
+                    access!(a[0], 0),
+                    call!(operation(expr!(access!(a)), expr!(access!(b))))
+                )
+            )),
+            enforce!(eq!(
+                access!(b[0], 1),
+                mul!(
+                    access!(b[0], 0),
+                    call!(operation(expr!(access!(a)), expr!(access!(b))))
+                )
+            )),
+        ],
+    ));
+
+    ParseTest::new().expect_module_ast(source, expected);
+}
+
+#[test]
+fn fn_call_in_vector_def() {
+    let source = "
+    def root
+
+    public_inputs {
+        stack_inputs: [16]
+    }
+
+    trace_columns {
+        main: [a[12], b[12]]
+    }
+
+    fn operation(a: felt[12], b: felt[12]) -> felt[12] {
+        return [x + y for (x, y) in (a, b)]
+    }
+
+    boundary_constraints {
+        enf a[0].first = 0
+    }
+
+    integrity_constraints {
+        let d = [a[0] * operation(a, b), b[0] * operation(a, b)]
+        enf a[0]' = d[0]
+        enf b[0]' = d[1]
+    }";
+
+    let mut expected = Module::new(ModuleType::Root, SourceSpan::UNKNOWN, ident!(root));
+
+    expected.functions.insert(
+        ident!(operation),
+        Function::new(
+            SourceSpan::UNKNOWN,
+            function_ident!(operation),
+            vec![(ident!(a), Type::Vector(12)), (ident!(b), Type::Vector(12))],
+            Type::Vector(12),
+            vec![return_!(expr!(
+                lc!(((x, expr!(access!(a))), (y, expr!(access!(b)))) => add!(
+                    access!(x),
+                    access!(y)
+                ))
+            ))],
+        ),
+    );
+
+    expected
+        .trace_columns
+        .push(trace_segment!(0, "$main", [(a, 12), (b, 12)]));
+
+    expected.public_inputs.insert(
+        ident!(stack_inputs),
+        PublicInput::new(SourceSpan::UNKNOWN, ident!(stack_inputs), 16),
+    );
+
+    expected.boundary_constraints = Some(Span::new(
+        SourceSpan::UNKNOWN,
+        vec![enforce!(eq!(
+            bounded_access!(a[0], Boundary::First),
+            int!(0)
+        ))],
+    ));
+
+    expected.integrity_constraints = Some(Span::new(
+        SourceSpan::UNKNOWN,
+        vec![let_!(
+                d = vector!(
+                    mul!(access!(a[0]), call!(operation(expr!(access!(a)), expr!(access!(b))))),
+                    mul!(access!(b[0]), call!(operation(expr!(access!(a)), expr!(access!(b))))))
+                    =>
+            enforce!(eq!(access!(a[0], 1), access!(d[0]))),
+            enforce!(eq!(access!(b[0], 1), access!(d[1]))))],
+    ));
+
+    ParseTest::new().expect_module_ast(source, expected);
+}

--- a/parser/src/parser/tests/mod.rs
+++ b/parser/src/parser/tests/mod.rs
@@ -448,6 +448,12 @@ macro_rules! let_ {
     };
 }
 
+macro_rules! return_ {
+    ($value:expr) => {
+        Statement::Expr($value)
+    };
+}
+
 macro_rules! enforce {
     ($expr:expr) => {
         Statement::Enforce($expr)
@@ -606,6 +612,7 @@ mod calls;
 mod constant_propagation;
 mod constants;
 mod evaluators;
+mod functions;
 mod identifiers;
 mod inlining;
 mod integrity_constraints;

--- a/parser/src/parser/tests/mod.rs
+++ b/parser/src/parser/tests/mod.rs
@@ -275,6 +275,18 @@ macro_rules! expr {
     };
 }
 
+macro_rules! scalar {
+    ($expr:expr) => {
+        ScalarExpr::try_from($expr).unwrap()
+    };
+}
+
+macro_rules! statement {
+    ($expr:expr) => {
+        Statement::try_from($expr).unwrap()
+    };
+}
+
 macro_rules! slice {
     ($name:ident, $range:expr) => {
         ScalarExpr::SymbolAccess(SymbolAccess {

--- a/parser/src/sema/errors.rs
+++ b/parser/src/sema/errors.rs
@@ -1,6 +1,6 @@
 use miden_diagnostics::{Diagnostic, Label, SourceSpan, Spanned, ToDiagnostic};
 
-use crate::ast::{Identifier, InvalidExprError, ModuleId};
+use crate::ast::{Identifier, InvalidExprError, InvalidTypeError, ModuleId};
 
 /// Represents the various module validation errors we might encounter during semantic analysis.
 #[derive(Debug, thiserror::Error)]
@@ -31,6 +31,8 @@ pub enum SemanticAnalysisError {
     ImportFailed(SourceSpan),
     #[error(transparent)]
     InvalidExpr(#[from] InvalidExprError),
+    #[error(transparent)]
+    InvalidType(#[from] InvalidTypeError),
     #[error("module is invalid, see diagnostics for details")]
     Invalid,
 }
@@ -89,6 +91,7 @@ impl ToDiagnostic for SemanticAnalysisError {
                 .with_labels(vec![Label::primary(span.source_id(), span)
                     .with_message("failed import occurred here")]),
             Self::InvalidExpr(err) => err.to_diagnostic(),
+            Self::InvalidType(err) => err.to_diagnostic(),
             Self::Invalid => Diagnostic::error().with_message("module is invalid, see diagnostics for details"),
         }
     }

--- a/parser/src/sema/semantic_analysis.rs
+++ b/parser/src/sema/semantic_analysis.rs
@@ -1562,6 +1562,14 @@ impl<'a> SemanticAnalysis<'a> {
                     }
                 }
             }
+            Expr::Let(ref expr) => {
+                self.diagnostics
+                    .diagnostic(Severity::Bug)
+                    .with_message("invalid expression")
+                    .with_primary_label(expr.span(), "let expressions are not valid here")
+                    .emit();
+                Err(InvalidAccessError::InvalidBinding)
+            }
         }
     }
 

--- a/parser/src/sema/semantic_analysis.rs
+++ b/parser/src/sema/semantic_analysis.rs
@@ -1386,7 +1386,7 @@ impl<'a> SemanticAnalysis<'a> {
                                         // and we will have already validated the reference
                                         let (import_id, module_id) = self.imported.get_key_value(&id).unwrap();
                                         let module = self.library.get(module_id).unwrap();
-                                        if module.evaluators.get(&id.id()).is_none() {
+                                        if !module.evaluators.contains_key(&id.id()) {
                                             self.invalid_constraint(id.span(), "calls in constraints must be to evaluator functions")
                                                 .with_secondary_label(import_id.span(), "the function imported here is not an evaluator")
                                                 .emit();

--- a/parser/src/transforms/constant_propagation.rs
+++ b/parser/src/transforms/constant_propagation.rs
@@ -69,6 +69,11 @@ impl<'a> ConstantPropagation<'a> {
             self.visit_mut_evaluator_function(evaluator)?;
         }
 
+        // Visit all of the functions
+        for function in program.functions.values_mut() {
+            self.visit_mut_function(function)?;
+        }
+
         // Visit all of the constraints
         self.visit_mut_boundary_constraints(&mut program.boundary_constraints)?;
         self.visit_mut_integrity_constraints(&mut program.integrity_constraints)

--- a/parser/src/transforms/constant_propagation.rs
+++ b/parser/src/transforms/constant_propagation.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use air_pass::Pass;
+use either::Either::{self, Left, Right};
 use miden_diagnostics::{DiagnosticsHandler, Span, Spanned};
 
 use crate::{
@@ -93,6 +94,79 @@ impl<'a> ConstantPropagation<'a> {
         // If both operands are constant, fold
         try_fold_binary_expr(expr).map_err(SemanticAnalysisError::InvalidExpr)
     }
+
+    /// When folding a `let`, one of the following can occur:
+    ///
+    /// * The let-bound variable is non-constant, so the entire let must remain, but we
+    ///   can constant-propagate as much of the bound expression and body as possible.
+    /// * The let-bound variable is constant, so once we have constant propagated the body,
+    ///   the let is no longer needed, and one of the following happens:
+    ///   * The `let` terminates with a constant expression, so the entire `let` is replaced
+    ///     with that expression.
+    ///   * The `let` terminates with a non-constant expression, or a constraint, so we inline
+    ///     the let body into the containing block. In the non-constant expression case, we
+    ///     replace the `let` with the last expression in the returned block, since in expression
+    ///     position, we may not have a statement block to inline into.
+    fn try_fold_let_expr(
+        &mut self,
+        expr: &mut Let,
+    ) -> Result<Either<Option<Span<ConstantExpr>>, Vec<Statement>>, SemanticAnalysisError> {
+        // Visit the binding expression first
+        if let ControlFlow::Break(err) = self.visit_mut_expr(&mut expr.value) {
+            return Err(err);
+        }
+
+        // Enter a new lexical scope
+        let prev_live = core::mem::take(&mut self.live);
+        self.local.enter();
+        // If the value is constant, record it in our bindings map
+        let is_constant = expr.value.is_constant();
+        if is_constant {
+            match expr.value {
+                Expr::Const(ref value) => {
+                    self.local.insert(expr.name, value.clone());
+                }
+                Expr::Range(ref range) => {
+                    let vector = range.item.clone().map(|i| i as u64).collect();
+                    self.local.insert(
+                        expr.name,
+                        Span::new(range.span(), ConstantExpr::Vector(vector)),
+                    );
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        // Visit the let body
+        if let ControlFlow::Break(err) = self.visit_mut_statement_block(&mut expr.body) {
+            return Err(err);
+        }
+
+        // If this let is constant, then the binding is no longer
+        // used in the body after constant propagation, so we can
+        // fold away the let entirely
+        let is_live = self.live.contains(&expr.name);
+        let result = if is_constant && !is_live {
+            match expr.body.last().unwrap() {
+                Statement::Expr(Expr::Const(ref const_value)) => {
+                    Left(Some(Span::new(expr.span(), const_value.item.clone())))
+                }
+                _ => Right(core::mem::take(&mut expr.body)),
+            }
+        } else {
+            Left(None)
+        };
+
+        // Propagate liveness from the body of the let to its parent scope
+        let mut live = core::mem::take(&mut self.live);
+        live.remove(&expr.name);
+        self.live = &prev_live | &live;
+
+        // Restore the previous scope
+        self.local.exit();
+
+        Ok(result)
+    }
 }
 impl<'a> VisitMut<SemanticAnalysisError> for ConstantPropagation<'a> {
     /// Fold constant expressions
@@ -166,6 +240,47 @@ impl<'a> VisitMut<SemanticAnalysisError> for ConstantPropagation<'a> {
             ScalarExpr::Call(ref mut call) => self.visit_mut_call(call),
             // This cannot be constant folded
             ScalarExpr::BoundedSymbolAccess(_) => ControlFlow::Continue(()),
+            // A let that evaluates to a constant value can be folded to the constant value
+            ScalarExpr::Let(ref mut let_expr) => {
+                match self.try_fold_let_expr(let_expr) {
+                    Ok(Left(Some(const_expr))) => {
+                        let span = const_expr.span();
+                        match const_expr.item {
+                            ConstantExpr::Scalar(value) => {
+                                *expr = ScalarExpr::Const(Span::new(span, value));
+                            }
+                            _ => {
+                                self.diagnostics.diagnostic(miden_diagnostics::Severity::Error)
+                                    .with_message("invalid scalar expression")
+                                    .with_primary_label(span, "expected scalar value, but this expression evaluates to an aggregate type")
+                                    .emit();
+                                return ControlFlow::Break(SemanticAnalysisError::Invalid);
+                            }
+                        }
+                    }
+                    Ok(Left(None)) => (),
+                    Ok(Right(mut block)) => match block.pop().unwrap() {
+                        Statement::Let(inner_expr) => {
+                            *let_expr.as_mut() = inner_expr;
+                        }
+                        Statement::Expr(inner_expr) => {
+                            match ScalarExpr::try_from(inner_expr)
+                                .map_err(SemanticAnalysisError::InvalidExpr)
+                            {
+                                Ok(scalar_expr) => {
+                                    *expr = scalar_expr;
+                                }
+                                Err(err) => return ControlFlow::Break(err),
+                            }
+                        }
+                        Statement::Enforce(_)
+                        | Statement::EnforceIf(_, _)
+                        | Statement::EnforceAll(_) => unreachable!(),
+                    },
+                    Err(err) => return ControlFlow::Break(err),
+                }
+                ControlFlow::Continue(())
+            }
         }
     }
 
@@ -458,6 +573,27 @@ impl<'a> VisitMut<SemanticAnalysisError> for ConstantPropagation<'a> {
                 *expr = Expr::Const(Span::new(span, ConstantExpr::Vector(folded)));
                 ControlFlow::Continue(())
             }
+            Expr::Let(ref mut let_expr) => {
+                match self.try_fold_let_expr(let_expr) {
+                    Ok(Left(Some(const_expr))) => {
+                        *expr = Expr::Const(Span::new(span, const_expr.item));
+                    }
+                    Ok(Left(None)) => (),
+                    Ok(Right(mut block)) => match block.pop().unwrap() {
+                        Statement::Let(inner_expr) => {
+                            *let_expr.as_mut() = inner_expr;
+                        }
+                        Statement::Expr(inner_expr) => {
+                            *expr = inner_expr;
+                        }
+                        Statement::Enforce(_)
+                        | Statement::EnforceIf(_, _)
+                        | Statement::EnforceAll(_) => unreachable!(),
+                    },
+                    Err(err) => return ControlFlow::Break(err),
+                }
+                ControlFlow::Continue(())
+            }
         }
     }
 
@@ -479,47 +615,16 @@ impl<'a> VisitMut<SemanticAnalysisError> for ConstantPropagation<'a> {
                         num_statements - 1,
                         "let is not in tail position of block"
                     );
-                    // Visit the binding expression first
-                    self.visit_mut_expr(&mut expr.value)?;
-                    // Enter a new lexical scope
-                    let prev_live = core::mem::take(&mut self.live);
-                    self.local.enter();
-                    // If the value is constant, record it in our bindings map
-                    let is_constant = expr.value.is_constant();
-                    if is_constant {
-                        match expr.value {
-                            Expr::Const(ref value) => {
-                                self.local.insert(expr.name, value.clone());
-                            }
-                            Expr::Range(ref range) => {
-                                let vector = range.item.clone().map(|i| i as u64).collect();
-                                self.local.insert(
-                                    expr.name,
-                                    Span::new(range.span(), ConstantExpr::Vector(vector)),
-                                );
-                            }
-                            _ => unreachable!(),
+                    match self.try_fold_let_expr(expr) {
+                        Ok(Left(Some(const_expr))) => {
+                            buffer.push(Statement::Expr(Expr::Const(const_expr)));
                         }
+                        Ok(Left(None)) => (),
+                        Ok(Right(mut block)) => {
+                            buffer.append(&mut block);
+                        }
+                        Err(err) => return ControlFlow::Break(err),
                     }
-
-                    // Visit the let body
-                    self.visit_mut_statement_block(&mut expr.body)?;
-
-                    // If this let is constant, then the binding is no longer
-                    // used in the body after constant propagation, flatten its
-                    // body into the current block.
-                    let is_live = self.live.contains(&expr.name);
-                    if is_constant && !is_live {
-                        buffer.append(&mut expr.body);
-                    }
-
-                    // Propagate liveness from the body of the let to its parent scope
-                    let mut live = core::mem::take(&mut self.live);
-                    live.remove(&expr.name);
-                    self.live = &prev_live | &live;
-
-                    // Restore the previous scope
-                    self.local.exit();
                 }
                 Statement::Enforce(ref mut expr) => {
                     self.visit_mut_enforce(expr)?;

--- a/parser/src/transforms/inlining.rs
+++ b/parser/src/transforms/inlining.rs
@@ -364,21 +364,21 @@ impl<'a> Inlining<'a> {
     /// Let expressions are expanded using the following rules:
     ///
     /// * The let-bound expression is expanded first. If it expands to a statement block and
-    /// not an expression, the block is inlined in place of the let being expanded, and the
-    /// rest of the expansion takes place at the end of the block; replacing the last statement
-    /// in the block. If the last statement in the block was an expression, it is treated as
-    /// the let-bound value. If the last statement in the block was another `let` however, then
-    /// we recursively walk down the let tree until we reach the bottom, which must always be
-    /// an expression statement.
+    ///   not an expression, the block is inlined in place of the let being expanded, and the
+    ///   rest of the expansion takes place at the end of the block; replacing the last statement
+    ///   in the block. If the last statement in the block was an expression, it is treated as
+    ///   the let-bound value. If the last statement in the block was another `let` however, then
+    ///   we recursively walk down the let tree until we reach the bottom, which must always be
+    ///   an expression statement.
     ///
     /// * The body is expanded in-place after the previous step has been completed.
     ///
     /// * If a let-bound variable is an alias for a declaration, we replace all uses
-    /// of the variable with direct references to the declaration, making the let-bound variable
-    /// dead
+    ///   of the variable with direct references to the declaration, making the let-bound
+    ///   variable dead
     ///
     /// * If a let-bound variable is dead (i.e. has no references), then the let is elided,
-    /// by replacing it with the result of expanding its body
+    ///   by replacing it with the result of expanding its body
     fn expand_let(&mut self, expr: Let) -> Result<Vec<Statement>, SemanticAnalysisError> {
         let span = expr.span();
         let name = expr.name;
@@ -744,9 +744,9 @@ impl<'a> Inlining<'a> {
     /// the expansion is, respectively:
     ///
     /// * A tree of let statements (using generated variables), where each let binds the value of a
-    /// single iteration of the comprehension. The body of the final let, and thus the effective value
-    /// of the entire tree, is a vector containing all of the bindings in the evaluation order of the
-    /// comprehension.
+    ///   single iteration of the comprehension. The body of the final let, and thus the effective
+    ///   value of the entire tree, is a vector containing all of the bindings in the evaluation
+    ///   order of the comprehension.
     /// * A flat list of constraint statements
     fn expand_comprehension(
         &mut self,

--- a/parser/src/transforms/inlining.rs
+++ b/parser/src/transforms/inlining.rs
@@ -115,11 +115,11 @@ impl<'p> Pass for Inlining<'p> {
             .collect();
 
         // We'll be referencing the trace configuration during inlining, so keep a copy of it
-        self.trace = program.trace_columns.clone();
+        self.trace.clone_from(&program.trace_columns);
         // Same with the random values
-        self.random_values = program.random_values.clone();
+        self.random_values.clone_from(&program.random_values);
         // And the public inputs
-        self.public_inputs = program.public_inputs.clone();
+        self.public_inputs.clone_from(&program.public_inputs);
 
         // Add all of the local bindings visible in the root module, except for
         // constants and periodic columns, which by this point have been rewritten

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.78"
+components = ["rustfmt", "rust-src", "clippy"]
+targets = ["wasm32-unknown-unknown"]
+profile = "minimal"


### PR DESCRIPTION
This PR introduces a new type of function to the AirScript language: "pure" functions. To summarize:

* Pure functions take zero or more parameters, and return a result of scalar or aggregate type.
* Pure functions must declare the type of all parameters and the result. These types are checked to ensure that uses of the parameters are consistent, and that all callers are passing values of the correct type.
* Pure functions **MUST** return a value, using the `return` statement
* Correspondingly, they **MAY NOT** have an empty body, and at minimum must contain a `return` statement
* `return` is the keyword for a new statement of the form `return EXPR`, where `EXPR` is the expression which evaluates to the value to be used as the output of the function. A bare `return` is not valid syntax.
* Pure functions **MAY NOT** contain constraints. This is reserved for evaluator functions, which have slightly different syntax and semantics.
* Like evaluator functions, pure functions may be placed in library modules and imported for use in any program linked to that library.

## Example

```
fn madd3(a: felt[3], b: felt) -> felt {
    let d = [c * b for c in a]
    return sum(d)
}
```

The example above demonstrates the key features of the new syntax. A few notes:

* Valid types are `felt`, `felt[N]`, or `felt[N][M]` where `N` and `M` are placeholders for the corresponding dimension of the given aggregate type (vectors and matrices, respectively)
* Function bodies can contain all the things you'd expect to find in `integrity_constraints` or `boundary_constraints`, except the constraints themselves as mentioned above (i.e. the `enf` keyword is not allowed in this context at all)

This PR supercedes #344 

---

Internally, the support for functions also comes with some refactoring of the AST, so as to allow us to represent arbitrarily complex expansions of syntax nodes in expression position. Previously, the AST was designed to forbid representing syntax that was not supported by the surface language. However, due to the requirements of the inlining phase, it has been necessary to relax this to some degree, and this PR takes that even further, now allowing the use of the `Let` syntax node in both `Expr` and `ScalarExpr` as an explicit variant.

Despite this additional flexibility though, it is still the case that the surface language does not have syntax for this. Furthermore, we explicitly do not support the use of `Let` in expression position until after semantic analysis; and while supported during constant propagation, we would not expect to see `Let` in this position until after the inlining pass has been applied.

The point being: do not look at the changes to the AST as representing changes to the language syntax. What is supported by the language is determined by the language grammar/parser, and the AST itself is considerably less restrictive so as to allow for arbitrary transformations during compilation.

@bobbinth I've added some tests, as well as built on top of those initially implemented by @tohrnii. I'm not certain how best to evaluate the codegen side of things, so I'll defer to you on that. However, the codegen tests written by @tohrnii do pass, so I'm assuming those are good.
