### PR TITLE
MassaLabs: add comma in match/case statement

### DIFF
--- a/air-script/tests/selectors/selectors.air
+++ b/air-script/tests/selectors/selectors.air
@@ -15,7 +15,7 @@ boundary_constraints {
 integrity_constraints {
     enf clk' = 0 when s[0] & !s[1];
     enf match {
-        case s[0] & s[1] & s[2]: clk' = clk
-        case !s[1] & !s[2]: clk' = 1
+        case s[0] & s[1] & s[2]: clk' = clk,
+        case !s[1] & !s[2]: clk' = 1,
     };
 }

--- a/air-script/tests/selectors/selectors_with_evaluators.air
+++ b/air-script/tests/selectors/selectors_with_evaluators.air
@@ -27,7 +27,7 @@ boundary_constraints {
 integrity_constraints {
     enf next_is_zero([clk]) when s[0] & !s[1];
     enf match {
-        case s[1] & s[2]: is_unchanged([clk, s[0]])
-        case !s[1] & !s[2]: next_is_one([clk])
+        case s[1] & s[2]: is_unchanged([clk, s[0]]),
+        case !s[1] & !s[2]: next_is_one([clk]),
     };
 }

--- a/ir/src/tests/selectors.rs
+++ b/ir/src/tests/selectors.rs
@@ -61,8 +61,8 @@ fn multiconstraint_selectors() {
     integrity_constraints {
         enf clk' = 0 when s[0] & !s[1];
         enf match {
-            case s[0] & s[1]: clk' = clk
-            case !s[0] & !s[1]: clk' = 1
+            case s[0] & s[1]: clk' = clk,
+            case !s[0] & !s[1]: clk' = 1,
         };
     }";
 
@@ -181,8 +181,8 @@ fn selectors_inside_match() {
     integrity_constraints {
         enf next_is_zero([clk]) when s[0] & !s[1];
         enf match {
-            case s[1] & s[2]: is_unchanged([clk, s[0]])
-            case !s[1] & !s[2]: next_is_one([clk])
+            case s[1] & s[2]: is_unchanged([clk, s[0]]),
+            case !s[1] & !s[2]: next_is_one([clk]),
         };
     }";
 

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -347,7 +347,7 @@ ReturnStatement: Expr = {
 }
 
 MatchArm: Statement = {
-    <l:@L> "case" <selector:ScalarExpr> ":" <constraint:ScalarConstraintExpr> <r:@R> => {
+    <l:@L> "case" <selector:ScalarExpr> ":" <constraint:ScalarConstraintExpr> "," <r:@R> => {
         let generated_name = format!("%{}", *next_var);
         *next_var += 1;
         let generated_binding = Identifier::new(SourceSpan::UNKNOWN, Symbol::intern(generated_name));

--- a/parser/src/parser/tests/inlining.rs
+++ b/parser/src/parser/tests/inlining.rs
@@ -1322,8 +1322,8 @@ fn test_repro_issue340() {
         enf instruction_word = word_sum;
 
         enf match {
-            case s: imm_reconstruction([instruction_bits, immediate])
-            case !s: immediate = 0
+            case s: imm_reconstruction([instruction_bits, immediate]),
+            case !s: immediate = 0,
         };
     }
 

--- a/parser/src/parser/tests/integrity_constraints.rs
+++ b/parser/src/parser/tests/integrity_constraints.rs
@@ -667,8 +667,8 @@ fn ic_match_constraint() {
 
     integrity_constraints {
         enf match {
-            case s[0] & s[1]: is_binary([c[0]])
-            case s[0]: c[1] = c[2]
+            case s[0] & s[1]: is_binary([c[0]]),
+            case s[0]: c[1] = c[2],
         };
     }";
 


### PR DESCRIPTION
As discussed in #353, this PR modify the grammar to require a comma at the end of case statements inside a match statement.