### PR TITLE
Typos fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ For example, a new change to the PARSER crate might have the following message: 
     // ================================================================================
     ```
 
-- [Rustfmt](https://github.com/rust-lang/rustfmt) and [Clippy](https://github.com/rust-lang/rust-clippy) linting is included in CI pipeline. Anyways it's prefferable to run linting locally before push:
+- [Rustfmt](https://github.com/rust-lang/rustfmt) and [Clippy](https://github.com/rust-lang/rust-clippy) linting is included in CI pipeline. Anyways it's preferable to run linting locally before push:
     ```
     cargo fix --allow-staged --allow-dirty --all-targets --all-features; cargo fmt; cargo clippy --workspace --all-targets --all-features -- -D warnings
     ```

--- a/parser/src/ast/declarations.rs
+++ b/parser/src/ast/declarations.rs
@@ -22,7 +22,7 @@
 //! * evaluators
 //! * pure functions
 //!
-//! There is no notion of public/private visiblity, so any declaration of the above types may be
+//! There is no notion of public/private visibility, so any declaration of the above types may be
 //! imported into another module, and "wildcard" imports will import all importable items.
 use std::{collections::HashSet, fmt};
 

--- a/parser/src/sema/semantic_analysis.rs
+++ b/parser/src/sema/semantic_analysis.rs
@@ -1333,7 +1333,7 @@ impl<'a> SemanticAnalysis<'a> {
                                 }
                             }
                             // We take care to only allow constructing Call with a function identifier, but it
-                            // is possible for someone to unintentionally set the callee to a binding identifer, which is
+                            // is possible for someone to unintentionally set the callee to a binding identifier, which is
                             // a compiler internal error, hence the panic
                             id => panic!("invalid callee identifier, expected function id, got binding: {:#?}", id),
                         }


### PR DESCRIPTION
# Fix: Corrected typos in comments

## What was changed
- **Corrected typos**  to improve clarity and professionalism.

## Why these changes were made
- **Fixing typos** enhances the clarity and readability of the codebase, making it more professional and easier to understand.

## Additional Notes
- These changes focus solely on correcting typographical errors in comments and do not affect the functionality of the code.
