### PR TITLE
fix: Remove unnecessary pub before main Update main.rs

### DIFF
--- a/air-script/src/main.rs
+++ b/air-script/src/main.rs
@@ -17,7 +17,7 @@ pub enum Command {
     Transpile(cli::Transpile),
 }
 
-pub fn main() {
+fn main() {
     env_logger::Builder::new()
         .format(|buf, record| writeln!(buf, "{}", record.args()))
         .filter_level(log::LevelFilter::Debug)


### PR DESCRIPTION
`main` was mistakenly declared as `pub fn main()`, which isn't needed